### PR TITLE
chore(gitignore): ignore .plans/ alongside docs/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,7 @@ config/licenses*
 
 # Superpowers docs (specs, plans) — generated per-session, not source of truth
 docs/
+.plans/
 
 # Git worktrees
 .worktrees/


### PR DESCRIPTION
## Summary

- Adds \`.plans/\` to \`.gitignore\` so session-local planning artefacts can't be re-committed.
- Companion to the history-rewrite that scrubbed \`.plans/\` from every branch and tag — without this guard, the directory would silently re-enter the tree the next time someone staged it.

## Test plan

- [ ] \`git status\` from a working tree containing a \`.plans/\` dir reports nothing