### PR TITLE
feat(stories): per-component MUI showcase (Telerik-style)

### DIFF
--- a/stories/MuiComponents/Accordion.stories.tsx
+++ b/stories/MuiComponents/Accordion.stories.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import Accordion from '@mui/material/Accordion';
+import AccordionSummary from '@mui/material/AccordionSummary';
+import AccordionDetails from '@mui/material/AccordionDetails';
+import Chip from '@mui/material/Chip';
+import Box from '@mui/material/Box';
+
+const meta: Meta<typeof Accordion> = {
+  title: 'MUI Components/Surfaces/Accordion',
+  component: Accordion,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Accordion, AccordionSummary, and AccordionDetails power the collapsible sub-grid cell in xldatagrid (MuiSubGridCell).',
+      },
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof Accordion>;
+
+export const Default: Story = {
+  render: () => (
+    <div style={{ padding: 16, width: 360 }}>
+      <Accordion>
+        <AccordionSummary>Summary</AccordionSummary>
+        <AccordionDetails>Expanded details go here.</AccordionDetails>
+      </Accordion>
+    </div>
+  ),
+};
+
+export const DefaultExpanded: Story = {
+  render: () => (
+    <div style={{ padding: 16, width: 360 }}>
+      <Accordion defaultExpanded>
+        <AccordionSummary>Already open</AccordionSummary>
+        <AccordionDetails>Renders expanded on mount.</AccordionDetails>
+      </Accordion>
+    </div>
+  ),
+};
+
+export const WithChipSummary: Story = {
+  render: () => (
+    <div style={{ padding: 16, width: 420 }}>
+      <Accordion>
+        <AccordionSummary>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <span>Sub-items</span>
+            <Chip label="3" size="small" />
+          </Box>
+        </AccordionSummary>
+        <AccordionDetails>
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+            <div>Row A</div>
+            <div>Row B</div>
+            <div>Row C</div>
+          </Box>
+        </AccordionDetails>
+      </Accordion>
+    </div>
+  ),
+};
+
+export const Disabled: Story = {
+  render: () => (
+    <div style={{ padding: 16, width: 360 }}>
+      <Accordion disabled>
+        <AccordionSummary>Disabled</AccordionSummary>
+        <AccordionDetails>Cannot expand.</AccordionDetails>
+      </Accordion>
+    </div>
+  ),
+};

--- a/stories/MuiComponents/Autocomplete.stories.tsx
+++ b/stories/MuiComponents/Autocomplete.stories.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import Autocomplete from '@mui/material/Autocomplete';
+import TextField from '@mui/material/TextField';
+
+const options = ['Apple', 'Banana', 'Cherry', 'Durian', 'Elderberry', 'Fig'];
+
+const meta: Meta<typeof Autocomplete> = {
+  title: 'MUI Components/Inputs/Autocomplete',
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Autocomplete drives the multi-value editors in xldatagrid (MuiTagsCell, MuiChipSelectCell, EditableAutocomplete) — used with multiple and freeSolo to capture chip lists.',
+      },
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj;
+
+export const Default: Story = {
+  render: () => (
+    <div style={{ padding: 16, width: 320 }}>
+      <Autocomplete
+        options={options}
+        renderInput={(params) => <TextField {...params} label="Fruit" size="small" />}
+      />
+    </div>
+  ),
+};
+
+export const Multiple: Story = {
+  render: () => (
+    <div style={{ padding: 16, width: 360 }}>
+      <Autocomplete
+        multiple
+        options={options}
+        defaultValue={['Apple', 'Banana']}
+        renderInput={(params) => <TextField {...params} label="Fruits" size="small" />}
+      />
+    </div>
+  ),
+};
+
+export const FreeSolo: Story = {
+  render: () => (
+    <div style={{ padding: 16, width: 360 }}>
+      <Autocomplete
+        multiple
+        freeSolo
+        options={options}
+        defaultValue={['Custom tag', 'Apple']}
+        renderInput={(params) => <TextField {...params} label="Tags" size="small" />}
+      />
+    </div>
+  ),
+};
+
+export const Disabled: Story = {
+  render: () => (
+    <div style={{ padding: 16, width: 320 }}>
+      <Autocomplete
+        disabled
+        options={options}
+        defaultValue="Apple"
+        renderInput={(params) => <TextField {...params} label="Fruit (disabled)" size="small" />}
+      />
+    </div>
+  ),
+};

--- a/stories/MuiComponents/Box.stories.tsx
+++ b/stories/MuiComponents/Box.stories.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import Box from '@mui/material/Box';
+import Chip from '@mui/material/Chip';
+
+const meta: Meta<typeof Box> = {
+  title: 'MUI Components/Layout/Box',
+  component: Box,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Box is the generic layout primitive xldatagrid cells use (via the `sx` prop) to arrange chips, controls, and inline content without writing CSS.',
+      },
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof Box>;
+
+export const Default: Story = {
+  render: () => (
+    <Box sx={{ p: 2, border: '1px solid', borderColor: 'divider', borderRadius: 1 }}>
+      Box content
+    </Box>
+  ),
+};
+
+export const FlexRow: Story = {
+  render: () => (
+    <Box sx={{ display: 'flex', gap: 1, p: 2 }}>
+      <Chip label="One" size="small" />
+      <Chip label="Two" size="small" />
+      <Chip label="Three" size="small" />
+    </Box>
+  ),
+};
+
+export const WrappingChipList: Story = {
+  render: () => (
+    <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, p: 2, maxWidth: 220 }}>
+      {['alpha', 'beta', 'gamma', 'delta', 'epsilon', 'zeta'].map((t) => (
+        <Chip key={t} label={t} size="small" />
+      ))}
+    </Box>
+  ),
+};
+
+export const WithSxStyles: Story = {
+  render: () => (
+    <Box
+      sx={{
+        p: 2,
+        bgcolor: 'background.paper',
+        color: 'text.primary',
+        border: '1px dashed',
+        borderColor: 'primary.main',
+        borderRadius: 1,
+        fontFamily: 'monospace',
+      }}
+    >
+      sx={'{ p: 2, bgcolor, border }'}
+    </Box>
+  ),
+};

--- a/stories/MuiComponents/Button.stories.tsx
+++ b/stories/MuiComponents/Button.stories.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import Button from '@mui/material/Button';
+
+const meta: Meta<typeof Button> = {
+  title: 'MUI Components/Buttons/Button',
+  component: Button,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Button is used by xldatagrid action cells (MuiActionsCell, MuiCompoundChipListCell, MuiUploadCell) — typically small with variant="outlined" or "contained".',
+      },
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof Button>;
+
+export const Default: Story = {
+  args: { children: 'Click me' },
+};
+
+export const Variants: Story = {
+  render: () => (
+    <div style={{ display: 'flex', gap: 8, padding: 16 }}>
+      <Button variant="text">Text</Button>
+      <Button variant="outlined">Outlined</Button>
+      <Button variant="contained">Contained</Button>
+    </div>
+  ),
+};
+
+export const Sizes: Story = {
+  render: () => (
+    <div style={{ display: 'flex', gap: 8, padding: 16, alignItems: 'center' }}>
+      <Button size="small" variant="contained">Small</Button>
+      <Button size="medium" variant="contained">Medium</Button>
+      <Button size="large" variant="contained">Large</Button>
+    </div>
+  ),
+};
+
+export const Colors: Story = {
+  render: () => (
+    <div style={{ display: 'flex', gap: 8, padding: 16 }}>
+      <Button variant="contained" color="primary">Primary</Button>
+      <Button variant="contained" color="secondary">Secondary</Button>
+      <Button variant="contained" color="success">Success</Button>
+      <Button variant="contained" color="error">Error</Button>
+    </div>
+  ),
+};
+
+export const Disabled: Story = {
+  render: () => (
+    <div style={{ display: 'flex', gap: 8, padding: 16 }}>
+      <Button variant="outlined" disabled>Outlined</Button>
+      <Button variant="contained" disabled>Contained</Button>
+    </div>
+  ),
+};

--- a/stories/MuiComponents/Checkbox.stories.tsx
+++ b/stories/MuiComponents/Checkbox.stories.tsx
@@ -1,0 +1,60 @@
+import React, { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import Checkbox from '@mui/material/Checkbox';
+
+const meta: Meta<typeof Checkbox> = {
+  title: 'MUI Components/Inputs/Checkbox',
+  component: Checkbox,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Checkbox is the boolean cell editor in xldatagrid (MuiBooleanCell). Typically rendered at size="small".',
+      },
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof Checkbox>;
+
+export const Default: Story = {
+  render: () => {
+    const [checked, setChecked] = useState(true);
+    return (
+      <div style={{ padding: 16 }}>
+        <Checkbox checked={checked} onChange={(_, v) => setChecked(v)} />
+      </div>
+    );
+  },
+};
+
+export const Sizes: Story = {
+  render: () => (
+    <div style={{ padding: 16, display: 'flex', gap: 8, alignItems: 'center' }}>
+      <Checkbox size="small" defaultChecked />
+      <Checkbox size="medium" defaultChecked />
+    </div>
+  ),
+};
+
+export const Colors: Story = {
+  render: () => (
+    <div style={{ padding: 16, display: 'flex', gap: 8, alignItems: 'center' }}>
+      <Checkbox defaultChecked color="primary" />
+      <Checkbox defaultChecked color="secondary" />
+      <Checkbox defaultChecked color="success" />
+      <Checkbox defaultChecked color="error" />
+    </div>
+  ),
+};
+
+export const States: Story = {
+  render: () => (
+    <div style={{ padding: 16, display: 'flex', gap: 8, alignItems: 'center' }}>
+      <Checkbox defaultChecked disabled />
+      <Checkbox disabled />
+      <Checkbox indeterminate />
+    </div>
+  ),
+};

--- a/stories/MuiComponents/Chip.stories.tsx
+++ b/stories/MuiComponents/Chip.stories.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import Chip from '@mui/material/Chip';
+import Box from '@mui/material/Box';
+
+const meta: Meta<typeof Chip> = {
+  title: 'MUI Components/Data Display/Chip',
+  component: Chip,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Chip displays tag-list values in xldatagrid (MuiTagsCell, MuiChipSelectCell, MuiCompoundChipListCell, MuiStatusCell, MuiSubGridCell). Usually size="small".',
+      },
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof Chip>;
+
+export const Default: Story = {
+  args: { label: 'Tag', size: 'small' },
+};
+
+export const Variants: Story = {
+  render: () => (
+    <div style={{ display: 'flex', gap: 8, padding: 16 }}>
+      <Chip label="Filled" size="small" variant="filled" />
+      <Chip label="Outlined" size="small" variant="outlined" />
+    </div>
+  ),
+};
+
+export const Colors: Story = {
+  render: () => (
+    <div style={{ display: 'flex', gap: 8, padding: 16, flexWrap: 'wrap' }}>
+      <Chip label="Draft" size="small" color="default" />
+      <Chip label="Active" size="small" color="primary" />
+      <Chip label="Success" size="small" color="success" />
+      <Chip label="Warning" size="small" color="warning" />
+      <Chip label="Error" size="small" color="error" />
+    </div>
+  ),
+};
+
+export const Deletable: Story = {
+  render: () => (
+    <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, p: 2 }}>
+      {['Apple', 'Banana', 'Cherry'].map((t) => (
+        <Chip key={t} label={t} size="small" onDelete={() => undefined} />
+      ))}
+    </Box>
+  ),
+};
+
+export const Clickable: Story = {
+  render: () => (
+    <div style={{ padding: 16 }}>
+      <Chip label="Click me" size="small" onClick={() => undefined} color="primary" />
+    </div>
+  ),
+};

--- a/stories/MuiComponents/IconButton.stories.tsx
+++ b/stories/MuiComponents/IconButton.stories.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import IconButton from '@mui/material/IconButton';
+import Undo from '@mui/icons-material/Undo';
+import Redo from '@mui/icons-material/Redo';
+import FilterList from '@mui/icons-material/FilterList';
+
+const meta: Meta<typeof IconButton> = {
+  title: 'MUI Components/Buttons/IconButton',
+  component: IconButton,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'IconButton wraps inline actions in xldatagrid cells (MuiActionsCell, MuiPasswordCell reveal toggle). Paired with @mui/icons-material glyphs.',
+      },
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof IconButton>;
+
+export const Default: Story = {
+  render: () => (
+    <div style={{ padding: 16 }}>
+      <IconButton aria-label="filter">
+        <FilterList />
+      </IconButton>
+    </div>
+  ),
+};
+
+export const Sizes: Story = {
+  render: () => (
+    <div style={{ display: 'flex', gap: 8, padding: 16, alignItems: 'center' }}>
+      <IconButton size="small" aria-label="small"><Undo fontSize="small" /></IconButton>
+      <IconButton size="medium" aria-label="medium"><Undo /></IconButton>
+      <IconButton size="large" aria-label="large"><Undo fontSize="large" /></IconButton>
+    </div>
+  ),
+};
+
+export const Colors: Story = {
+  render: () => (
+    <div style={{ display: 'flex', gap: 8, padding: 16 }}>
+      <IconButton color="primary" aria-label="primary"><Undo /></IconButton>
+      <IconButton color="secondary" aria-label="secondary"><Redo /></IconButton>
+      <IconButton color="error" aria-label="error"><FilterList /></IconButton>
+    </div>
+  ),
+};
+
+export const Disabled: Story = {
+  render: () => (
+    <div style={{ padding: 16 }}>
+      <IconButton disabled aria-label="disabled"><Undo /></IconButton>
+    </div>
+  ),
+};

--- a/stories/MuiComponents/InputAdornment.stories.tsx
+++ b/stories/MuiComponents/InputAdornment.stories.tsx
@@ -1,0 +1,75 @@
+import React, { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import InputAdornment from '@mui/material/InputAdornment';
+import TextField from '@mui/material/TextField';
+import IconButton from '@mui/material/IconButton';
+
+const meta: Meta<typeof InputAdornment> = {
+  title: 'MUI Components/Inputs/InputAdornment',
+  component: InputAdornment,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'InputAdornment renders prefix/suffix content inside inputs — used by xldatagrid for currency symbols (MuiCurrencyCell) and password reveal toggle (MuiPasswordCell).',
+      },
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof InputAdornment>;
+
+export const Start: Story = {
+  render: () => (
+    <div style={{ padding: 16 }}>
+      <TextField
+        size="small"
+        defaultValue="100.00"
+        slotProps={{
+          input: { startAdornment: <InputAdornment position="start">$</InputAdornment> },
+        }}
+      />
+    </div>
+  ),
+};
+
+export const End: Story = {
+  render: () => (
+    <div style={{ padding: 16 }}>
+      <TextField
+        size="small"
+        defaultValue="42"
+        slotProps={{
+          input: { endAdornment: <InputAdornment position="end">kg</InputAdornment> },
+        }}
+      />
+    </div>
+  ),
+};
+
+export const InteractiveEnd: Story = {
+  render: () => {
+    const [show, setShow] = useState(false);
+    return (
+      <div style={{ padding: 16 }}>
+        <TextField
+          size="small"
+          type={show ? 'text' : 'password'}
+          defaultValue="hunter2"
+          slotProps={{
+            input: {
+              endAdornment: (
+                <InputAdornment position="end">
+                  <IconButton size="small" onClick={() => setShow((s) => !s)} aria-label="toggle">
+                    {show ? 'Hide' : 'Show'}
+                  </IconButton>
+                </InputAdornment>
+              ),
+            },
+          }}
+        />
+      </div>
+    );
+  },
+};

--- a/stories/MuiComponents/LinearProgress.stories.tsx
+++ b/stories/MuiComponents/LinearProgress.stories.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import LinearProgress from '@mui/material/LinearProgress';
+
+const meta: Meta<typeof LinearProgress> = {
+  title: 'MUI Components/Feedback/LinearProgress',
+  component: LinearProgress,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'LinearProgress reports upload progress inside xldatagrid cells (MuiUploadCell) — used both indeterminate and with a numeric value.',
+      },
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof LinearProgress>;
+
+export const Indeterminate: Story = {
+  render: () => (
+    <div style={{ padding: 16, width: 240 }}>
+      <LinearProgress />
+    </div>
+  ),
+};
+
+export const Determinate: Story = {
+  render: () => (
+    <div style={{ padding: 16, width: 240 }}>
+      <LinearProgress variant="determinate" value={42} />
+    </div>
+  ),
+};
+
+export const Buffer: Story = {
+  render: () => (
+    <div style={{ padding: 16, width: 240 }}>
+      <LinearProgress variant="buffer" value={35} valueBuffer={55} />
+    </div>
+  ),
+};
+
+export const Colors: Story = {
+  render: () => (
+    <div style={{ padding: 16, width: 240, display: 'grid', gap: 8 }}>
+      <LinearProgress color="primary" />
+      <LinearProgress color="secondary" />
+      <LinearProgress color="success" variant="determinate" value={80} />
+      <LinearProgress color="error" variant="determinate" value={20} />
+    </div>
+  ),
+};

--- a/stories/MuiComponents/MenuItem.stories.tsx
+++ b/stories/MuiComponents/MenuItem.stories.tsx
@@ -1,0 +1,65 @@
+import React, { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import MenuItem from '@mui/material/MenuItem';
+import MenuList from '@mui/material/MenuList';
+import Paper from '@mui/material/Paper';
+import Select from '@mui/material/Select';
+
+const meta: Meta<typeof MenuItem> = {
+  title: 'MUI Components/Inputs/MenuItem',
+  component: MenuItem,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'MenuItem populates Select dropdowns and menu lists in xldatagrid (MuiStatusCell, MuiListCell).',
+      },
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof MenuItem>;
+
+export const InSelect: Story = {
+  render: () => {
+    const [value, setValue] = useState('Banana');
+    return (
+      <div style={{ padding: 16, width: 220 }}>
+        <Select size="small" value={value} onChange={(e) => setValue(String(e.target.value))} fullWidth>
+          <MenuItem value="Apple">Apple</MenuItem>
+          <MenuItem value="Banana">Banana</MenuItem>
+          <MenuItem value="Cherry">Cherry</MenuItem>
+        </Select>
+      </div>
+    );
+  },
+};
+
+export const Standalone: Story = {
+  render: () => (
+    <div style={{ padding: 16 }}>
+      <Paper sx={{ width: 220 }}>
+        <MenuList>
+          <MenuItem>Draft</MenuItem>
+          <MenuItem selected>Active</MenuItem>
+          <MenuItem disabled>Archived</MenuItem>
+        </MenuList>
+      </Paper>
+    </div>
+  ),
+};
+
+export const Dense: Story = {
+  render: () => (
+    <div style={{ padding: 16 }}>
+      <Paper sx={{ width: 220 }}>
+        <MenuList dense>
+          <MenuItem dense>Cell</MenuItem>
+          <MenuItem dense>Row</MenuItem>
+          <MenuItem dense>Range</MenuItem>
+        </MenuList>
+      </Paper>
+    </div>
+  ),
+};

--- a/stories/MuiComponents/Overview.stories.tsx
+++ b/stories/MuiComponents/Overview.stories.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import * as styles from '../stories.styles';
+
+const meta: Meta = {
+  title: 'MUI Components/Overview',
+};
+export default meta;
+
+const components: [string, string, string][] = [
+  ['TextField', 'Inputs', 'Text/numeric/currency/password editable cells'],
+  ['Autocomplete', 'Inputs', 'Tag & chip-select editors (multi, freeSolo)'],
+  ['Select', 'Inputs', 'Status/list dropdown editors'],
+  ['MenuItem', 'Inputs', 'Option rows for Select'],
+  ['Checkbox', 'Inputs', 'Boolean cell editor'],
+  ['InputAdornment', 'Inputs', 'Currency symbol, password reveal toggle'],
+  ['Button', 'Buttons', 'Action cells, upload trigger'],
+  ['IconButton', 'Buttons', 'Inline row actions, reveal toggle'],
+  ['Typography', 'Data Display', 'Read-only display for numeric/currency/date cells'],
+  ['Chip', 'Data Display', 'Tags, chip-select, status, sub-grid summaries'],
+  ['Tooltip', 'Data Display', 'Action-cell icon labels'],
+  ['LinearProgress', 'Feedback', 'Upload progress indicator'],
+  ['Box', 'Layout', 'Flex/wrap layout primitive via sx prop'],
+  ['Accordion', 'Surfaces', 'Sub-grid collapsible cell'],
+];
+
+export const Index: StoryObj = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Telerik-style per-component showcase of every MUI component consumed by @istracked/datagrid-mui. Pick a component from the sidebar to see its variants.',
+      },
+    },
+  },
+  render: () => (
+    <div style={styles.introWrapper}>
+      <h1 style={styles.introTitle}>MUI Components</h1>
+      <p style={styles.introSubtitle}>
+        One showcase page per MUI primitive that xldatagrid depends on. Grouped by MUI&apos;s
+        own category taxonomy (Inputs, Buttons, Data Display, Feedback, Layout, Surfaces).
+      </p>
+      <table style={styles.introTable}>
+        <thead>
+          <tr>
+            <th style={styles.introTh}>Component</th>
+            <th style={styles.introTh}>Category</th>
+            <th style={styles.introTh}>Where xldatagrid uses it</th>
+          </tr>
+        </thead>
+        <tbody>
+          {components.map(([name, category, usage]) => (
+            <tr key={name}>
+              <td style={styles.introTd}><strong>{name}</strong></td>
+              <td style={styles.introTd}>{category}</td>
+              <td style={styles.introTd}>{usage}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  ),
+};

--- a/stories/MuiComponents/Select.stories.tsx
+++ b/stories/MuiComponents/Select.stories.tsx
@@ -1,0 +1,121 @@
+import React, { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import Select from '@mui/material/Select';
+import MenuItem from '@mui/material/MenuItem';
+import FormControl from '@mui/material/FormControl';
+import InputLabel from '@mui/material/InputLabel';
+
+const meta: Meta<typeof Select> = {
+  title: 'MUI Components/Inputs/Select',
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Select backs the dropdown editors in xldatagrid (MuiStatusCell, MuiListCell, EditableSelect) — usually with size="small" and native MenuItems.',
+      },
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj;
+
+const statuses = ['Draft', 'Active', 'Archived'];
+
+export const Default: Story = {
+  render: () => {
+    const [value, setValue] = useState('Active');
+    return (
+      <div style={{ padding: 16, width: 220 }}>
+        <FormControl fullWidth size="small">
+          <InputLabel>Status</InputLabel>
+          <Select label="Status" value={value} onChange={(e) => setValue(String(e.target.value))}>
+            {statuses.map((s) => (
+              <MenuItem key={s} value={s}>
+                {s}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+      </div>
+    );
+  },
+};
+
+export const Sizes: Story = {
+  render: () => (
+    <div style={{ display: 'flex', gap: 12, padding: 16 }}>
+      <FormControl size="small" sx={{ minWidth: 140 }}>
+        <InputLabel>Small</InputLabel>
+        <Select label="Small" defaultValue="Active">
+          {statuses.map((s) => (
+            <MenuItem key={s} value={s}>
+              {s}
+            </MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+      <FormControl size="medium" sx={{ minWidth: 140 }}>
+        <InputLabel>Medium</InputLabel>
+        <Select label="Medium" defaultValue="Active">
+          {statuses.map((s) => (
+            <MenuItem key={s} value={s}>
+              {s}
+            </MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+    </div>
+  ),
+};
+
+export const Standard: Story = {
+  render: () => (
+    <div style={{ padding: 16, width: 220 }}>
+      <FormControl variant="standard" fullWidth>
+        <InputLabel>Standard</InputLabel>
+        <Select label="Standard" defaultValue="Draft">
+          {statuses.map((s) => (
+            <MenuItem key={s} value={s}>
+              {s}
+            </MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+    </div>
+  ),
+};
+
+export const Disabled: Story = {
+  render: () => (
+    <div style={{ padding: 16, width: 220 }}>
+      <FormControl fullWidth size="small" disabled>
+        <InputLabel>Disabled</InputLabel>
+        <Select label="Disabled" defaultValue="Active">
+          {statuses.map((s) => (
+            <MenuItem key={s} value={s}>
+              {s}
+            </MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+    </div>
+  ),
+};
+
+export const Error: Story = {
+  render: () => (
+    <div style={{ padding: 16, width: 220 }}>
+      <FormControl fullWidth size="small" error>
+        <InputLabel>Status</InputLabel>
+        <Select label="Status" defaultValue="">
+          {statuses.map((s) => (
+            <MenuItem key={s} value={s}>
+              {s}
+            </MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+    </div>
+  ),
+};

--- a/stories/MuiComponents/TextField.stories.tsx
+++ b/stories/MuiComponents/TextField.stories.tsx
@@ -1,0 +1,74 @@
+import React, { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import TextField from '@mui/material/TextField';
+import InputAdornment from '@mui/material/InputAdornment';
+
+const meta: Meta<typeof TextField> = {
+  title: 'MUI Components/Inputs/TextField',
+  component: TextField,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'TextField is the primary text-input surface used by xldatagrid editable cells (MuiTextCell, MuiNumericCell, MuiCurrencyCell, MuiPasswordCell, EditableTextField).',
+      },
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof TextField>;
+
+export const Default: Story = {
+  args: { label: 'Label', placeholder: 'Type here' },
+};
+
+export const Sizes: Story = {
+  render: () => (
+    <div style={{ display: 'flex', gap: 12, padding: 16 }}>
+      <TextField size="small" label="Small" defaultValue="small" />
+      <TextField size="medium" label="Medium" defaultValue="medium" />
+    </div>
+  ),
+};
+
+export const Variants: Story = {
+  render: () => (
+    <div style={{ display: 'flex', gap: 12, padding: 16 }}>
+      <TextField variant="outlined" label="Outlined" defaultValue="outlined" />
+      <TextField variant="filled" label="Filled" defaultValue="filled" />
+      <TextField variant="standard" label="Standard" defaultValue="standard" />
+    </div>
+  ),
+};
+
+export const States: Story = {
+  render: () => (
+    <div style={{ display: 'flex', gap: 12, padding: 16 }}>
+      <TextField label="Disabled" defaultValue="can't edit" disabled />
+      <TextField label="Error" defaultValue="bad" error helperText="Invalid value" />
+      <TextField label="Required" defaultValue="" required helperText="Required field" />
+    </div>
+  ),
+};
+
+export const WithAdornment: Story = {
+  render: () => {
+    const [value, setValue] = useState('100.00');
+    return (
+      <div style={{ padding: 16 }}>
+        <TextField
+          label="Currency"
+          size="small"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          slotProps={{
+            input: {
+              startAdornment: <InputAdornment position="start">$</InputAdornment>,
+            },
+          }}
+        />
+      </div>
+    );
+  },
+};

--- a/stories/MuiComponents/Tooltip.stories.tsx
+++ b/stories/MuiComponents/Tooltip.stories.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import Tooltip from '@mui/material/Tooltip';
+import IconButton from '@mui/material/IconButton';
+import Button from '@mui/material/Button';
+import Undo from '@mui/icons-material/Undo';
+
+const meta: Meta<typeof Tooltip> = {
+  title: 'MUI Components/Data Display/Tooltip',
+  component: Tooltip,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Tooltip labels inline icon controls in xldatagrid (MuiActionsCell). Always attach to a focusable child for accessibility.',
+      },
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof Tooltip>;
+
+export const Default: Story = {
+  render: () => (
+    <div style={{ padding: 32 }}>
+      <Tooltip title="Undo last change">
+        <IconButton aria-label="undo"><Undo /></IconButton>
+      </Tooltip>
+    </div>
+  ),
+};
+
+export const Placements: Story = {
+  render: () => (
+    <div style={{ display: 'flex', gap: 24, padding: 48 }}>
+      <Tooltip title="Top" placement="top"><Button variant="outlined">Top</Button></Tooltip>
+      <Tooltip title="Right" placement="right"><Button variant="outlined">Right</Button></Tooltip>
+      <Tooltip title="Bottom" placement="bottom"><Button variant="outlined">Bottom</Button></Tooltip>
+      <Tooltip title="Left" placement="left"><Button variant="outlined">Left</Button></Tooltip>
+    </div>
+  ),
+};
+
+export const Arrow: Story = {
+  render: () => (
+    <div style={{ padding: 32 }}>
+      <Tooltip title="With arrow" arrow>
+        <Button variant="outlined">Hover me</Button>
+      </Tooltip>
+    </div>
+  ),
+};
+
+export const DisabledChildWrapper: Story = {
+  render: () => (
+    <div style={{ padding: 32 }}>
+      <Tooltip title="Disabled buttons need a wrapping span">
+        <span>
+          <Button variant="contained" disabled>Disabled</Button>
+        </span>
+      </Tooltip>
+    </div>
+  ),
+};

--- a/stories/MuiComponents/Typography.stories.tsx
+++ b/stories/MuiComponents/Typography.stories.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import Typography from '@mui/material/Typography';
+
+const meta: Meta<typeof Typography> = {
+  title: 'MUI Components/Data Display/Typography',
+  component: Typography,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Typography renders read-only cell values in xldatagrid (DisplayTypography wrapper used by MuiNumericCell, MuiCurrencyCell, MuiCalendarCell, MuiUploadCell).',
+      },
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof Typography>;
+
+export const Default: Story = {
+  args: { children: 'The quick brown fox jumps over the lazy dog.' },
+};
+
+export const Variants: Story = {
+  render: () => (
+    <div style={{ padding: 16, display: 'grid', gap: 4 }}>
+      <Typography variant="h5">Heading 5</Typography>
+      <Typography variant="subtitle1">Subtitle 1</Typography>
+      <Typography variant="body1">Body 1 — standard paragraph text.</Typography>
+      <Typography variant="body2">Body 2 — secondary text.</Typography>
+      <Typography variant="caption">Caption</Typography>
+    </div>
+  ),
+};
+
+export const Colors: Story = {
+  render: () => (
+    <div style={{ padding: 16, display: 'grid', gap: 4 }}>
+      <Typography color="primary">Primary text</Typography>
+      <Typography color="text.secondary">Secondary text</Typography>
+      <Typography color="error">Error text</Typography>
+      <Typography color="success.main">Success text</Typography>
+    </div>
+  ),
+};
+
+export const Truncated: Story = {
+  render: () => (
+    <div style={{ padding: 16, width: 240 }}>
+      <Typography noWrap>
+        A very long single-line value that must be truncated with ellipsis inside a narrow grid cell.
+      </Typography>
+    </div>
+  ),
+};
+
+export const Monospace: Story = {
+  render: () => (
+    <div style={{ padding: 16 }}>
+      <Typography variant="body2" sx={{ fontFamily: 'monospace' }}>
+        $ 1,234.56
+      </Typography>
+    </div>
+  ),
+};


### PR DESCRIPTION
## Summary

- Adds a new Storybook section under **MUI Components/** with one `.stories.tsx` per MUI primitive consumed by `packages/mui`.
- Each story is grouped by MUI's own category (Inputs, Buttons, Data Display, Feedback, Layout, Surfaces) and covers the variants/props xldatagrid actually uses.
- Includes an **Overview** index page mapping each component to its xldatagrid consumer (e.g. `MuiTagsCell`, `MuiStatusCell`).

## Components covered (14)

- **Inputs**: TextField, Autocomplete, Select, MenuItem, Checkbox, InputAdornment
- **Buttons**: Button, IconButton
- **Data Display**: Typography, Chip, Tooltip
- **Feedback**: LinearProgress
- **Layout**: Box
- **Surfaces**: Accordion (+ AccordionSummary / AccordionDetails)

This matches the full inventory of `@mui/material` components imported under `packages/mui/src`. No follow-ups needed for missing components.

## Test plan

- [x] `pnpm build-storybook` succeeds — 14 new story files compile cleanly.
- [x] `pnpm test` — 1481/1481 pass.
- [x] `pnpm typecheck` — clean.
- [ ] `pnpm test:storybook` — not run: pre-existing environment issue (esbuild chokes on the space in `/Volumes/MacIntosh HD 1/...`). Unrelated to this PR.
- [ ] Manual spot-check: open Storybook sidebar, confirm each component page renders a default plus 2–5 variant stories.

## Out of scope

- No refactors to any existing MUI consumer code — stories only.
- No new docs pages beyond the per-component showcase and its Overview.

## Playwright coverage

- None (Storybook-only feature)

---
**Closes**: #19