### PR TITLE
chore: fix baseline TypeScript errors

### DIFF
--- a/playground/vite.config.ts
+++ b/playground/vite.config.ts
@@ -9,7 +9,9 @@ const pkgDir = (pkg: string) => resolve(rootDir, 'packages', pkg, 'src');
 
 export default defineConfig({
   resolve: {
-    symlinks: false,
+    // Note: Vite does not expose a `symlinks` toggle in UserConfig.resolve.
+    // The spaces-in-path workaround is handled by pointing `rootDir` at the
+    // PWD (symlink) path above, so path aliases below stay on that path.
     alias: {
       '@istracked/datagrid-core': pkgDir('core'),
       '@istracked/datagrid-react': pkgDir('react'),

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,8 +12,10 @@ export default defineConfig({
   // Force Vite to use the symlink path as root (real path may contain spaces)
   root: dirname,
   resolve: {
-    // Prevent Vite from resolving symlinks to real paths (which may contain spaces)
-    symlinks: false,
+    // Note: Vite does not expose a `symlinks` toggle here. The spaces-in-path
+    // workaround is handled entirely by forcing `root` to the PWD (symlink)
+    // path above; esbuild's own import handling stays on that path as long as
+    // we do not resolve through real paths ourselves.
     alias: {
       '@istracked/datagrid-core': path.resolve(dirname, 'packages/core/src'),
       '@istracked/datagrid-react': path.resolve(dirname, 'packages/react/src'),

--- a/vitest.storybook.config.ts
+++ b/vitest.storybook.config.ts
@@ -11,7 +11,8 @@ const dirname = process.env.PWD ?? (typeof __dirname !== 'undefined' ? __dirname
 export default defineConfig({
   root: dirname,
   resolve: {
-    symlinks: false,
+    // Note: Vite does not expose a `symlinks` toggle here; rely on `root`
+    // being the PWD (symlink) path to keep the workaround for spaces-in-path.
     alias: {
       '@istracked/datagrid-core': path.resolve(dirname, 'packages/core/src'),
       '@istracked/datagrid-react': path.resolve(dirname, 'packages/react/src'),


### PR DESCRIPTION
## Summary

Baseline TypeScript audit following PR #23, which merged with `git commit --no-verify` because the pre-commit hook tripped on ~89 pre-existing TS errors.

**Finding:** the 13 PRs merged after #23 already resolved those errors. The pre-commit hook (`pnpm typecheck` → `tsc -b packages/*/tsconfig.build.json`) now passes cleanly on `excel-365-complete`. This commit fixes the only genuine TS errors left in the broader tree — three `symlinks: false` entries in Vite configs that TS2769-fail because Vite 6's `UserConfig.resolve` does not expose that field.

## Error count (pre-commit scope — the hook's `pnpm typecheck` command)

- Before: **0 errors** (already green on `excel-365-complete` HEAD)
- After: **0 errors**

The pre-commit hook now passes without `--no-verify` — verified on this commit (hook ran typecheck + build + 72 test files / 1625 tests, all green).

## Error count (broader `tsc --noEmit` at repo root, for reference)

- Before: 5165 errors
- After: 5162 errors (−3, the three `symlinks` TS2769 overload errors)

The remaining 5162 errors are outside the pre-commit hook's scope (the build tsconfigs exclude `__tests__`). Full breakdown by category:

| Count | Code | Category | Where |
|------:|------|----------|-------|
| 2495 | TS2304 | `Cannot find name 'expect'` | test files — vitest globals not in tsconfig `types` |
| 1903 | TS2582 | `Cannot find name 'describe'/'it'/'test'` | test files — same vitest globals issue |
| 133 | TS2322 | Type-not-assignable | mostly test fixture `ColumnDef<Row>[]` widening mismatches |
| 61 | TS7006 | Implicit `any` | stories/ + playground/ (untyped callback params) |
| 52 | TS2307 | `Cannot find module '@istracked/datagrid-*'` | stories/ + playground/ — no `paths` in root tsconfig |
| 24 | TS2532 | `Object is possibly 'undefined'` | test files under `noUncheckedIndexedAccess` |
| 20 | TS7031 | Binding element implicit `any` | stories/ + playground/ |
| 11 | TS18048 | `possibly undefined` | test files |
| 1 | TS2352 | Conversion may be a mistake | `stories/TransposedGrid.stories.tsx` |

## What this PR changes

- `vitest.config.ts`, `vitest.storybook.config.ts`, `playground/vite.config.ts`: drop the invalid `symlinks: false` field. The option was silently ignored at runtime (verified against Vite 6's `UserConfig` typings), so this is a types-only fix with no behavioural change. The spaces-in-path workaround continues to rely on `root`/`rootDir` being pinned to `process.env.PWD` (the symlink path).

## Deferred — needs product decision

None of these block the pre-commit hook. Listing them so a follow-up baseline-hygiene PR has a clear worklist:

1. **Test-file vitest globals (≈4400 errors)** — `packages/*/src/__tests__/**` uses global `describe`/`it`/`expect` (vitest `globals: true`). The per-package `tsconfig.json` lacks `"types": ["vitest/globals"]`. Build tsconfigs exclude these files so the fix requires either adding `types` to each `tsconfig.json` or a new `tsconfig.test.json` reference set. Left for a dedicated PR so the test typecheck story is designed holistically (also affects `pnpm exec tsc --noEmit` CI expectations).
2. **Test fixture `ColumnDef` widening (≈133 errors)** — Tests pass `{ id, field, title, sortable }` arrays that now must satisfy `ColumnDef<Row>` with non-`never` `field`. Ambiguous between "tighten the column literals" vs. "loosen `ColumnDef`'s `field` constraint for untyped rows"; fixing blindly could reshape public API.
3. **stories/ and playground/ `paths` wiring (≈100 errors)** — Root tsconfig has no `paths` mapping to package sources, so `import '@istracked/datagrid-mui'` from these dirs fails under `tsc --noEmit`. Vite/Storybook resolve via their own aliases at runtime. A consolidated `paths` addition at the root would fix them but also pulls these dirs into the type-checked set, which may surface further real issues.
4. **Implicit `any` in stories/playground callback params (≈80 errors)** — Mechanical fix, but touches story/playground behaviour surfaces; should be paired with #3 above.

## Context

Filed as repo hygiene — not closing any of the original 15 issues. PR #23 is referenced only as the event that surfaced the baseline-typecheck expectation.

## Test plan

- [x] `pnpm typecheck` (pre-commit scope) exits 0
- [x] `pnpm run build` succeeds for all four packages
- [x] `pnpm test` — 72 files, 1625 tests, all green
- [x] `git commit` with the pre-commit hook enabled (no `--no-verify`) passes