### PR TITLE
fix(365-theme): prevent indexed-setter TypeError in setValueForStyle

### DIFF
--- a/packages/react/src/DataGrid.tsx
+++ b/packages/react/src/DataGrid.tsx
@@ -187,9 +187,19 @@ export function resolveThemeStyle(
   theme: 'light' | 'dark' | Record<string, string> | undefined,
 ): React.CSSProperties {
   if (!theme) return {};
-  if (theme === 'light') return LIGHT_THEME as unknown as React.CSSProperties;
-  if (theme === 'dark') return DARK_THEME as unknown as React.CSSProperties;
-  return theme as unknown as React.CSSProperties;
+  if (theme === 'light') return { ...LIGHT_THEME } as unknown as React.CSSProperties;
+  if (theme === 'dark') return { ...DARK_THEME } as unknown as React.CSSProperties;
+  // A string preset we do not recognise (e.g. `"excel365"`) is handled
+  // entirely via CSS — the grid root receives `data-theme="…"` and the
+  // matching stylesheet provides the tokens. Returning the string itself
+  // here would cause callers to spread it as indexed character properties
+  // into `style`, which React DOM then rejects with
+  // `TypeError: Indexed property setter is not supported` inside
+  // `setValueForStyle`. A custom token map is copied into a plain object
+  // for the same reason — callers treat the result as a writable
+  // `React.CSSProperties` bag and must not receive a frozen/exotic object.
+  if (typeof theme === 'string') return {};
+  return { ...theme } as unknown as React.CSSProperties;
 }
 
 export { LIGHT_THEME, DARK_THEME };

--- a/packages/react/src/__tests__/theming.test.tsx
+++ b/packages/react/src/__tests__/theming.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import { DataGrid, LIGHT_THEME, DARK_THEME } from '../DataGrid';
+import { DataGrid, LIGHT_THEME, DARK_THEME, resolveThemeStyle } from '../DataGrid';
 
 // ---------------------------------------------------------------------------
 // Shared fixtures
@@ -267,5 +267,81 @@ describe('Theming', () => {
     const grid = screen.getByRole('grid');
     expect(grid.style.transition).toContain('color');
     expect(grid.style.transition).toContain('background');
+  });
+
+  // ---------------------------------------------------------------------------
+  // Non-plain-object safety (regression #20)
+  //
+  // React DOM's `setValueForStyle` assigns each style property onto a
+  // `CSSStyleDeclaration` via an indexed setter. If the `style` prop ever
+  // receives an object whose keys are numeric (e.g. the indexed characters
+  // produced by accidentally spreading a string), React throws
+  // `TypeError: Indexed property setter is not supported`.
+  //
+  // Guard against that by:
+  //   1. Asserting `resolveThemeStyle` always returns a plain POJO whose
+  //      keys are valid CSS identifiers (not `"0"`, `"1"`, …).
+  //   2. Rendering the `"excel365"` preset end-to-end to confirm the grid
+  //      mounts without that TypeError being thrown.
+  // ---------------------------------------------------------------------------
+
+  describe('resolveThemeStyle returns plain-object style bag (regression #20)', () => {
+    const hasNumericIndexKeys = (obj: object): boolean =>
+      Object.keys(obj).some((k) => /^\d+$/.test(k));
+
+    it('returns a plain object for the light preset', () => {
+      const result = resolveThemeStyle('light');
+      expect(Object.getPrototypeOf(result)).toBe(Object.prototype);
+      expect(hasNumericIndexKeys(result)).toBe(false);
+    });
+
+    it('returns a plain object for the dark preset', () => {
+      const result = resolveThemeStyle('dark');
+      expect(Object.getPrototypeOf(result)).toBe(Object.prototype);
+      expect(hasNumericIndexKeys(result)).toBe(false);
+    });
+
+    it('returns a plain object for a custom token map', () => {
+      const input = { '--dg-primary-color': '#123' };
+      const result = resolveThemeStyle(input);
+      expect(Object.getPrototypeOf(result)).toBe(Object.prototype);
+      expect(hasNumericIndexKeys(result)).toBe(false);
+      // Callers treat the result as a writable CSSProperties bag; the
+      // returned object must not share identity with the caller's input
+      // (which may be frozen or otherwise exotic).
+      expect(result).not.toBe(input);
+    });
+
+    it('returns an empty plain object for an unknown string preset', () => {
+      // A string like "excel365" is handled entirely by CSS via
+      // `data-theme="excel365"`. Returning the string itself would spread
+      // indexed character properties into `style` — the exact shape that
+      // triggers `TypeError: Indexed property setter is not supported`
+      // inside React DOM's `setValueForStyle`.
+      const result = resolveThemeStyle('excel365' as unknown as 'light');
+      expect(Object.getPrototypeOf(result)).toBe(Object.prototype);
+      expect(hasNumericIndexKeys(result)).toBe(false);
+      expect(Object.keys(result)).toHaveLength(0);
+    });
+
+    it('mounts a grid with theme="excel365" without throwing indexed-setter errors', () => {
+      // The grid mounts, and its inline `style` must not contain numeric
+      // keys — `setValueForStyle` would throw if it did.
+      render(
+        <DataGrid
+          data={makeData()}
+          columns={columns}
+          rowKey="id"
+          theme={'excel365' as unknown as 'light'}
+        />,
+      );
+      const grid = screen.getByRole('grid');
+      // The data-theme attribute is how the CSS tokens get applied.
+      expect(grid.getAttribute('data-theme')).toBe('excel365');
+      // No indexed character properties leaked into the inline style.
+      for (let i = 0; i < 'excel365'.length; i++) {
+        expect(grid.style.getPropertyValue(String(i))).toBe('');
+      }
+    });
   });
 });


### PR DESCRIPTION
## Summary

`resolveThemeStyle` returned the raw `theme` prop for any string it did not recognise. When callers spread the result into the grid's inline `style`, a string like `"excel365"` became `{0: 'e', 1: 'x', ...}` — numeric character keys that React DOM's `setValueForStyle` rejects with `TypeError: Indexed property setter is not supported` when writing them to `CSSStyleDeclaration`.

The `excel365` preset is already handled entirely via CSS (the grid root emits `data-theme="excel365"` and the stylesheet applies the tokens), so there is nothing meaningful to inline. `resolveThemeStyle` now returns an empty plain object for unknown string presets. Known presets (`"light"`, `"dark"`) and custom token maps are shallow-copied into fresh plain objects so callers never receive a frozen or otherwise exotic reference.

## Changes

- `packages/react/src/DataGrid.tsx` — `resolveThemeStyle` now always returns a plain `{}`-prototype `React.CSSProperties` bag.
- `packages/react/src/__tests__/theming.test.tsx` — new regression tests:
  - Asserts `resolveThemeStyle` returns a plain-prototype object with no numeric keys for every branch (`light` / `dark` / custom map / unknown string).
  - Asserts a grid mounts with `theme="excel365"` and does not leak indexed character properties onto its inline style.

## Test plan

- [x] `pnpm vitest run packages/react/src/__tests__/theming.test.tsx` — 29/29 pass (5 new, 24 existing).
- [x] `pnpm test` — 1486/1486 pass across 64 files.
- [x] Confirmed the new `resolveThemeStyle` tests fail before the fix (wrong prototype / string return).
- [x] `pnpm typecheck` error count unchanged (89 pre-existing errors on `excel-365-complete`, none introduced).

Closes #20