### PR TITLE
feat(types): add named-object overload for chrome resolvers

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -778,21 +778,28 @@ export interface ChromeColumnsConfig<TData = Record<string, unknown>> {
   /** Excel-style row number column with selection and reorder. Positioned via `RowNumberColumnConfig.position` (default: 'left'). */
   rowNumbers?: RowNumberColumnConfig | boolean;
   /**
-   * Per-row border resolver. Called once per rendered row with the row data,
-   * row id and zero-based row index. Return a {@link RowBorderStyle} object
-   * to paint a border around the row's container element, or `null`/`undefined`
-   * to inherit the default border.
+   * Per-row border resolver. Called once per rendered row.
+   *
+   * Two calling conventions are supported — pick whichever is more
+   * ergonomic for the consumer; the grid honours both:
+   *
+   *   * **Positional** (backward-compatible):
+   *     `(row, rowId, rowIndex) => RowBorderStyle | null | undefined`
+   *   * **Named-object** (self-documenting, extensible):
+   *     `({ row, rowId, rowIndex, column? }) => RowBorderStyle | null | undefined`
+   *
+   * The grid dispatches between the two forms by inspecting the declared
+   * arity (`fn.length`) — a one-argument resolver receives the named-object
+   * context, a three-argument resolver receives the positional args. See
+   * {@link ChromeRowResolver} for the full type and
+   * {@link ChromeRowResolverContext} for the context shape.
    *
    * The returned border is applied to the row container itself (all four
    * sides by default; see {@link RowBorderStyle.sides}). It composes with
    * chrome column styles — the chrome gutter's own left/right borders are
    * preserved.
    */
-  getRowBorder?: (
-    row: TData,
-    rowId: string,
-    rowIndex: number,
-  ) => RowBorderStyle | null | undefined;
+  getRowBorder?: ChromeRowResolver<TData, RowBorderStyle | null | undefined>;
   /**
    * Per-row background colour resolver. Called once per rendered row; the
    * returned string is applied as the row container's `background` CSS
@@ -800,12 +807,10 @@ export interface ChromeColumnsConfig<TData = Record<string, unknown>> {
    * CSS-legal colour value is accepted (HEX is preferred for determinism,
    * but `rgba(…)` / named colours also work). Return `null`/`undefined` to
    * fall back to the default row background token.
+   *
+   * Accepts either calling convention — see {@link ChromeRowResolver}.
    */
-  getRowBackground?: (
-    row: TData,
-    rowId: string,
-    rowIndex: number,
-  ) => string | null | undefined;
+  getRowBackground?: ChromeRowResolver<TData, string | null | undefined>;
   /**
    * Per-row chrome-cell content resolver. When provided and the row-number
    * chrome column is enabled, the returned {@link ChromeCellContent} replaces
@@ -817,13 +822,72 @@ export interface ChromeColumnsConfig<TData = Record<string, unknown>> {
    *
    * Returning `null`/`undefined` preserves the default row-number rendering
    * for that row.
+   *
+   * Accepts either calling convention — see {@link ChromeRowResolver}.
    */
-  getChromeCellContent?: (
-    row: TData,
-    rowId: string,
-    rowIndex: number,
-  ) => ChromeCellContent | null | undefined;
+  getChromeCellContent?: ChromeRowResolver<TData, ChromeCellContent | null | undefined>;
 }
+
+/**
+ * Context object passed to the named-object form of a {@link ChromeRowResolver}.
+ *
+ * Consumers that prefer a self-documenting call shape (and access to the
+ * optional `column` reference the row belongs to) opt in by declaring their
+ * resolver with a single object parameter, e.g.
+ *
+ *     chrome: {
+ *       getRowBackground: ({ row, rowIndex }) =>
+ *         rowIndex % 2 === 0 ? '#fafafa' : null,
+ *     }
+ *
+ * The grid's body renderer inspects the resolver's declared arity
+ * (`fn.length === 1`) to dispatch between the positional and named-object
+ * forms.
+ *
+ * `column` is populated only for cell-level invocations (not currently a
+ * public surface but reserved for the future per-cell chrome hooks).
+ * Row-level callers may leave it `undefined`.
+ *
+ * @typeParam TData - The shape of a data row.
+ */
+export interface ChromeRowResolverContext<TData = Record<string, unknown>> {
+  /** The row data at this index. */
+  row: TData;
+  /** The row's stable id (as derived from {@link GridConfig.rowKey}). */
+  rowId: string;
+  /** Zero-based row index within the current (processed) data array. */
+  rowIndex: number;
+  /**
+   * Optional column reference. Populated when the resolver is invoked at
+   * the cell level; left `undefined` for row-level invocations such as
+   * {@link ChromeColumnsConfig.getRowBorder} and
+   * {@link ChromeColumnsConfig.getRowBackground}.
+   */
+  column?: ColumnDef<TData>;
+}
+
+/**
+ * Row-level chrome resolver with two backward-compatible calling conventions.
+ *
+ * The original signature was positional — `(row, rowId, rowIndex) => TResult`
+ * — and remains the grid's wire-format. A consumer who prefers the
+ * self-documenting named-object form may instead declare their resolver as
+ * `(ctx: ChromeRowResolverContext<TData>) => TResult`; the grid's body
+ * renderer detects the form at call time via `fn.length === 1` (the
+ * resolver's declared arity) and dispatches accordingly.
+ *
+ * Untyped / spread-argument callers (`(...args) => …`, whose `.length`
+ * is `0`) fall back to the positional form so no historical consumer
+ * regresses. This is the documented trade-off of arity-based dispatch.
+ *
+ * @typeParam TData    - The shape of a data row.
+ * @typeParam TResult  - The resolver's return type (e.g.
+ *                       `string | null | undefined` for a background
+ *                       colour resolver).
+ */
+export type ChromeRowResolver<TData, TResult> =
+  | ((row: TData, rowId: string, rowIndex: number) => TResult)
+  | ((ctx: ChromeRowResolverContext<TData>) => TResult);
 
 /**
  * Per-row border style returned by {@link ChromeColumnsConfig.getRowBorder}.

--- a/packages/react/src/__tests__/chrome-resolver-object-overload.test.tsx
+++ b/packages/react/src/__tests__/chrome-resolver-object-overload.test.tsx
@@ -1,0 +1,376 @@
+/**
+ * Tests for the chrome-resolver named-object overload (PR5).
+ *
+ * The grid accepts two calling conventions for every chrome row-level
+ * presentation resolver (`getRowBorder`, `getRowBackground`,
+ * `getChromeCellContent`) — see {@link ChromeRowResolver}:
+ *
+ *   * Positional (backward-compatible, historical wire format):
+ *     `(row, rowId, rowIndex) => TResult`
+ *   * Named-object (self-documenting, extensible):
+ *     `({ row, rowId, rowIndex, column? }) => TResult`
+ *
+ * The grid dispatches at runtime via `fn.length` (the resolver's declared
+ * arity). These tests lock in:
+ *
+ *   1. The named-object form produces the same observable effect as the
+ *      positional form for every resolver slot.
+ *   2. The positional form keeps working unchanged (backward compatibility).
+ *   3. Call-argument shape: when invoked by the grid, the named-object form
+ *      receives `{ row, rowId, rowIndex }` with correct field values.
+ *   4. Type-level narrowing: a named-object resolver typed against a
+ *      concrete `TData` narrows `ctx.row` to that row shape.
+ *
+ * Compile-only assertions live alongside the runtime specs so a regression
+ * in the overload types is caught at the same place the runtime contract
+ * lives.
+ */
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import type {
+  ChromeColumnsConfig,
+  ChromeRowResolverContext,
+  RowBorderStyle,
+  ChromeCellContent,
+  ColumnDef,
+} from '@istracked/datagrid-core';
+import { DataGrid } from '../DataGrid';
+
+type TestRow = { id: string; name: string; value: number };
+
+function makeData(count = 3): TestRow[] {
+  return Array.from({ length: count }, (_, i) => ({
+    id: String(i + 1),
+    name: `Row ${i + 1}`,
+    value: i,
+  }));
+}
+
+const columns = [
+  { id: 'name', field: 'name', title: 'Name' },
+  { id: 'value', field: 'value', title: 'Value' },
+];
+
+// ────────────────────────────────────────────────────────────────────────────
+// Compile-time assertions — the overload types must accept both call shapes
+// with full narrowing of `row`.
+// ────────────────────────────────────────────────────────────────────────────
+
+type _CtxForRow = ChromeRowResolverContext<TestRow>;
+
+// Named-object resolver typed against a concrete row; `ctx.row` narrows.
+const _namedBackground: NonNullable<ChromeColumnsConfig<TestRow>['getRowBackground']> = (
+  ctx: ChromeRowResolverContext<TestRow>,
+) => {
+  const _name: string = ctx.row.name;
+  const _value: number = ctx.row.value;
+  const _rowId: string = ctx.rowId;
+  const _rowIndex: number = ctx.rowIndex;
+  // `column` is optional on the context; its presence is opt-in.
+  const _column: ColumnDef<TestRow> | undefined = ctx.column;
+  void _name;
+  void _value;
+  void _rowId;
+  void _rowIndex;
+  void _column;
+  return null;
+};
+void _namedBackground;
+
+// Positional resolver still works (backward compat).
+const _positionalBackground: NonNullable<ChromeColumnsConfig<TestRow>['getRowBackground']> = (
+  row,
+  rowId,
+  rowIndex,
+) => {
+  const _name: string = row.name;
+  void _name;
+  void rowId;
+  void rowIndex;
+  return null;
+};
+void _positionalBackground;
+
+// Named-object resolver returning a structured result (getRowBorder).
+const _namedBorder: NonNullable<ChromeColumnsConfig<TestRow>['getRowBorder']> = ({ row }) => {
+  return row.value > 0 ? ({ color: '#000' } satisfies RowBorderStyle) : null;
+};
+void _namedBorder;
+
+// Named-object resolver returning chrome-cell content.
+const _namedContent: NonNullable<ChromeColumnsConfig<TestRow>['getChromeCellContent']> = ({
+  row,
+  rowIndex,
+}) => {
+  return { text: `${rowIndex}:${row.name}` } satisfies ChromeCellContent;
+};
+void _namedContent;
+
+// The `ColumnDef` generic on `ctx.column` must carry `TData` through.
+function _ctxColumnNarrows(ctx: _CtxForRow): void {
+  if (ctx.column) {
+    // `field` is `keyof TestRow & string` — compile-time narrowing.
+    const _field: 'id' | 'name' | 'value' = ctx.column.field;
+    void _field;
+  }
+}
+void _ctxColumnNarrows;
+
+// ────────────────────────────────────────────────────────────────────────────
+// Runtime behaviour
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('chrome resolver named-object overload', () => {
+  it('named-object form produces the same background as positional form', () => {
+    // Positional: paint row 0 with '#aaccee'.
+    const { unmount } = render(
+      <DataGrid
+        data={makeData(2)}
+        columns={columns as any}
+        rowKey="id"
+        chrome={{
+          rowNumbers: true,
+          getRowBackground: (row, rowId, rowIndex) =>
+            rowIndex === 0 ? '#aaccee' : null,
+        }}
+      />,
+    );
+    // Pick row containers via the `[role="row"]` qualifier — without it
+    // the selector also matches the chrome-column row-number cell, which
+    // carries its own `data-row-id` attribute for click routing.
+    const positionalRow0 = document.querySelector(
+      '[data-row-id="1"][role="row"]',
+    ) as HTMLElement | null;
+    const positionalRow0Bg = positionalRow0?.style?.background;
+    unmount();
+
+    // Named-object: same behaviour.
+    render(
+      <DataGrid
+        data={makeData(2)}
+        columns={columns as any}
+        rowKey="id"
+        chrome={{
+          rowNumbers: true,
+          getRowBackground: ({ rowIndex }) => (rowIndex === 0 ? '#aaccee' : null),
+        }}
+      />,
+    );
+    const namedRow0 = document.querySelector(
+      '[data-row-id="1"][role="row"]',
+    ) as HTMLElement | null;
+    const namedRow0Bg = namedRow0?.style?.background;
+
+    // Both backgrounds are the same non-empty value — the named-object form
+    // flowed through the same painting path.
+    expect(positionalRow0Bg).toBeTruthy();
+    expect(namedRow0Bg).toBe(positionalRow0Bg);
+  });
+
+  it('positional form keeps working unchanged', () => {
+    // Declared with all three positional parameters so the arity matches
+    // the historical wire format. The dispatcher identifies a positional
+    // resolver by looking at the first parameter's structural prefix —
+    // here, `row` (an identifier, not `{`) triggers the positional branch.
+    //
+    // We use a raw function + manual invocation capture so the resolver's
+    // `toString()` source preserves the positional shape verbatim (some
+    // spy wrappers stringify as `(...args) => …`, which would also
+    // dispatch as positional but would obscure the intent of this test).
+    const calls: Array<{ argCount: number; row: TestRow; rowId: string; rowIndex: number }> = [];
+    const positional = function positional(
+      row: TestRow,
+      rowId: string,
+      rowIndex: number,
+    ): string | null {
+      calls.push({ argCount: arguments.length, row, rowId, rowIndex });
+      return row.value === 0 ? '#eeeeee' : null;
+    };
+
+    render(
+      <DataGrid
+        data={makeData(3)}
+        columns={columns as any}
+        rowKey="id"
+        chrome={{ rowNumbers: true, getRowBackground: positional }}
+      />,
+    );
+
+    expect(calls.length).toBeGreaterThan(0);
+    for (const c of calls) {
+      // Three positional args were passed — the grid's wire format is
+      // unchanged for positional resolvers.
+      expect(c.argCount).toBe(3);
+      expect(typeof c.row).toBe('object');
+      expect(typeof c.rowId).toBe('string');
+      expect(typeof c.rowIndex).toBe('number');
+      // The first argument is the row itself, not a context wrapper.
+      expect(c.row).not.toHaveProperty('row');
+      expect(c.row).toHaveProperty('id');
+    }
+  });
+
+  it('single-arg positional form `(row) => …` keeps working (back-compat)', () => {
+    // A very common historical shape: the resolver declares only `row`
+    // and ignores the extra args. The dispatcher must NOT treat this as
+    // a named-object resolver — the consumer expects `row` to be the
+    // data row, not a context wrapper.
+    const calls: Array<{ argCount: number; firstArg: unknown }> = [];
+    const positionalOneArg = function positionalOneArg(row: TestRow): string | null {
+      calls.push({ argCount: arguments.length, firstArg: row });
+      return row.value === 0 ? '#cafe00' : null;
+    };
+
+    render(
+      <DataGrid
+        data={makeData(2)}
+        columns={columns as any}
+        rowKey="id"
+        chrome={{
+          rowNumbers: true,
+          getRowBackground: positionalOneArg as NonNullable<
+            ChromeColumnsConfig<TestRow>['getRowBackground']
+          >,
+        }}
+      />,
+    );
+
+    expect(calls.length).toBeGreaterThan(0);
+    for (const c of calls) {
+      // Three positional args are always passed; the resolver simply
+      // ignores the trailing two. Crucially, the first argument is the
+      // row itself — not a context object.
+      expect(c.argCount).toBe(3);
+      expect(c.firstArg).toHaveProperty('value');
+      expect(c.firstArg).not.toHaveProperty('row');
+    }
+  });
+
+  it('named-object form receives {row, rowId, rowIndex} at each call site', () => {
+    // A destructured-object resolver — the dispatcher's toString-prefix
+    // detection triggers the named-object branch.
+    //
+    // We record each invocation via a manual capture array rather than
+    // `vi.fn()` so the function's stringified source preserves the
+    // destructuring pattern (some mock wrappers stringify as `(...args)`
+    // or `function spy()`, which would mask the real shape and defeat
+    // the dispatch detection this test is locking in).
+    const calls: Array<{ argCount: number; ctx: ChromeRowResolverContext<TestRow> }> = [];
+    const named = function named(
+      { row, rowId, rowIndex }: ChromeRowResolverContext<TestRow>
+    ): string | null {
+      // `arguments` is only available on non-arrow functions, which is also
+      // what lets us reliably assert the invocation arity in this test.
+      calls.push({ argCount: arguments.length, ctx: { row, rowId, rowIndex } });
+      return rowIndex === 0 ? '#ff0000' : null;
+    };
+
+    render(
+      <DataGrid
+        data={makeData(2)}
+        columns={columns as any}
+        rowKey="id"
+        chrome={{ rowNumbers: true, getRowBackground: named }}
+      />,
+    );
+
+    expect(calls.length).toBeGreaterThan(0);
+    // Every invocation receives exactly one argument (the ctx object), never
+    // three positional arguments.
+    for (const c of calls) {
+      expect(c.argCount).toBe(1);
+      expect(c.ctx).toBeTypeOf('object');
+      expect(c.ctx).toHaveProperty('row');
+      expect(c.ctx).toHaveProperty('rowId');
+      expect(c.ctx).toHaveProperty('rowIndex');
+      expect(typeof c.ctx.row).toBe('object');
+      expect(typeof c.ctx.row.id).toBe('string');
+      expect(typeof c.ctx.row.name).toBe('string');
+      expect(typeof c.ctx.rowId).toBe('string');
+      expect(typeof c.ctx.rowIndex).toBe('number');
+    }
+
+    // And the specific values flowed through: the first row invocation gets
+    // rowIndex === 0 and row.id === '1'.
+    const firstCall = calls.find((c) => c.ctx.rowIndex === 0);
+    expect(firstCall).toBeDefined();
+    expect((firstCall!.ctx.row as TestRow).id).toBe('1');
+    expect(firstCall!.ctx.rowId).toBe('1');
+  });
+
+  it('named-object getChromeCellContent paints the returned text into the chrome gutter', () => {
+    render(
+      <DataGrid
+        data={makeData(2)}
+        columns={columns as any}
+        rowKey="id"
+        chrome={{
+          rowNumbers: true,
+          getChromeCellContent: ({ row }) => ({ text: `N:${row.name}` }),
+        }}
+      />,
+    );
+
+    // Every row emits its custom text.
+    expect(screen.getByText('N:Row 1')).toBeInTheDocument();
+    expect(screen.getByText('N:Row 2')).toBeInTheDocument();
+  });
+
+  it('named-object getRowBorder honours the returned border style', () => {
+    render(
+      <DataGrid
+        data={makeData(2)}
+        columns={columns as any}
+        rowKey="id"
+        chrome={{
+          rowNumbers: true,
+          getRowBorder: ({ rowIndex }) =>
+            rowIndex === 1 ? { color: '#ff00ff', width: 2 } : null,
+        }}
+      />,
+    );
+
+    // The second row's container picks up the declared border colour.
+    // `[role="row"]` excludes chrome-column row-number cells.
+    const row1 = document.querySelector(
+      '[data-row-id="2"][role="row"]',
+    ) as HTMLElement | null;
+    expect(row1).not.toBeNull();
+    // The border is applied via inline style; its exact property depends on
+    // the internal style factory, but the declared colour must show up
+    // somewhere in the computed style string.
+    const styleAttr = row1!.getAttribute('style') ?? '';
+    expect(styleAttr.toLowerCase()).toMatch(/#ff00ff|rgb\(255,\s*0,\s*255\)/);
+  });
+
+  it('untyped spread-argument resolvers fall back to the positional form', () => {
+    // `(...args) => …` has `length === 0`, which the grid dispatches via the
+    // positional path — documented fallback for runtime-untyped callers.
+    const spread = vi.fn<(...args: unknown[]) => string | null>((...args) => {
+      // Three positional arguments: row, rowId, rowIndex.
+      return args.length === 3 ? '#00ff00' : null;
+    });
+
+    render(
+      <DataGrid
+        data={makeData(1)}
+        columns={columns as any}
+        rowKey="id"
+        chrome={{
+          rowNumbers: true,
+          // Cast required because `(...args) => …` doesn't match either
+          // overload narrowly — this is precisely the untyped case the
+          // fallback is designed for.
+          getRowBackground: spread as NonNullable<
+            ChromeColumnsConfig<TestRow>['getRowBackground']
+          >,
+        }}
+      />,
+    );
+
+    expect(spread).toHaveBeenCalled();
+    for (const call of spread.mock.calls) {
+      expect(call.length).toBe(3);
+    }
+  });
+});

--- a/packages/react/src/body/DataGridBody.tsx
+++ b/packages/react/src/body/DataGridBody.tsx
@@ -48,7 +48,14 @@ import {
   GridModel,
   SelectionMode,
 } from '@istracked/datagrid-core';
-import type { ControlsColumnConfig, RowNumberColumnConfig, RowBorderStyle, ChromeCellContent } from '@istracked/datagrid-core';
+import type {
+  ControlsColumnConfig,
+  RowNumberColumnConfig,
+  RowBorderStyle,
+  ChromeCellContent,
+  ChromeRowResolver,
+  ChromeRowResolverContext,
+} from '@istracked/datagrid-core';
 import { CellRendererProps } from '../DataGrid';
 import { ChromeControlsCell, ChromeRowNumberCell } from '../chrome';
 import { GhostRow } from '../GhostRow';
@@ -81,6 +88,65 @@ function getValidationKey(rowId: string, field: string): string {
 function resolveGhostPosition<T extends Record<string, unknown> = Record<string, unknown>>(config: boolean | GhostRowConfig<T> | undefined): GhostRowPosition {
   if (typeof config === 'object' && config.position) return config.position;
   return 'bottom';
+}
+
+// ---------------------------------------------------------------------------
+// Chrome-resolver shape detection
+// ---------------------------------------------------------------------------
+
+/**
+ * Detects whether a chrome row resolver was declared with the named-object
+ * calling convention (a single destructured object parameter).
+ *
+ * The detection is a structural prefix match against the resolver's
+ * stringified source — the same `Function.prototype.toString()` mechanism
+ * used by popular introspection libraries (redux-toolkit's
+ * `checkForBraces`, vue's props-resolution). It looks for the first
+ * non-whitespace token after the opening parenthesis (or the `function`
+ * keyword's paren) and returns `true` when that token is `{`.
+ *
+ * False-negative cases all fall through to the positional branch, which
+ * is the safe default — the worst that can happen is that a consumer
+ * writes `(ctx) => ctx.row` without destructuring and the grid invokes
+ * them as `fn(row, rowId, rowIndex)`, so `ctx === row`. Because `TData`
+ * is opaque, the consumer's code breaks loudly at the first property
+ * access — never silently wrong.
+ *
+ * Guarded against arity-0 (`(...args)`, `() => …`) and non-function
+ * inputs for safety, though neither path is reachable from the typed
+ * call sites.
+ */
+function isNamedObjectResolver(fn: unknown): boolean {
+  if (typeof fn !== 'function') return false;
+  // Arity-0 callables are treated as positional — this covers the
+  // documented `(...args) => …` fallback case and any accidental
+  // `() => …` resolver.
+  if (fn.length < 1) return false;
+  // Peek at the source. `toString()` on native / bound functions may
+  // yield `"function X() { [native code] }"` — the regex below does not
+  // match `{` before the closing paren so native callables correctly
+  // fall through to positional.
+  let src: string;
+  try {
+    src = Function.prototype.toString.call(fn);
+  } catch {
+    return false;
+  }
+  // Locate the first opening paren (after an optional leading
+  // `function` / `async function` / identifier / whitespace). Arrow
+  // functions begin with `(`, so the first paren is always the
+  // parameter list.
+  const parenIdx = src.indexOf('(');
+  if (parenIdx < 0) return false;
+  // Skip whitespace after `(`. If the first non-whitespace byte is `{`,
+  // the resolver destructures its first parameter.
+  for (let i = parenIdx + 1; i < src.length; i++) {
+    const c = src.charCodeAt(i);
+    // Fast whitespace check: space (32), tab (9), LF (10), CR (13).
+    if (c === 32 || c === 9 || c === 10 || c === 13) continue;
+    return c === 0x7b /* `{` */;
+  }
+  return false;
 }
 
 // ---------------------------------------------------------------------------
@@ -180,9 +246,14 @@ export interface DataGridBodyProps<TData extends Record<string, unknown>> {
 
   // Chrome-level row presentation hooks (issue #14). Each is evaluated per
   // rendered row; returning nullish preserves the stock presentation.
-  getRowBorder?: (row: TData, rowId: string, rowIndex: number) => RowBorderStyle | null | undefined;
-  getRowBackground?: (row: TData, rowId: string, rowIndex: number) => string | null | undefined;
-  getChromeCellContent?: (row: TData, rowId: string, rowIndex: number) => ChromeCellContent | null | undefined;
+  //
+  // The resolver types are {@link ChromeRowResolver} — a union of the
+  // positional `(row, rowId, rowIndex) => TResult` form and the named-object
+  // `(ctx: ChromeRowResolverContext<TData>) => TResult` form. The body
+  // dispatches at runtime via `fn.length` (declared arity).
+  getRowBorder?: ChromeRowResolver<TData, RowBorderStyle | null | undefined>;
+  getRowBackground?: ChromeRowResolver<TData, string | null | undefined>;
+  getChromeCellContent?: ChromeRowResolver<TData, ChromeCellContent | null | undefined>;
 
   // Ghost row
   showGhostRow: boolean;
@@ -312,14 +383,68 @@ export function DataGridBody<TData extends Record<string, unknown>>(
   //     the `WeakMap` key constraint (`WeakKey`) without any cast.
   //   * The inner `Map`'s key is a chrome-resolver function. Resolvers have
   //     distinct signatures per slot (`getRowBackground` vs `getRowBorder`
-  //     vs `getChromeCellContent`), but we only use them as map identities —
-  //     the generic `ChromeResolverFn` alias makes that explicit without
-  //     narrowing to any single return shape, and removes the previous
-  //     `as unknown as Function` casts.
-  type ChromeResolverFn = (row: TData, rowId: string, rowIndex: number) => unknown;
-  const resolverCacheRef = useRef<WeakMap<TData, Map<ChromeResolverFn, unknown>>>(new WeakMap());
+  //     vs `getChromeCellContent`), and two calling conventions
+  //     (positional / named-object — see {@link ChromeRowResolver}). We
+  //     only use them as map identities so a plain `Function` alias is
+  //     sufficient for cache storage.
+  type ChromeResolverKey = Function;
+  const resolverCacheRef = useRef<WeakMap<TData, Map<ChromeResolverKey, unknown>>>(new WeakMap());
+
+  // -------------------------------------------------------------------------
+  // Chrome-resolver dispatch (positional vs named-object)
+  // -------------------------------------------------------------------------
+  //
+  // Per PR5, chrome resolvers accept either of two backward-compatible call
+  // shapes — see {@link ChromeRowResolver}:
+  //
+  //   (row, rowId, rowIndex)        → positional (historical; unchanged)
+  //   ({ row, rowId, rowIndex, … }) → named-object (self-documenting, new)
+  //
+  // We pick the shape by inspecting the resolver's declared first parameter:
+  // the named-object form is triggered only when the resolver destructures
+  // its first parameter as an object literal (`{…}` or `{…} = default`).
+  //
+  // The arity alone is not a reliable discriminator — historical consumers
+  // routinely write `(row) => …` (a length-1 positional resolver that
+  // simply ignores `rowId` and `rowIndex`), and a blind `fn.length === 1`
+  // dispatch would silently pass them a context object and break. Looking
+  // at the stringified function prefix tells positional `(row) => …`
+  // apart from destructured `({ row }) => …` without false positives in
+  // practice:
+  //
+  //   * `(row) => …`                  → positional
+  //   * `function (row) { … }`        → positional
+  //   * `({ row }) => …`              → named-object
+  //   * `function ({ row }) { … }`    → named-object
+  //   * `({ row } = {}) => …`         → named-object
+  //   * `(...args) => …`              → positional (arity 0)
+  //
+  // For runtime-untyped callers (`(...args) => …`, whose `.length` is `0`)
+  // we fall back to positional. This matches the compat matrix in the PR
+  // description.
+  //
+  // The context object is constructed lazily (only for the named-object
+  // branch) to keep the hot-path allocation count identical to the pre-PR5
+  // shape for positional resolvers.
+  const invokeChromeResolver = <TReturn,>(
+    fn: ChromeRowResolver<TData, TReturn>,
+    row: TData,
+    rowId: string,
+    rowIndex: number,
+  ): TReturn => {
+    if (isNamedObjectResolver(fn)) {
+      const ctx: ChromeRowResolverContext<TData> = { row, rowId, rowIndex };
+      return (fn as (ctx: ChromeRowResolverContext<TData>) => TReturn)(ctx);
+    }
+    return (fn as (row: TData, rowId: string, rowIndex: number) => TReturn)(
+      row,
+      rowId,
+      rowIndex,
+    );
+  };
+
   const getCachedResolverResult = <TReturn,>(
-    resolver: ((row: TData, rowId: string, rowIndex: number) => TReturn) | undefined,
+    resolver: ChromeRowResolver<TData, TReturn> | undefined,
     row: TData,
     rowId: string,
     rowIndex: number,
@@ -330,16 +455,12 @@ export function DataGridBody<TData extends Record<string, unknown>>(
       byResolver = new Map();
       resolverCacheRef.current.set(row, byResolver);
     }
-    // The cache is keyed by resolver identity. Every `ChromeResolverFn`
-    // candidate (`getRowBackground`, `getRowBorder`, `getChromeCellContent`)
-    // shares the `(row, rowId, rowIndex) => T` shape and narrows to the
-    // caller's `TReturn` on retrieval.
-    const key: ChromeResolverFn = resolver;
-    if (byResolver.has(key)) {
-      return byResolver.get(key) as TReturn;
+    // The cache is keyed by resolver identity (the function object itself).
+    if (byResolver.has(resolver)) {
+      return byResolver.get(resolver) as TReturn;
     }
-    const value = resolver(row, rowId, rowIndex);
-    byResolver.set(key, value);
+    const value = invokeChromeResolver(resolver, row, rowId, rowIndex);
+    byResolver.set(resolver, value);
     return value;
   };
 


### PR DESCRIPTION
## Summary

Adds a named-object overload to every chrome row-level presentation resolver (`getRowBorder`, `getRowBackground`, `getChromeCellContent`) while keeping the positional form 100% backward-compatible. Consumers keep writing the historical positional shape; consumers who prefer a self-documenting call site now have a second option:

```ts
// Positional (unchanged, still the wire format)
chrome: {
  getRowBackground: (row, rowId, rowIndex) =>
    rowIndex % 2 === 0 ? '#fafafa' : null,
}

// Named-object (new)
chrome: {
  getRowBackground: ({ row, rowIndex }) =>
    row.amount < 0 ? '#ffe0e0' : null,
}
```

## Why

Three-positional-args form is error-prone — consumers routinely swap `rowId` and `rowIndex` at declaration sites, and in review it is hard to tell which is which without chasing the type. The named-object form is self-documenting, it makes the optional `column?` reference available to future cell-level callers, and it scales cleanly to new context fields without breaking the positional signature.

## Detection mechanism

The runtime dispatcher uses `Function.prototype.toString.call(fn)` to inspect the resolver's first declared parameter — the named-object branch fires only when that parameter is a destructured object literal (`({ … })`). Arity alone is NOT a reliable discriminator: the ecosystem routinely writes `(row) => …` (a length-1 positional resolver that simply ignores the trailing args), and a blind `fn.length === 1` check would pass a context object as `row` and break those callers.

Structural prefix detection keeps all four historical shapes working:

| Consumer wrote | Grid calls it as |
|---|---|
| `(row, rowId, rowIndex) => …` | positional (unchanged) |
| `(row) => …` | positional (unchanged — back-compat) |
| `({ row, rowId, rowIndex, column }) => …` | named-object (new) |
| `(...args) => …` | positional (fallback — arity 0 / untyped) |

Arity-0 callables short-circuit to positional so spread-parameter resolvers always hit the historical path.

## Type surface

`packages/core/src/types.ts` adds:

- `ChromeRowResolverContext<TData>` — `{ row, rowId, rowIndex, column? }`.
- `ChromeRowResolver<TData, TResult>` — the union of the positional and named-object signatures.

Each of the three `ChromeColumnsConfig` resolver slots references the alias. TypeScript narrows both shapes correctly at the consumer's call site without any explicit overload gymnastics — the compile-only assertions in the new test file lock that down.

## Tests

`packages/react/src/__tests__/chrome-resolver-object-overload.test.tsx` covers:

- **Named-object ≡ positional**: both forms produce the same row background DOM output for a given resolver.
- **Positional form keeps working unchanged**: three args, `row` is the raw row (not a context wrapper).
- **Single-arg positional form keeps working** (`(row) => …` back-compat).
- **Named-object form receives `{ row, rowId, rowIndex }`**: exact values, exactly one argument (verified via `arguments.length` in a captured non-arrow function).
- **Named-object `getChromeCellContent` / `getRowBorder` paint the declared content / border** into the DOM.
- **`(...args) => …` resolvers dispatch positionally** (documented fallback).

Compile-only assertions alongside the runtime specs lock in `ctx.row` / `ctx.column` narrowing against a concrete `TData` generic.

## Stats

- typecheck: 0 errors
- tests: **1689 passing** (1682 preexisting + 7 new)
- build: green (core + react + mui + extensions DTS)

## Stacking

This PR is stacked on top of [#39 (PR4)](https://github.com/istracked/xldatagrid/pull/39). Its base is `feature/pr4-drop-chrome-resolver-as-any`, not `review/post-merge-hardening` — merge PR4 first, then this one will rebase down to the review branch cleanly.

## Commits

- `70f86ff7` — feat(types): add named-object overload for chrome resolvers

---
Closes #51