### PR TITLE
fix(editing): Esc cancels edit, reverts value, keeps selection (#11)

### DIFF
--- a/packages/react/src/__tests__/DataGrid.test.tsx
+++ b/packages/react/src/__tests__/DataGrid.test.tsx
@@ -162,6 +162,68 @@ describe('DataGrid editing', () => {
     expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
   });
 
+  // Issue #11: Esc reverts the draft, exits edit mode, and keeps selection.
+  it('Escape reverts typed value and keeps cell selected (issue #11)', () => {
+    const onCellEdit = vi.fn();
+    renderGrid({ onCellEdit });
+    const cells = screen.getAllByRole('gridcell');
+    const aliceNameCell = cells[0]!;
+
+    // Select via click, then enter edit mode and type a new value.
+    fireEvent.click(aliceNameCell);
+    expect(aliceNameCell).toHaveStyle({
+      outline: '2px solid var(--dg-selection-border, #3b82f6)',
+    });
+    fireEvent.dblClick(aliceNameCell);
+    const input = screen.getByRole('textbox') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'Mallory' } });
+    expect(input.value).toBe('Mallory');
+
+    // Escape must cancel (no commit), exit edit mode, and keep selection.
+    fireEvent.keyDown(input, { key: 'Escape' });
+
+    // The blur that fires when React unmounts the input must not commit.
+    fireEvent.blur(input);
+
+    // Value in the row data reverted: onCellEdit never fired, display shows
+    // the original text.
+    expect(onCellEdit).not.toHaveBeenCalled();
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+    const refreshedCell = screen.getAllByRole('gridcell')[0]!;
+    expect(refreshedCell.textContent).toContain('Alice');
+
+    // Selection still on the same cell.
+    expect(refreshedCell).toHaveStyle({
+      outline: '2px solid var(--dg-selection-border, #3b82f6)',
+    });
+  });
+
+  it('Escape bubbling from input to grid-level handler keeps selection (issue #11)', () => {
+    const onCellEdit = vi.fn();
+    renderGrid({ onCellEdit });
+    const cells = screen.getAllByRole('gridcell');
+    const aliceNameCell = cells[0]!;
+
+    fireEvent.click(aliceNameCell);
+    fireEvent.dblClick(aliceNameCell);
+    const input = screen.getByRole('textbox') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'Mallory' } });
+
+    // fireEvent.keyDown on the input bubbles through React delegation to the
+    // grid container's native keydown listener. The cell-level React handler
+    // cancels the edit first; when the bubble reaches the grid, `editing`
+    // is already null — the grid handler must detect `e.target` is still the
+    // input and NOT clear the selection.
+    fireEvent.keyDown(input, { key: 'Escape' });
+
+    expect(onCellEdit).not.toHaveBeenCalled();
+    const refreshedCell = screen.getAllByRole('gridcell')[0]!;
+    expect(refreshedCell.textContent).toContain('Alice');
+    expect(refreshedCell).toHaveStyle({
+      outline: '2px solid var(--dg-selection-border, #3b82f6)',
+    });
+  });
+
   it('read-only mode prevents editing on double click', () => {
     renderGrid({ readOnly: true });
     const cells = screen.getAllByRole('gridcell');

--- a/packages/react/src/body/DataGridBody.tsx
+++ b/packages/react/src/body/DataGridBody.tsx
@@ -33,7 +33,7 @@
  *  - {@link ./DataGridBody.styles} — inline CSSProperties factories used
  *    across both render paths.
  */
-import React from 'react';
+import React, { useRef } from 'react';
 import {
   ColumnDef,
   CellAddress,
@@ -223,6 +223,14 @@ export function DataGridBody<TData extends Record<string, unknown>>(
   const ghostPosition = showGhostRow ? resolveGhostPosition(ghostRowConfig) : 'bottom';
   const ghostAtTop = ghostPosition === 'top' && showGhostRow;
 
+  // Issue #11: when Esc is pressed inside the fallback inline editor, the
+  // unmount that follows `model.cancelEdit()` triggers a native `blur` event
+  // that would otherwise commit the draft. This ref flips to `true` in the
+  // Escape handler and is consulted by `onBlur` so the cancelled draft is
+  // discarded. It lives at component scope so the closure captured by the
+  // input survives the unmount.
+  const inlineEditCancelledRef = useRef(false);
+
   // Row-number chrome column position.
   //
   // Defaults to 'left' to match the Excel 365 convention: row numbers sit to
@@ -381,7 +389,13 @@ export function DataGridBody<TData extends Record<string, unknown>>(
             autoFocus
             defaultValue={value != null ? String(value) : ''}
             style={styles.cellInput}
+            ref={(el) => {
+              // Clear the cancellation flag each time a new edit input
+              // mounts, so a previous Esc doesn't silence the next commit.
+              if (el) inlineEditCancelledRef.current = false;
+            }}
             onBlur={e => {
+              if (inlineEditCancelledRef.current) return;
               const newVal = e.target.value;
               const vResult = validateCell(col, newVal, rowId);
               if (vResult && vResult.severity === 'error') {
@@ -409,6 +423,7 @@ export function DataGridBody<TData extends Record<string, unknown>>(
                 model.cancelEdit();
                 onCellEdit?.(rowId, col.field, newVal, value);
               } else if (e.key === 'Escape') {
+                inlineEditCancelledRef.current = true;
                 model.cancelEdit();
               }
               e.stopPropagation();

--- a/packages/react/src/cells/CurrencyCell/CurrencyCell.tsx
+++ b/packages/react/src/cells/CurrencyCell/CurrencyCell.tsx
@@ -122,11 +122,14 @@ export const CurrencyCell = React.memo(function CurrencyCell<TData = Record<stri
   const numericValue = value === null || value === undefined ? '' : String(value);
   const [draft, setDraft] = useState(numericValue);
   const inputRef = useRef<HTMLInputElement>(null);
+  // Prevents the unmount-blur from committing a cancelled draft (issue #11).
+  const cancelledRef = useRef(false);
 
   // Reset draft and auto-focus/select when entering edit mode
   useEffect(() => {
     if (isEditing) {
       setDraft(numericValue);
+      cancelledRef.current = false;
       inputRef.current?.focus();
       inputRef.current?.select();
     }
@@ -160,6 +163,7 @@ export const CurrencyCell = React.memo(function CurrencyCell<TData = Record<stri
    * when the draft is empty, a lone minus sign, or otherwise unparseable.
    */
   const commit = () => {
+    if (cancelledRef.current) return;
     if (draft === '' || draft === '-') {
       onCommit(null);
       return;
@@ -171,7 +175,10 @@ export const CurrencyCell = React.memo(function CurrencyCell<TData = Record<stri
   /** Commits on Enter, cancels on Escape. */
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter') commit();
-    else if (e.key === 'Escape') onCancel();
+    else if (e.key === 'Escape') {
+      cancelledRef.current = true;
+      onCancel();
+    }
   };
 
   // --- Edit mode input ---

--- a/packages/react/src/cells/NumericCell/NumericCell.tsx
+++ b/packages/react/src/cells/NumericCell/NumericCell.tsx
@@ -94,11 +94,15 @@ export const NumericCell = React.memo(function NumericCell<TData = Record<string
   const rawValue = value === null || value === undefined ? '' : String(value);
   const [draft, setDraft] = useState(rawValue);
   const inputRef = useRef<HTMLInputElement>(null);
+  // Tracks an Escape-triggered cancel so the trailing blur (on unmount)
+  // does not commit the in-progress draft (issue #11).
+  const cancelledRef = useRef(false);
 
   // Reset the draft and focus the input whenever the cell enters edit mode
   useEffect(() => {
     if (isEditing) {
       setDraft(rawValue);
+      cancelledRef.current = false;
       inputRef.current?.focus();
       inputRef.current?.select();
     }
@@ -154,6 +158,7 @@ export const NumericCell = React.memo(function NumericCell<TData = Record<string
     if (e.key === 'Enter') {
       commit(draft);
     } else if (e.key === 'Escape') {
+      cancelledRef.current = true;
       onCancel();
     } else if (e.key === 'ArrowUp') {
       // Increment the current value by 1, clamping to bounds
@@ -195,7 +200,10 @@ export const NumericCell = React.memo(function NumericCell<TData = Record<string
       max={column.max}
       onChange={handleChange}
       onKeyDown={handleKeyDown}
-      onBlur={() => commit(draft)}
+      onBlur={() => {
+        if (cancelledRef.current) return;
+        commit(draft);
+      }}
       style={styles.editInput}
     />
   );

--- a/packages/react/src/cells/PasswordCell/PasswordCell.tsx
+++ b/packages/react/src/cells/PasswordCell/PasswordCell.tsx
@@ -77,11 +77,14 @@ export const PasswordCell = React.memo(function PasswordCell<TData = Record<stri
   const [revealed, setRevealed] = useState(false);
   const [draft, setDraft] = useState(strValue);
   const inputRef = useRef<HTMLInputElement>(null);
+  // Prevents the unmount-blur from committing a cancelled draft (issue #11).
+  const cancelledRef = useRef(false);
 
   // Sync draft and auto-focus when entering edit mode
   useEffect(() => {
     if (isEditing) {
       setDraft(strValue);
+      cancelledRef.current = false;
       inputRef.current?.focus();
     }
   }, [isEditing]); // eslint-disable-line react-hooks/exhaustive-deps
@@ -111,7 +114,10 @@ export const PasswordCell = React.memo(function PasswordCell<TData = Record<stri
   /** Commits on Enter, cancels on Escape. */
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter') onCommit(draft);
-    else if (e.key === 'Escape') onCancel();
+    else if (e.key === 'Escape') {
+      cancelledRef.current = true;
+      onCancel();
+    }
   };
 
   // --- Edit mode ---
@@ -123,7 +129,10 @@ export const PasswordCell = React.memo(function PasswordCell<TData = Record<stri
       value={draft}
       onChange={(e) => setDraft(e.target.value)}
       onKeyDown={handleKeyDown}
-      onBlur={() => onCommit(draft)}
+      onBlur={() => {
+        if (cancelledRef.current) return;
+        onCommit(draft);
+      }}
       style={styles.editInput}
     />
   );

--- a/packages/react/src/cells/TextCell/TextCell.tsx
+++ b/packages/react/src/cells/TextCell/TextCell.tsx
@@ -76,11 +76,16 @@ export const TextCell = React.memo(function TextCell<TData = Record<string, unkn
   const displayValue = value == null ? '' : String(value);
   const [draft, setDraft] = useState(displayValue);
   const inputRef = useRef<HTMLInputElement | HTMLTextAreaElement>(null);
+  // Tracks whether the current edit was cancelled via Escape. Without this
+  // flag the blur that fires when the input unmounts on cancel would commit
+  // the partially-edited draft back to the model (issue #11).
+  const cancelledRef = useRef(false);
 
   // Sync draft when edit mode starts
   useEffect(() => {
     if (isEditing) {
       setDraft(displayValue);
+      cancelledRef.current = false;
       // Focus after render so the cursor is placed inside the input immediately
       inputRef.current?.focus();
     }
@@ -102,17 +107,24 @@ export const TextCell = React.memo(function TextCell<TData = Record<string, unkn
 
   // --- Edit mode key handling ---
 
+  /** Marks the edit as cancelled and notifies the grid to exit edit mode. */
+  const handleCancel = () => {
+    cancelledRef.current = true;
+    onCancel();
+  };
+
   /** Commits on Enter (single-line only) and cancels on Escape. */
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter' && !column.format?.includes('multiline')) {
       onCommit(draft);
     } else if (e.key === 'Escape') {
-      onCancel();
+      handleCancel();
     }
   };
 
-  /** Commits the current draft when the input loses focus. */
+  /** Commits the current draft when the input loses focus, unless cancelled. */
   const handleBlur = () => {
+    if (cancelledRef.current) return;
     onCommit(draft);
   };
 
@@ -127,7 +139,7 @@ export const TextCell = React.memo(function TextCell<TData = Record<string, unkn
         placeholder={column.placeholder}
         onChange={(e) => setDraft(e.target.value)}
         onKeyDown={(e) => {
-          if (e.key === 'Escape') onCancel();
+          if (e.key === 'Escape') handleCancel();
         }}
         onBlur={handleBlur}
         style={styles.editTextarea}

--- a/packages/react/src/cells/hooks/useDraftState.ts
+++ b/packages/react/src/cells/hooks/useDraftState.ts
@@ -61,12 +61,17 @@ export function useDraftState({
 }: UseDraftStateOptions): UseDraftStateReturn {
   const [draft, setDraft] = useState(initialValue);
   const inputRef = useRef<HTMLInputElement | HTMLTextAreaElement | null>(null);
+  // Marks the current edit as cancelled so a trailing blur (fired when the
+  // input unmounts after Escape) does not turn the cancel into a commit.
+  // Issue #11: Esc must revert the value, never persist the draft via blur.
+  const cancelledRef = useRef(false);
 
   // Reset draft and focus the input whenever the cell enters edit mode.
   useEffect(() => {
     if (!isEditing) return;
 
     setDraft(initialValue);
+    cancelledRef.current = false;
 
     const focusInput = () => {
       inputRef.current?.focus();
@@ -85,6 +90,7 @@ export function useDraftState({
   /** Transforms and commits a value, defaulting to the current draft. */
   const commit = useCallback(
     (raw?: string) => {
+      if (cancelledRef.current) return;
       const source = raw !== undefined ? raw : draft;
       const committed = transformCommit ? transformCommit(source) : source;
       onCommit(committed);
@@ -98,6 +104,7 @@ export function useDraftState({
       if (e.key === 'Enter') {
         commit();
       } else if (e.key === 'Escape') {
+        cancelledRef.current = true;
         onCancel();
       }
     },
@@ -106,6 +113,7 @@ export function useDraftState({
 
   /** Commits the current draft when the input loses focus. */
   const handleBlur = useCallback(() => {
+    if (cancelledRef.current) return;
     commit();
   }, [commit]);
 

--- a/packages/react/src/use-keyboard.ts
+++ b/packages/react/src/use-keyboard.ts
@@ -105,12 +105,34 @@ export function useKeyboard<TData extends Record<string, unknown>>(
         }
         break;
       }
-      // --- Escape: cancel edit or clear selection ---
+      // --- Escape: cancel edit (keeps selection), or clear selection when idle ---
+      //
+      // Issue #11: Pressing Esc in edit mode must revert the cell value and
+      // keep the original cell selected. Because cell editors (e.g. TextCell)
+      // handle Escape at the input level first — calling `model.cancelEdit()`
+      // synchronously — by the time this native bubble-phase listener runs,
+      // `editing.cell` is already null. Without the `isEditor` guard below,
+      // the `else` branch would then wipe the selection.
+      //
+      // The event target tells us whether Esc was pressed inside an editor
+      // input/textarea: if so, the cell already cancelled the edit and we
+      // must preserve the selection. Otherwise (Esc pressed while the grid
+      // has focus and no edit is active), we keep the existing
+      // clear-selection behaviour.
       case 'Escape': {
         if (editing.cell) {
           model.cancelEdit();
+          e.preventDefault();
+          e.stopPropagation();
         } else {
-          model.clearSelectionState();
+          const target = e.target as HTMLElement | null;
+          const isEditor =
+            target instanceof HTMLInputElement ||
+            target instanceof HTMLTextAreaElement ||
+            (target != null && target.isContentEditable);
+          if (!isEditor) {
+            model.clearSelectionState();
+          }
         }
         break;
       }

--- a/stories/Editing.stories.tsx
+++ b/stories/Editing.stories.tsx
@@ -83,6 +83,38 @@ export const WithValidation: StoryObj = {
   },
 };
 
+export const EscapeCancelsAndKeepsSelection: StoryObj = {
+  render: () => {
+    const [log, setLog] = useState<string[]>([]);
+    return (
+      <div style={storyContainer}>
+        <h2 style={styles.heading}>Escape Cancels Edit and Keeps Selection</h2>
+        <p style={styles.subtitle}>
+          Click a cell to select it, press <kbd>F2</kbd> or double-click to edit,
+          type a new value, then press <kbd>Escape</kbd>. The original value is
+          preserved and the cell remains selected (issue #11). The onCellEdit
+          log below should stay empty after Escape.
+        </p>
+        <div style={gridContainer}>
+          <MuiDataGrid
+            data={makeEmployees(8)}
+            columns={defaultColumns as any}
+            rowKey="id"
+            selectionMode="cell"
+            keyboardNavigation
+            onCellEdit={(rowId, field, value, prev) =>
+              setLog((p) => [...p.slice(-6), `[${rowId}].${field}: ${String(prev)} -> ${String(value)}`])
+            }
+          />
+        </div>
+        <pre style={styles.logPre}>
+          {log.length ? log.join('\n') : '(no commits — press Escape to cancel edits)'}
+        </pre>
+      </div>
+    );
+  },
+};
+
 export const UndoRedo: StoryObj = {
   render: () => (
     <div style={storyContainer}>


### PR DESCRIPTION
## Summary

- Esc while editing now reliably reverts the in-progress draft, exits edit mode, and preserves the original cell's selection.
- The grid-level keyboard handler (`use-keyboard.ts`) no longer wipes selection when Esc bubbles up from a cell editor — it inspects `e.target` to detect when the cancel originated inside an input/textarea.
- Each text-based cell editor (`TextCell`, `NumericCell`, `CurrencyCell`, `PasswordCell`, the inline fallback `<input>` in `DataGridBody`, and the shared `useDraftState` hook) now tracks an Esc-triggered cancel via a local ref so the trailing `blur` event fired on unmount does NOT silently commit the draft.

Closes #11

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test` (1483 tests, 2 new)
- [x] New `DataGrid.test.tsx` cases: after type + Esc, value is reverted, edit mode is exited, and the cell retains its selection outline — both for the cell-level handler path and the native-bubble-to-grid path
- [x] Pre-existing Esc-clears-selection-when-idle test still passes
- [x] Enter/Tab commit logic untouched (owned by issue #10)