### PR TITLE
fix: Clear Filters drops custom-condition predicates (#7)

### DIFF
--- a/packages/react/src/DataGrid.tsx
+++ b/packages/react/src/DataGrid.tsx
@@ -914,12 +914,38 @@ export function DataGrid<TData extends Record<string, unknown>>(props: DataGridP
   // result collapses back to `null` so the grid reports "no filter". Logic
   // (`and`/`or`) is preserved from the existing tree or defaults to `and` for
   // a fresh tree.
+  //
+  // Pruning walks the tree recursively so nested composites emitted by the
+  // "Custom Filter…" dialog (shape: { logic, filters: [...leaves on field] })
+  // are removed along with plain leaves. A composite whose entire subtree
+  // only targeted `field` collapses to an empty list and is dropped; a mixed
+  // composite loses its `field`-matching branches but stays in the tree.
   const replaceFieldFilter = useCallback(
     (field: string, replacement: FilterDescriptor | CompositeFilterDescriptor | null) => {
       const prev = state.filter;
-      const otherFilters = prev
-        ? prev.filters.filter((child) => !('field' in child) || child.field !== field)
-        : [];
+
+      const stripField = (
+        node: FilterDescriptor | CompositeFilterDescriptor,
+      ): FilterDescriptor | CompositeFilterDescriptor | null => {
+        if ('filters' in node) {
+          const kept: Array<FilterDescriptor | CompositeFilterDescriptor> = [];
+          for (const child of node.filters) {
+            const pruned = stripField(child);
+            if (pruned !== null) kept.push(pruned);
+          }
+          if (kept.length === 0) return null;
+          return { ...node, filters: kept };
+        }
+        return node.field === field ? null : node;
+      };
+
+      const otherFilters: Array<FilterDescriptor | CompositeFilterDescriptor> = [];
+      if (prev) {
+        for (const child of prev.filters) {
+          const pruned = stripField(child);
+          if (pruned !== null) otherFilters.push(pruned);
+        }
+      }
       const nextChildren = replacement ? [...otherFilters, replacement] : otherFilters;
       const next: CompositeFilterDescriptor | null =
         nextChildren.length > 0 ? { logic: prev?.logic ?? 'and', filters: nextChildren } : null;

--- a/packages/react/src/__tests__/sort-filter-integration.test.tsx
+++ b/packages/react/src/__tests__/sort-filter-integration.test.tsx
@@ -765,3 +765,117 @@ describe('filter integration', () => {
     expect(onFilterChange).toHaveBeenCalledWith(filterState);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Regression: "Clear Filter from <col>" must also drop predicates emitted
+// by the custom-condition dialog, which arrive as nested composites rather
+// than flat leaves. See issue #7.
+// ---------------------------------------------------------------------------
+
+describe('filter integration — clear custom condition filter (#7)', () => {
+  function getNameCells(): string[] {
+    return screen
+      .getAllByRole('gridcell')
+      .filter((c) => c.getAttribute('data-field') === 'name')
+      .map((c) => c.textContent?.trim() ?? '');
+  }
+
+  it('clears a custom text filter applied via the condition dialog', async () => {
+    const onFilterChange = vi.fn();
+    render(
+      <DataGrid
+        data={makeSortData()}
+        columns={sortColumns}
+        rowKey="id"
+        filtering={true}
+        showFilterMenu
+        sorting
+        onFilterChange={onFilterChange}
+      />
+    );
+
+    // Sanity: all three rows are visible initially.
+    expect(getNameCells().sort()).toEqual(['Alice', 'Bob', 'Charlie']);
+
+    // Open the column filter menu for "name".
+    const nameHeader = screen.getByRole('columnheader', { name: /^name/i });
+    const chevron = within(nameHeader).getByTestId('column-filter-icon');
+    fireEvent.click(chevron);
+
+    // Open the Text Filters… custom-condition dialog.
+    fireEvent.click(screen.getByTestId('column-filter-conditions'));
+
+    // Build: name contains "li" (matches Charlie and Alice).
+    fireEvent.change(screen.getByTestId('filter-cond-op-1'), { target: { value: 'contains' } });
+    fireEvent.change(screen.getByTestId('filter-cond-val-1'), { target: { value: 'li' } });
+    fireEvent.click(screen.getByTestId('filter-cond-ok'));
+
+    // Filter is active → Charlie + Alice visible, Bob gone.
+    expect(getNameCells().sort()).toEqual(['Alice', 'Charlie']);
+    // The dialog emits a composite child; onFilterChange must have received it.
+    const lastFilterCall = onFilterChange.mock.calls.at(-1)![0];
+    expect(lastFilterCall).toEqual({
+      logic: 'and',
+      filters: [
+        {
+          logic: 'and',
+          filters: [{ field: 'name', operator: 'contains', value: 'li' }],
+        },
+      ],
+    });
+
+    // Re-open the menu and click "Clear Filter from 'Name'".
+    fireEvent.click(within(nameHeader).getByTestId('column-filter-icon'));
+    const clearBtn = screen.getByTestId('column-filter-clear');
+    expect(clearBtn).not.toHaveAttribute('aria-disabled');
+    fireEvent.click(clearBtn);
+
+    // After clearing, all rows must be visible again and the filter state null.
+    expect(getNameCells().sort()).toEqual(['Alice', 'Bob', 'Charlie']);
+    expect(onFilterChange).toHaveBeenLastCalledWith(null);
+  });
+
+  it('clears a custom filter even when mixed with a filter on a different field', async () => {
+    const onFilterChange = vi.fn();
+    render(
+      <DataGrid
+        data={makeSortData()}
+        columns={sortColumns}
+        rowKey="id"
+        filtering={true}
+        showFilterMenu
+        sorting
+        onFilterChange={onFilterChange}
+        // Pre-seed a filter on a different column (`age > 28`). Clearing the
+        // name-column custom filter must not touch this one.
+        initialFilter={{
+          logic: 'and',
+          filters: [{ field: 'age', operator: 'gt', value: 28 }],
+        }}
+      />
+    );
+
+    // Apply a custom-condition filter on `name`.
+    const nameHeader = screen.getByRole('columnheader', { name: /^name/i });
+    fireEvent.click(within(nameHeader).getByTestId('column-filter-icon'));
+    fireEvent.click(screen.getByTestId('column-filter-conditions'));
+    fireEvent.change(screen.getByTestId('filter-cond-op-1'), { target: { value: 'contains' } });
+    fireEvent.change(screen.getByTestId('filter-cond-val-1'), { target: { value: 'li' } });
+    fireEvent.click(screen.getByTestId('filter-cond-ok'));
+
+    // Only Charlie (age 35 > 28 AND name contains "li").
+    expect(getNameCells()).toEqual(['Charlie']);
+
+    // Clear the name filter; the `age > 28` predicate must stay in place.
+    fireEvent.click(within(nameHeader).getByTestId('column-filter-icon'));
+    fireEvent.click(screen.getByTestId('column-filter-clear'));
+
+    // With only `age > 28`: Charlie (35) and Bob (30) pass, Alice (25) filtered out.
+    expect(getNameCells().sort()).toEqual(['Bob', 'Charlie']);
+    const lastCall = onFilterChange.mock.calls.at(-1)![0];
+    expect(lastCall).toEqual({
+      logic: 'and',
+      filters: [{ field: 'age', operator: 'gt', value: 28 }],
+    });
+  });
+});


### PR DESCRIPTION
Closes #7.

## Summary
- `Clear Filter from <col>` only removed flat leaf predicates whose top-level `field` matched the column.
- Filters produced by `FilterConditionDialog` (Text/Number/Date Filters…) arrive as nested composite children — shape `{ logic, filters: [...leaves] }` — and were silently retained, so the grid kept filtering after the user clicked Clear.
- Rewrote `replaceFieldFilter` in `packages/react/src/DataGrid.tsx` to recursively prune any descendant leaf targeting the field. A composite whose entire subtree is about that field collapses to empty and is dropped; mixed composites keep their unrelated branches intact.

## Test plan
- [x] New regression tests in `packages/react/src/__tests__/sort-filter-integration.test.tsx` drive the real UI (chevron → Text Filters… → OK → Clear Filter) and assert both that rows come back and that `onFilterChange` fires with `null`.
- [x] A companion test verifies mixed state: clearing the custom filter on one column preserves an unrelated predicate on another column.
- [x] Verified both regressions fail on the pre-fix code.
- [x] `pnpm test` — 1483/1483 pass.
- [x] `pnpm typecheck` — clean.