### PR TITLE
feat: Excel-style Ctrl+Arrow jump to edge of populated cell block

### DIFF
--- a/packages/core/src/__tests__/selection.test.ts
+++ b/packages/core/src/__tests__/selection.test.ts
@@ -14,8 +14,10 @@ import {
   getLastCell,
   getNextCellInRow,
   getPrevCellInRow,
+  getEndJumpCell,
+  isCellValueEmpty,
 } from '../selection';
-import { ColumnDef } from '../types';
+import { CellAddress, ColumnDef } from '../types';
 
 const cols: ColumnDef[] = [
   { id: 'c1', field: 'name', title: 'Name' },
@@ -381,5 +383,123 @@ describe('multi-range selection', () => {
   it('createSelection initializes with empty ranges', () => {
     const s = createSelection();
     expect(s.ranges).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getEndJumpCell / isCellValueEmpty — Excel-style Ctrl+Arrow "End" navigation
+// ---------------------------------------------------------------------------
+
+describe('isCellValueEmpty', () => {
+  it('treats null, undefined, and empty string as empty', () => {
+    expect(isCellValueEmpty(null)).toBe(true);
+    expect(isCellValueEmpty(undefined)).toBe(true);
+    expect(isCellValueEmpty('')).toBe(true);
+  });
+
+  it('treats 0, false, and non-empty strings as non-empty', () => {
+    expect(isCellValueEmpty(0)).toBe(false);
+    expect(isCellValueEmpty(false)).toBe(false);
+    expect(isCellValueEmpty('x')).toBe(false);
+  });
+});
+
+describe('getEndJumpCell', () => {
+  // A 3-column x 4-row fixture with controlled blanks so we can exercise every
+  // "current empty / neighbour empty" permutation Excel distinguishes.
+  //
+  //          name    age    city
+  //   r1:    Alice   30     Paris
+  //   r2:    Bob     ''     Lyon        ← blank middle column
+  //   r3:    ''      ''     ''          ← fully blank row
+  //   r4:    Dan     40     Rome
+  const endCols: ColumnDef[] = [
+    { id: 'c1', field: 'name', title: 'Name' },
+    { id: 'c2', field: 'age', title: 'Age' },
+    { id: 'c3', field: 'city', title: 'City' },
+  ];
+  const endRowIds = ['r1', 'r2', 'r3', 'r4'];
+  const endData: Record<string, Record<string, unknown>> = {
+    r1: { name: 'Alice', age: 30, city: 'Paris' },
+    r2: { name: 'Bob', age: '', city: 'Lyon' },
+    r3: { name: '', age: '', city: '' },
+    r4: { name: 'Dan', age: 40, city: 'Rome' },
+  };
+  const get = (cell: CellAddress) => endData[cell.rowId]?.[cell.field];
+
+  it('returns null when already at the edge in the requested direction', () => {
+    expect(getEndJumpCell({ rowId: 'r1', field: 'name' }, 'left', endCols, endRowIds, get)).toBeNull();
+    expect(getEndJumpCell({ rowId: 'r1', field: 'city' }, 'right', endCols, endRowIds, get)).toBeNull();
+    expect(getEndJumpCell({ rowId: 'r1', field: 'name' }, 'up', endCols, endRowIds, get)).toBeNull();
+    expect(getEndJumpCell({ rowId: 'r4', field: 'name' }, 'down', endCols, endRowIds, get)).toBeNull();
+  });
+
+  it('right from a populated run with populated neighbour lands on the run\'s last non-empty cell', () => {
+    // r1 is fully populated, so right from name should stop on city (Excel "End" → last non-blank in block).
+    expect(getEndJumpCell({ rowId: 'r1', field: 'name' }, 'right', endCols, endRowIds, get))
+      .toEqual({ rowId: 'r1', field: 'city' });
+  });
+
+  it('right from a populated cell with an empty neighbour skips the gap to the next non-empty cell', () => {
+    // r2 row: [Bob, '', Lyon] — right from name should leap over the blank and land on city.
+    expect(getEndJumpCell({ rowId: 'r2', field: 'name' }, 'right', endCols, endRowIds, get))
+      .toEqual({ rowId: 'r2', field: 'city' });
+  });
+
+  it('right from an empty cell stops on the next non-empty neighbour', () => {
+    // r2.age is blank; the next populated cell is city.
+    expect(getEndJumpCell({ rowId: 'r2', field: 'age' }, 'right', endCols, endRowIds, get))
+      .toEqual({ rowId: 'r2', field: 'city' });
+  });
+
+  it('right from an all-empty row lands on the far edge', () => {
+    // r3 is fully blank — Excel walks to the last column.
+    expect(getEndJumpCell({ rowId: 'r3', field: 'name' }, 'right', endCols, endRowIds, get))
+      .toEqual({ rowId: 'r3', field: 'city' });
+  });
+
+  it('left mirrors right: populated run → first non-empty, gap → skip to next block', () => {
+    // r1 (all populated): left from city → name.
+    expect(getEndJumpCell({ rowId: 'r1', field: 'city' }, 'left', endCols, endRowIds, get))
+      .toEqual({ rowId: 'r1', field: 'name' });
+    // r2 (gap in middle): left from city → name, skipping over blank age.
+    expect(getEndJumpCell({ rowId: 'r2', field: 'city' }, 'left', endCols, endRowIds, get))
+      .toEqual({ rowId: 'r2', field: 'name' });
+  });
+
+  it('down from populated with empty gap skips the gap onto the next populated row', () => {
+    // name column: r1=Alice, r2=Bob, r3='', r4=Dan. Down from r2 should jump over r3 to r4.
+    expect(getEndJumpCell({ rowId: 'r2', field: 'name' }, 'down', endCols, endRowIds, get))
+      .toEqual({ rowId: 'r4', field: 'name' });
+  });
+
+  it('down from populated with populated neighbour stops at end of contiguous run', () => {
+    // name column r1→r2 is a populated run ending at r2 (r3 is blank).
+    expect(getEndJumpCell({ rowId: 'r1', field: 'name' }, 'down', endCols, endRowIds, get))
+      .toEqual({ rowId: 'r2', field: 'name' });
+  });
+
+  it('up from populated with empty gap jumps over the gap to the next populated row', () => {
+    // name column: up from r4 (Dan) skips blank r3 and lands on r2 (Bob).
+    expect(getEndJumpCell({ rowId: 'r4', field: 'name' }, 'up', endCols, endRowIds, get))
+      .toEqual({ rowId: 'r2', field: 'name' });
+  });
+
+  it('up from an all-empty column lands on the first row when nothing is populated', () => {
+    // age column: r1=30, r2='', r3='', r4=40. From r3 walking up, we look for
+    // first non-empty above: r2 is blank, r1 is 30 → land on r1.
+    expect(getEndJumpCell({ rowId: 'r3', field: 'age' }, 'up', endCols, endRowIds, get))
+      .toEqual({ rowId: 'r1', field: 'age' });
+  });
+
+  it('skips hidden columns when scanning horizontally', () => {
+    const withHidden: ColumnDef[] = [
+      { id: 'c1', field: 'name', title: 'Name' },
+      { id: 'c2', field: 'age', title: 'Age', visible: false },
+      { id: 'c3', field: 'city', title: 'City' },
+    ];
+    // r1 populated; age is hidden so the only visible neighbour is city.
+    expect(getEndJumpCell({ rowId: 'r1', field: 'name' }, 'right', withHidden, endRowIds, get))
+      .toEqual({ rowId: 'r1', field: 'city' });
   });
 });

--- a/packages/core/src/selection.ts
+++ b/packages/core/src/selection.ts
@@ -430,3 +430,118 @@ export function getPrevCellInRow(current: CellAddress, columns: ColumnDef<any>[]
   }
   return null;
 }
+
+/**
+ * Treats `null`, `undefined`, and the empty string as "blank" — matching the
+ * convention already used by the filtering module so that Excel-style "End"
+ * navigation agrees with how the rest of the grid judges emptiness.
+ *
+ * @param value - The cell value to classify.
+ * @returns `true` when the value should be considered an empty cell.
+ */
+export function isCellValueEmpty(value: unknown): boolean {
+  return value == null || value === '';
+}
+
+/**
+ * Computes the Excel-style "End mode" destination when Ctrl+Arrow is pressed.
+ *
+ * Semantics mirror Excel: starting from `current`, scan in `direction` along
+ * the same row or column and pick the landing cell using these rules, based on
+ * whether the current cell and its immediate neighbour are empty:
+ *
+ * - **current empty, neighbour empty** — jump to the first non-empty cell (or
+ *   the grid edge if every cell is empty).
+ * - **current empty, neighbour non-empty** — stop on that neighbour (the near
+ *   edge of the next populated block).
+ * - **current non-empty, neighbour empty** — skip the empty gap and land on
+ *   the first non-empty cell after it (or the grid edge if the run of empties
+ *   reaches all the way to the edge).
+ * - **current non-empty, neighbour non-empty** — continue through the current
+ *   populated run and stop on its last non-empty cell.
+ *
+ * `getCellValue` receives a cell address and returns that cell's stored value.
+ * This lets the helper stay decoupled from the storage model (processed data,
+ * plain array, virtualised view, etc.) — `isCellValueEmpty` decides emptiness.
+ *
+ * @param current - The starting cell address.
+ * @param direction - The direction to scan (`'up'`, `'down'`, `'left'`, `'right'`).
+ * @param columns - Full list of column definitions (hidden columns skipped).
+ * @param rowIds - Ordered list of all row identifiers.
+ * @param getCellValue - Reader that returns the raw value for a given cell.
+ * @returns The destination {@link CellAddress}, or `null` when no movement is possible
+ *   (e.g. already at the edge).
+ */
+export function getEndJumpCell(
+  current: CellAddress,
+  direction: 'up' | 'down' | 'left' | 'right',
+  columns: ColumnDef<any>[],
+  rowIds: string[],
+  getCellValue: (cell: CellAddress) => unknown,
+): CellAddress | null {
+  const visibleCols = columns.filter(c => c.visible !== false);
+
+  // Build the ordered sequence of cells we would visit if we kept pressing the
+  // plain arrow key from `current`, so the scan is direction-agnostic.
+  const sequence: CellAddress[] = [];
+  if (direction === 'left' || direction === 'right') {
+    const colIdx = visibleCols.findIndex(c => c.field === current.field);
+    if (colIdx === -1) return null;
+    if (direction === 'right') {
+      for (let i = colIdx + 1; i < visibleCols.length; i++) {
+        sequence.push({ rowId: current.rowId, field: visibleCols[i]!.field });
+      }
+    } else {
+      for (let i = colIdx - 1; i >= 0; i--) {
+        sequence.push({ rowId: current.rowId, field: visibleCols[i]!.field });
+      }
+    }
+  } else {
+    const rowIdx = rowIds.indexOf(current.rowId);
+    if (rowIdx === -1) return null;
+    if (direction === 'down') {
+      for (let i = rowIdx + 1; i < rowIds.length; i++) {
+        sequence.push({ rowId: rowIds[i]!, field: current.field });
+      }
+    } else {
+      for (let i = rowIdx - 1; i >= 0; i--) {
+        sequence.push({ rowId: rowIds[i]!, field: current.field });
+      }
+    }
+  }
+
+  // Already at the edge — no cell to jump to.
+  if (sequence.length === 0) return null;
+
+  const startEmpty = isCellValueEmpty(getCellValue(current));
+  const firstNeighbourEmpty = isCellValueEmpty(getCellValue(sequence[0]!));
+
+  // Case A: current is empty → find the first non-empty cell in `sequence`.
+  // If nothing is non-empty we land on the far edge. This covers both the
+  // "neighbour empty" and "neighbour non-empty" sub-cases from the doc-comment
+  // because `findIndex` returns 0 when the immediate neighbour is already populated.
+  if (startEmpty) {
+    const firstNonEmpty = sequence.findIndex(c => !isCellValueEmpty(getCellValue(c)));
+    if (firstNonEmpty !== -1) return sequence[firstNonEmpty]!;
+    return sequence[sequence.length - 1]!;
+  }
+
+  // Case B: current non-empty, neighbour empty → skip the empty run and land
+  // on the first non-empty cell after it (or on the far edge when the empty
+  // run extends all the way to the grid boundary, matching Excel).
+  if (firstNeighbourEmpty) {
+    for (let i = 1; i < sequence.length; i++) {
+      if (!isCellValueEmpty(getCellValue(sequence[i]!))) return sequence[i]!;
+    }
+    return sequence[sequence.length - 1]!;
+  }
+
+  // Case C: current non-empty and neighbour non-empty → walk through the
+  // populated run and stop at its last non-empty cell.
+  let lastNonEmpty = sequence[0]!;
+  for (let i = 1; i < sequence.length; i++) {
+    if (isCellValueEmpty(getCellValue(sequence[i]!))) break;
+    lastNonEmpty = sequence[i]!;
+  }
+  return lastNonEmpty;
+}

--- a/packages/react/src/__tests__/keyboard-nav.test.tsx
+++ b/packages/react/src/__tests__/keyboard-nav.test.tsx
@@ -314,34 +314,95 @@ describe('Keyboard navigation', () => {
     expect(isSelected('2', 'name')).toBe(true);
   });
 
-  // -- Ctrl+Arrow (jump to edge) -------------------------------------------
+  // -- Ctrl+Arrow (Excel "End" jump) ---------------------------------------
 
-  it('Ctrl+ArrowRight jumps to last cell in row', () => {
+  // When every cell along the row or column is populated, "End" mode walks to
+  // the far edge of the populated run — which is the grid edge in this fixture.
+
+  it('Ctrl+ArrowRight jumps to last non-empty cell in row', () => {
     renderGrid();
     fireEvent.click(getCell('1', 'name'));
     fireEvent.keyDown(getGrid(), { key: 'ArrowRight', ctrlKey: true });
     expect(isSelected('1', 'active')).toBe(true);
   });
 
-  it('Ctrl+ArrowLeft jumps to first cell in row', () => {
+  it('Ctrl+ArrowLeft jumps to first non-empty cell in row', () => {
     renderGrid();
     fireEvent.click(getCell('1', 'active'));
     fireEvent.keyDown(getGrid(), { key: 'ArrowLeft', ctrlKey: true });
     expect(isSelected('1', 'name')).toBe(true);
   });
 
-  it('Ctrl+ArrowDown jumps to last row in column', () => {
+  it('Ctrl+ArrowDown jumps to last non-empty cell in column', () => {
     renderGrid();
     fireEvent.click(getCell('1', 'name'));
     fireEvent.keyDown(getGrid(), { key: 'ArrowDown', ctrlKey: true });
     expect(isSelected('3', 'name')).toBe(true);
   });
 
-  it('Ctrl+ArrowUp jumps to first row in column', () => {
+  it('Ctrl+ArrowUp jumps to first non-empty cell in column', () => {
     renderGrid();
     fireEvent.click(getCell('3', 'name'));
     fireEvent.keyDown(getGrid(), { key: 'ArrowUp', ctrlKey: true });
     expect(isSelected('1', 'name')).toBe(true);
+  });
+
+  // -- Ctrl+Shift+Arrow (extend range to End target) -----------------------
+
+  /** Whether the given cell renders `aria-selected="true"` — covers the whole range. */
+  function isInRange(rowId: string, field: string): boolean {
+    return getCell(rowId, field).getAttribute('aria-selected') === 'true';
+  }
+
+  it('Ctrl+Shift+ArrowRight extends selection to the row\'s last non-empty cell', () => {
+    renderGrid();
+    fireEvent.click(getCell('1', 'name'));
+    fireEvent.keyDown(getGrid(), { key: 'ArrowRight', ctrlKey: true, shiftKey: true });
+
+    // Every cell between the anchor (inclusive) and the row's last populated cell lights up.
+    expect(isInRange('1', 'name')).toBe(true);
+    expect(isInRange('1', 'age')).toBe(true);
+    expect(isInRange('1', 'active')).toBe(true);
+    // Other rows remain untouched.
+    expect(isInRange('2', 'name')).toBe(false);
+  });
+
+  it('Ctrl+Shift+ArrowDown extends selection to the column\'s last non-empty row', () => {
+    renderGrid();
+    fireEvent.click(getCell('1', 'name'));
+    fireEvent.keyDown(getGrid(), { key: 'ArrowDown', ctrlKey: true, shiftKey: true });
+
+    expect(isInRange('1', 'name')).toBe(true);
+    expect(isInRange('2', 'name')).toBe(true);
+    expect(isInRange('3', 'name')).toBe(true);
+    // Other columns stay out of range.
+    expect(isInRange('2', 'age')).toBe(false);
+  });
+
+  it('Ctrl+Shift+ArrowLeft extends left to the first non-empty cell, keeping the anchor', () => {
+    renderGrid();
+    fireEvent.click(getCell('3', 'active'));
+    fireEvent.keyDown(getGrid(), { key: 'ArrowLeft', ctrlKey: true, shiftKey: true });
+
+    // Row 3, all three columns, selected.
+    expect(isInRange('3', 'name')).toBe(true);
+    expect(isInRange('3', 'age')).toBe(true);
+    expect(isInRange('3', 'active')).toBe(true);
+    // Rows above are untouched.
+    expect(isInRange('1', 'name')).toBe(false);
+  });
+
+  it('Ctrl+Shift+ArrowUp extends up to the first non-empty row, keeping the anchor column', () => {
+    renderGrid();
+    fireEvent.click(getCell('3', 'active'));
+    fireEvent.keyDown(getGrid(), { key: 'ArrowUp', ctrlKey: true, shiftKey: true });
+
+    // "active" column should light up from r1 through the anchor at r3.
+    expect(isInRange('1', 'active')).toBe(true);
+    expect(isInRange('2', 'active')).toBe(true);
+    expect(isInRange('3', 'active')).toBe(true);
+    // Adjacent columns stay out of range.
+    expect(isInRange('1', 'age')).toBe(false);
   });
 
   // -- PageDown / PageUp ----------------------------------------------------

--- a/packages/react/src/use-keyboard.ts
+++ b/packages/react/src/use-keyboard.ts
@@ -5,7 +5,8 @@
  * keyboard events into {@link GridModel} mutations -- cell navigation,
  * selection extension, editing lifecycle, undo/redo, and boolean toggling.
  * Supports standard spreadsheet-like key bindings including arrow keys with
- * Shift (extend selection), Ctrl/Cmd (jump to edge), Tab (move within row),
+ * Shift (extend selection), Ctrl/Cmd (Excel "End" jump to the edge of the
+ * current data block), Ctrl+Shift (extend to that edge), Tab (move within row),
  * Enter (commit edit / begin edit), Escape (cancel), Home/End, F2, Delete,
  * Ctrl+A, and Ctrl+Z/Y.
  *
@@ -20,6 +21,7 @@ import {
   getLastCell,
   getNextCellInRow,
   getPrevCellInRow,
+  getEndJumpCell,
   ColumnDef,
   serializeRangeToText,
   parseTextToGrid,
@@ -130,23 +132,29 @@ export function useKeyboard<TData extends Record<string, unknown>>(
           e.key === 'ArrowLeft' ? 'left' :
           e.key === 'ArrowDown' ? 'down' : 'up';
 
-        if (e.shiftKey) {
+        if (e.ctrlKey || e.metaKey) {
+          // Ctrl/Cmd+Arrow jumps Excel "End" style: walk along the row/column and
+          // stop at the edge of the nearest populated block. Ctrl+Shift+Arrow
+          // extends the range to the same target instead of moving the caret.
+          const processedData = model.getProcessedData();
+          const getCellValue = (cell: CellAddress): unknown => {
+            const rowIndex = rowIds.indexOf(cell.rowId);
+            if (rowIndex < 0) return undefined;
+            const row = processedData[rowIndex] as Record<string, unknown> | undefined;
+            return row ? row[cell.field] : undefined;
+          };
+          const target = getEndJumpCell(current, dir, columns, rowIds, getCellValue);
+          if (target) {
+            if (e.shiftKey) {
+              model.extendTo(target);
+            } else {
+              model.select(target);
+            }
+          }
+        } else if (e.shiftKey) {
           // Shift+Arrow extends the selection range to the adjacent cell.
           const target = getNextCell(current, dir, columns, rowIds);
           if (target) model.extendTo(target);
-        } else if (e.ctrlKey || e.metaKey) {
-          // Ctrl/Cmd+Arrow jumps to the edge of the grid in that direction.
-          if (dir === 'right' || dir === 'left') {
-            const edge = dir === 'right'
-              ? getLastCell(columns, rowIds)
-              : getFirstCell(columns, rowIds);
-            if (edge) model.select({ rowId: current.rowId, field: edge.field });
-          } else {
-            const edge = dir === 'down'
-              ? getLastCell(columns, rowIds)
-              : getFirstCell(columns, rowIds);
-            if (edge) model.select({ rowId: edge.rowId, field: current.field });
-          }
         } else {
           // Plain arrow key moves selection by one cell.
           const next = getNextCell(current, dir, columns, rowIds);

--- a/stories/Keyboard.stories.tsx
+++ b/stories/Keyboard.stories.tsx
@@ -26,6 +26,8 @@ export const FullKeyboardSupport: StoryObj = {
             {[
               ['Arrow keys', 'Move selection'],
               ['Shift + Arrow', 'Extend range selection'],
+              ['Ctrl + Arrow', 'Jump to edge of the current data block (Excel "End" mode)'],
+              ['Ctrl + Shift + Arrow', 'Extend selection to edge of the current data block'],
               ['Tab / Shift+Tab', 'Move to next/previous cell'],
               ['Enter', 'Start editing / commit + move down'],
               ['Escape', 'Cancel edit / clear selection'],


### PR DESCRIPTION
## Summary
- Ctrl+Arrow now jumps to the edge of the current populated run (Excel "End" mode) rather than flying to the grid boundary.
- Ctrl+Shift+Arrow extends the range to the same destination, keeping the anchor fixed so range selection composes naturally.
- Emptiness follows the existing filter-module convention: null, undefined, or empty string.

The logic lives in a new framework-agnostic getEndJumpCell helper in the core selection module; the React keyboard hook wires it up and threads the model's processed data through a cell-value reader.

Closes #13

## Test plan
- [x] `pnpm test` — 1498/1498 passing (includes 11 new unit tests for getEndJumpCell and 5 new Ctrl+Arrow / Ctrl+Shift+Arrow integration tests in keyboard-nav.test.tsx)
- [x] `pnpm typecheck`
- [x] Build passes (pre-commit hook)
- [ ] Manual check in Keyboard Navigation story — new shortcut row documented; try Ctrl+Arrow against a dataset with blank cells to confirm the Excel-matching jumps