### PR TITLE
Remove sort entries from column header context menu

### DIFF
--- a/packages/react/src/DataGrid.tsx
+++ b/packages/react/src/DataGrid.tsx
@@ -1164,7 +1164,7 @@ export function DataGrid<TData extends Record<string, unknown>>(props: DataGridP
         )}
 
         {/*
-         * The legacy column menu (sort, hide, freeze) continues to mount
+         * The legacy column menu (hide, freeze) continues to mount
          * unconditionally — it coexists with the Excel dropdown rather than
          * being replaced by it. Visibility is driven by the interaction
          * reducer's `menu` discriminant, so rendering the component while no
@@ -1174,10 +1174,7 @@ export function DataGrid<TData extends Record<string, unknown>>(props: DataGridP
           menuState={interaction.state.menu}
           headerHeight={headerHeight}
           hasColumnGroups={!!columnGroupConfig}
-          isSortingEnabled={isSortingEnabled}
           getColumnFrozen={getColumnFrozenByField}
-          onSortAsc={handleColumnMenuSortAsc}
-          onSortDesc={handleColumnMenuSortDesc}
           onHide={handleColumnMenuHide}
           onFreeze={handleColumnMenuFreeze}
           onUnfreeze={handleColumnMenuUnfreeze}

--- a/packages/react/src/__tests__/column-ops-integration.test.tsx
+++ b/packages/react/src/__tests__/column-ops-integration.test.tsx
@@ -416,36 +416,6 @@ describe('column header integration', () => {
     expect(menuTriggers.length).toBe(4); // One per column
   });
 
-  it('column header menu shows sort ascending option', () => {
-    render(
-      <DataGrid
-        data={makeColData()}
-        columns={colColumns}
-        rowKey="id"
-        sorting={true}
-        showColumnMenu={true}
-      />
-    );
-    const nameHeader = screen.getByRole('columnheader', { name: /^name/i });
-    fireEvent.contextMenu(nameHeader);
-    expect(screen.getByTestId('column-menu-sort-asc')).toBeInTheDocument();
-  });
-
-  it('column header menu shows sort descending option', () => {
-    render(
-      <DataGrid
-        data={makeColData()}
-        columns={colColumns}
-        rowKey="id"
-        sorting={true}
-        showColumnMenu={true}
-      />
-    );
-    const nameHeader = screen.getByRole('columnheader', { name: /^name/i });
-    fireEvent.contextMenu(nameHeader);
-    expect(screen.getByTestId('column-menu-sort-desc')).toBeInTheDocument();
-  });
-
   it('column header menu shows hide column option', () => {
     render(
       <DataGrid

--- a/packages/react/src/header/DataGridColumnMenu.tsx
+++ b/packages/react/src/header/DataGridColumnMenu.tsx
@@ -6,10 +6,7 @@ export interface DataGridColumnMenuProps {
   menuState: MenuState;
   headerHeight: number;
   hasColumnGroups: boolean;
-  isSortingEnabled: boolean;
   getColumnFrozen: (field: string) => 'left' | 'right' | null;
-  onSortAsc: (field: string) => void;
-  onSortDesc: (field: string) => void;
   onHide: (field: string) => void;
   onFreeze: (field: string) => void;
   onUnfreeze: (field: string) => void;
@@ -21,10 +18,7 @@ export function DataGridColumnMenu(props: DataGridColumnMenuProps) {
     menuState,
     headerHeight,
     hasColumnGroups,
-    isSortingEnabled,
     getColumnFrozen,
-    onSortAsc,
-    onSortDesc,
     onHide,
     onFreeze,
     onUnfreeze,
@@ -41,30 +35,6 @@ export function DataGridColumnMenu(props: DataGridColumnMenuProps) {
       data-testid="column-header-menu"
       style={styles.columnHeaderMenu(headerHeight, hasColumnGroups)}
     >
-      {isSortingEnabled && (
-        <>
-          <div
-            data-testid="column-menu-sort-asc"
-            style={styles.columnMenuItem}
-            onClick={() => {
-              onSortAsc(field);
-              onClose();
-            }}
-          >
-            Sort Ascending
-          </div>
-          <div
-            data-testid="column-menu-sort-desc"
-            style={styles.columnMenuItem}
-            onClick={() => {
-              onSortDesc(field);
-              onClose();
-            }}
-          >
-            Sort Descending
-          </div>
-        </>
-      )}
       <div
         data-testid="column-menu-hide"
         style={styles.columnMenuItem}


### PR DESCRIPTION
## Summary
- Drop Sort Ascending / Sort Descending from the legacy column-header context menu (the Excel 365 filter dropdown already hosts them, and click / Shift-click on the header remains fully functional).
- Simplify `DataGridColumnMenu` props accordingly — `isSortingEnabled`, `onSortAsc`, `onSortDesc` are no longer needed on this component. The sort handlers in `DataGrid.tsx` stay because the filter menu still uses them.
- Remove the two now-obsolete tests in `column-ops-integration.test.tsx` that asserted the menu rows.

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (1479 / 1479)
- [ ] Right-click a column header: only Hide Column / Freeze Column rows appear
- [ ] Click header to sort and Shift-click to multi-sort still work
- [ ] Sort rows remain visible in the Excel filter dropdown (when `showFilterMenu` is on)

Closes #8