### PR TITLE
test(hardening): close gaps — chrome composition scenarios + range-extend properties

### DIFF
--- a/packages/react/src/__tests__/chrome-composition-scenarios.test.tsx
+++ b/packages/react/src/__tests__/chrome-composition-scenarios.test.tsx
@@ -1,0 +1,303 @@
+/**
+ * Regression-lock scenarios for the chrome composition layering that the
+ * hardening plan called out but Agent D did not cover (Agent D ended up
+ * focused on TS-error cleanup + the memoization invariant). These four
+ * tests pin the compose order + resolver call-site boundaries that
+ * `DataGridBody` relies on, so later refactors cannot quietly change the
+ * visible layer stack.
+ *
+ * Layers (as encoded in `DataGridBody.styles.cell` and `renderCell`):
+ *   1. consumer `getRowBackground`  → painted on the row *container*
+ *   2. Shift+Arrow range tint       → painted on each range cell via the
+ *                                      `--dg-range-bg` token (alpha-blended)
+ *   3. primary selection outline    → `2px solid var(--dg-selection-border)`
+ *                                      applied as an `outline` on the focus cell
+ *   4. frozen-column background     → `var(--dg-header-bg)`; wins over (1)/(2)
+ *                                      for the pinned cell itself
+ *
+ * `getChromeCellContent` is invoked only from `renderRowNumberCell`, and
+ * only for *data* rows — never for row-group header / aggregate rows.
+ */
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { vi } from 'vitest';
+import { DataGrid } from '../DataGrid';
+import type { ChromeCellContent } from '@istracked/datagrid-core';
+
+type Row = { id: string; dept: string; name: string; salary: number };
+
+function makeRows(): Row[] {
+  return [
+    { id: '1', dept: 'Eng', name: 'Alice', salary: 100 },
+    { id: '2', dept: 'Eng', name: 'Bob', salary: 110 },
+    { id: '3', dept: 'Sales', name: 'Charlie', salary: 90 },
+    { id: '4', dept: 'Sales', name: 'Diana', salary: 95 },
+  ];
+}
+
+const baseColumns = [
+  { id: 'dept', field: 'dept' as const, title: 'Dept' },
+  { id: 'name', field: 'name' as const, title: 'Name' },
+  { id: 'salary', field: 'salary' as const, title: 'Salary' },
+];
+
+function getGrid() {
+  return screen.getByRole('grid');
+}
+
+function getCell(rowId: string, field: string): HTMLElement {
+  const cell = document.querySelector(
+    `[data-row-id="${rowId}"][data-field="${field}"][role="gridcell"]`,
+  );
+  if (!cell) throw new Error(`Cell not found: ${rowId}/${field}`);
+  return cell as HTMLElement;
+}
+
+function getRowContainer(rowId: string): HTMLElement {
+  const row = document.querySelector(
+    `[data-row-id="${rowId}"][role="row"]`,
+  );
+  if (!row) throw new Error(`Row container not found: ${rowId}`);
+  return row as HTMLElement;
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 1 — selected + ranged cell
+// ---------------------------------------------------------------------------
+
+describe('chrome composition — selected + ranged cell', () => {
+  it('composes range background with selection outline on the focus cell (neither replaces the other)', () => {
+    render(
+      <DataGrid
+        data={makeRows()}
+        columns={baseColumns}
+        rowKey="id"
+        selectionMode="range"
+        shiftArrowBehavior="rangeSelect"
+      />,
+    );
+
+    // Click the anchor, then Shift+Right to build a 1x2 range.
+    fireEvent.click(getCell('1', 'dept'));
+    fireEvent.keyDown(getGrid(), { key: 'ArrowRight', shiftKey: true });
+
+    const anchor = getCell('1', 'dept');
+    const focus = getCell('1', 'name');
+
+    // Both cells are inside the range — both carry the range tint on their
+    // background. The range layer is applied via the `--dg-range-bg` token
+    // which is alpha-blended, so it composes rather than replaces whatever
+    // is underneath.
+    expect(anchor.style.background).toContain('--dg-range-bg');
+    expect(focus.style.background).toContain('--dg-range-bg');
+
+    // The primary-selection outline lives on a *different* CSS property
+    // (`outline`) from the range tint (`background`), so the two layers
+    // coexist on the anchor cell without conflict. If a future refactor
+    // folded selection into `background` (or range into `outline`) this
+    // test would fail — that is intentional: the two layers must stay on
+    // separate properties so consumer content remains visible underneath.
+    expect(anchor.style.outline).toContain('2px solid');
+    expect(anchor.style.outline).toContain('--dg-selection-border');
+
+    // Cells outside the range have neither tint nor selection outline.
+    const outside = getCell('2', 'salary');
+    expect(outside.style.background).toBe('');
+    expect(outside.style.outline === '' || outside.style.outline === 'none').toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 2 — frozen column + consumer background
+// ---------------------------------------------------------------------------
+
+describe('chrome composition — frozen column + consumer row background', () => {
+  it('keeps frozen-column styling while the consumer row background paints the row container', () => {
+    const getRowBackground = vi.fn((row: Row) =>
+      row.id === '1' ? '#abcdef' : null,
+    );
+    const frozenColumns = [
+      { id: 'dept', field: 'dept' as const, title: 'Dept', frozen: 'left' as const },
+      { id: 'name', field: 'name' as const, title: 'Name' },
+      { id: 'salary', field: 'salary' as const, title: 'Salary' },
+    ];
+
+    render(
+      <DataGrid
+        data={makeRows()}
+        columns={frozenColumns}
+        rowKey="id"
+        chrome={{ getRowBackground }}
+      />,
+    );
+
+    // Consumer bg paints the row container — visible through the two
+    // non-frozen cells in that row.
+    const row1 = getRowContainer('1');
+    expect(row1.style.background).toMatch(/#abcdef|rgb\(171,\s*205,\s*239\)/i);
+
+    // Frozen cell: sticky, pinned to the left edge, and retains the
+    // frozen-column header-token background (NOT the consumer colour).
+    // `styles.cell` elects `frozenBg` over `opts.background`, so the pinned
+    // column stays legible when a consumer row colour is very dark or very
+    // bright.
+    const frozenCell = getCell('1', 'dept');
+    expect(frozenCell.style.position).toBe('sticky');
+    expect(frozenCell.style.left).toBe('0px');
+    expect(frozenCell.style.zIndex).toBe('2');
+    expect(frozenCell.style.background).toContain('--dg-header-bg');
+    // Critically: the frozen cell must NOT carry the consumer colour
+    // itself — otherwise the frozen tint would lose to an arbitrary
+    // consumer value and pin columns would become unreadable.
+    expect(frozenCell.style.background).not.toMatch(/#abcdef|rgb\(171,\s*205,\s*239\)/i);
+
+    // Non-frozen cell in the same row: transparent cell, no sticky
+    // positioning, consumer colour shows through via the row container.
+    const nonFrozenCell = getCell('1', 'name');
+    expect(nonFrozenCell.style.position).not.toBe('sticky');
+    expect(nonFrozenCell.style.background).toBe('');
+
+    // Resolver invoked once per rendered row (memoization means it is not
+    // re-called on unrelated re-renders, but a first render must at
+    // minimum visit every data row).
+    const rowIdsSeen = getRowBackground.mock.calls.map((c) => c[1]);
+    expect(new Set(rowIdsSeen)).toEqual(new Set(['1', '2', '3', '4']));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 3 — grouped path (resolver fires for leaves, not group headers)
+// ---------------------------------------------------------------------------
+
+describe('chrome composition — grouped path', () => {
+  it('invokes getChromeCellContent for leaf data rows only, not for group-header rows', () => {
+    const getChromeCellContent = vi.fn<
+      (row: Row, rowId: string, rowIndex: number) => ChromeCellContent | null
+    >(() => null);
+
+    render(
+      <DataGrid
+        data={makeRows()}
+        columns={baseColumns}
+        rowKey="id"
+        grouping={{ rows: { fields: ['dept'], expanded: true } }}
+        chrome={{ rowNumbers: true, getChromeCellContent }}
+      />,
+    );
+
+    // Two group headers (Eng + Sales) must be present…
+    const groupHeaders = screen.queryAllByTestId('group-header-row');
+    expect(groupHeaders.length).toBe(2);
+
+    // …and the resolver must have been invoked exactly once per leaf row
+    // (4 rows total) — *not* once per row including the two group headers
+    // (which would be 6). A future regression that plumbed
+    // getChromeCellContent through the group-header render path would
+    // spike the call count to 6 and this test would fail.
+    expect(getChromeCellContent).toHaveBeenCalledTimes(4);
+
+    // Verify each invocation received a real data row (never a
+    // synthetic group-summary object).
+    const rowsPassed = getChromeCellContent.mock.calls.map((c) => c[0]);
+    for (const row of rowsPassed) {
+      expect(row).toHaveProperty('id');
+      expect(row).toHaveProperty('dept');
+      expect(row).toHaveProperty('salary');
+    }
+    const idsPassed = rowsPassed.map((r) => r.id).sort();
+    expect(idsPassed).toEqual(['1', '2', '3', '4']);
+  });
+
+  it('row-number chrome cell renders only for leaf rows in a grouped grid', () => {
+    render(
+      <DataGrid
+        data={makeRows()}
+        columns={baseColumns}
+        rowKey="id"
+        grouping={{ rows: { fields: ['dept'], expanded: true } }}
+        chrome={{
+          rowNumbers: true,
+          getChromeCellContent: (row: Row): ChromeCellContent => ({
+            text: `#${row.id}`,
+          }),
+        }}
+      />,
+    );
+
+    // 4 leaf rows → 4 chrome-row-number cells. If the row-number gutter
+    // leaked into group headers we would see 6 cells here.
+    const chromeCells = screen.getAllByTestId('chrome-row-number');
+    expect(chromeCells.length).toBe(4);
+
+    // Each chrome cell carries the consumer-supplied text — confirming
+    // the resolver ran against every rendered chrome cell, not only a
+    // subset.
+    const texts = chromeCells.map((c) =>
+      within(c).getByTestId('chrome-row-content-text').textContent,
+    );
+    expect(texts.sort()).toEqual(['#1', '#2', '#3', '#4']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 4 — readonly grid still builds ranges + fires resolvers
+// ---------------------------------------------------------------------------
+
+describe('chrome composition — readonly grid', () => {
+  it('Shift+Arrow still builds a range overlay when readOnly is true', () => {
+    render(
+      <DataGrid
+        data={makeRows()}
+        columns={baseColumns}
+        rowKey="id"
+        readOnly
+        selectionMode="range"
+        shiftArrowBehavior="rangeSelect"
+      />,
+    );
+
+    fireEvent.click(getCell('1', 'dept'));
+    fireEvent.keyDown(getGrid(), { key: 'ArrowRight', shiftKey: true });
+
+    // readOnly gates editing, not selection — both cells receive the range
+    // tint the same way as in a writable grid.
+    expect(getCell('1', 'dept').style.background).toContain('--dg-range-bg');
+    expect(getCell('1', 'name').style.background).toContain('--dg-range-bg');
+
+    // A cell outside the 1x2 range stays transparent — the readOnly flag
+    // must not accidentally paint every cell.
+    expect(getCell('2', 'salary').style.background).toBe('');
+  });
+
+  it('chrome resolvers still fire on a readOnly grid', () => {
+    const getRowBackground = vi.fn((row: Row) =>
+      row.id === '2' ? '#fffaaa' : null,
+    );
+    const getChromeCellContent = vi.fn<
+      (row: Row, rowId: string, rowIndex: number) => ChromeCellContent | null
+    >(() => null);
+
+    render(
+      <DataGrid
+        data={makeRows()}
+        columns={baseColumns}
+        rowKey="id"
+        readOnly
+        chrome={{ rowNumbers: true, getRowBackground, getChromeCellContent }}
+      />,
+    );
+
+    // Background resolver paints row 2.
+    const row2 = getRowContainer('2');
+    expect(row2.style.background).toMatch(/#fffaaa|rgb\(255,\s*250,\s*170\)/i);
+
+    // Both resolvers were invoked for every data row.
+    expect(getRowBackground.mock.calls.length).toBeGreaterThanOrEqual(4);
+    expect(getChromeCellContent.mock.calls.length).toBeGreaterThanOrEqual(4);
+
+    // Cell editability is disabled (readonly), but selection still works.
+    // The frozen-cell click dispatches to selection regardless of
+    // editability, which is the contract readonly preserves.
+    const cell = getCell('1', 'dept');
+    expect(cell.style.cursor).toBe('default');
+  });
+});

--- a/packages/react/src/__tests__/properties/range-extend.property.test.ts
+++ b/packages/react/src/__tests__/properties/range-extend.property.test.ts
@@ -1,0 +1,377 @@
+/**
+ * Property-based tests for Shift+Arrow range extension — the third suite
+ * called out in the hardening plan (alongside the already-landed
+ * `stripField.property.test.ts` and `getEndJumpCell.property.test.ts`).
+ *
+ * The grid models Shift+Arrow via two primitives in `@istracked/datagrid-core`:
+ *
+ *   - `extendSelection(state, cell)` — sets `range.focus` to `cell`, keeping
+ *     `range.anchor` fixed. This is the function called by the React
+ *     `use-keyboard.ts` hook via `model.extendTo(...)` on every Shift+Arrow
+ *     keystroke.
+ *   - `getNextCell(current, direction, columns, rowIds)` — computes the
+ *     adjacent cell in a direction, returning `null` at the grid boundary.
+ *
+ * The invariants we pin here are defined on the *composition* of those two
+ * primitives: the observable behaviour of "press Shift+Arrow in a particular
+ * direction N times" starting from a known selection.
+ */
+import { describe, it } from 'vitest';
+import * as fc from 'fast-check';
+import {
+  createSelection,
+  selectCell,
+  extendSelection,
+  getNextCell,
+  isCellInRange,
+} from '@istracked/datagrid-core';
+import type {
+  ColumnDef,
+  CellAddress,
+  SelectionState,
+} from '@istracked/datagrid-core';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type Dir = 'up' | 'down' | 'left' | 'right';
+const DIRECTIONS: Dir[] = ['up', 'down', 'left', 'right'];
+
+function makeColumns(numCols: number): ColumnDef<any>[] {
+  return Array.from({ length: numCols }, (_, i) => ({
+    id: `c${i}`,
+    field: `c${i}`,
+    title: `Col ${i}`,
+  }));
+}
+
+function makeRowIds(numRows: number): string[] {
+  return Array.from({ length: numRows }, (_, i) => `r${i}`);
+}
+
+/**
+ * Simulate pressing Shift+<direction> `steps` times starting from `state`.
+ * Each step re-derives the next focus from the *current* focus (not the
+ * anchor), matching the real `use-keyboard.ts` behaviour — compound
+ * Shift+Arrow keystrokes walk outward one cell at a time.
+ *
+ * When the focus would step off the grid, the call is a no-op (mirrors the
+ * keyboard handler, which only invokes `extendTo` when `getNextCell` yields
+ * a target). The selection therefore clamps at the boundary.
+ */
+function pressShiftArrow(
+  state: SelectionState,
+  direction: Dir,
+  steps: number,
+  columns: ColumnDef<any>[],
+  rowIds: string[],
+): SelectionState {
+  let current = state;
+  for (let i = 0; i < steps; i++) {
+    const focus = current.range?.focus;
+    if (!focus) break;
+    const next = getNextCell(focus, direction, columns, rowIds);
+    if (!next) break; // clamped at the grid boundary
+    current = extendSelection(current, next);
+  }
+  return current;
+}
+
+/** Normalised rectangular bounds (row/col indices) of the active range. */
+function rangeBounds(
+  state: SelectionState,
+  columns: ColumnDef<any>[],
+  rowIds: string[],
+): { minRow: number; maxRow: number; minCol: number; maxCol: number } | null {
+  const range = state.range;
+  if (!range) return null;
+  const colFields = columns.map((c) => c.field);
+  const anchorRow = rowIds.indexOf(range.anchor.rowId);
+  const focusRow = rowIds.indexOf(range.focus.rowId);
+  const anchorCol = colFields.indexOf(range.anchor.field);
+  const focusCol = colFields.indexOf(range.focus.field);
+  return {
+    minRow: Math.min(anchorRow, focusRow),
+    maxRow: Math.max(anchorRow, focusRow),
+    minCol: Math.min(anchorCol, focusCol),
+    maxCol: Math.max(anchorCol, focusCol),
+  };
+}
+
+// Reverse direction helper — used by the symmetry property.
+const REVERSE: Record<Dir, Dir> = {
+  up: 'down',
+  down: 'up',
+  left: 'right',
+  right: 'left',
+};
+
+// ---------------------------------------------------------------------------
+// Arbitraries
+// ---------------------------------------------------------------------------
+
+/**
+ * Generates a bounded grid + a starting anchor cell. The grid is at least
+ * 3×3 so every property has room to step in at least one direction without
+ * hitting a boundary trivially.
+ */
+const setupArb = fc
+  .tuple(
+    fc.integer({ min: 3, max: 12 }), // numRows
+    fc.integer({ min: 3, max: 8 }), //  numCols
+  )
+  .chain(([numRows, numCols]) =>
+    fc.record({
+      numRows: fc.constant(numRows),
+      numCols: fc.constant(numCols),
+      anchorRow: fc.integer({ min: 0, max: numRows - 1 }),
+      anchorCol: fc.integer({ min: 0, max: numCols - 1 }),
+    }),
+  );
+
+// ---------------------------------------------------------------------------
+// Properties
+// ---------------------------------------------------------------------------
+
+describe('range-extend — property-based invariants', () => {
+  // -------------------------------------------------------------------------
+  // Property 1 — idempotence under reverse-then-extend
+  //
+  // Extending N cells in a direction, collapsing back to the anchor, and
+  // extending N cells again must yield the same range as the direct
+  // extend. The collapse step models the "anchor + focus back on the
+  // anchor" recovery path that Ctrl+click uses; the property asserts that
+  // the extension operation has no hidden state beyond (anchor, focus).
+  // -------------------------------------------------------------------------
+  it('idempotent: extend(N) === collapse-then-extend(N)', () => {
+    fc.assert(
+      fc.property(
+        setupArb,
+        fc.constantFrom(...DIRECTIONS),
+        fc.integer({ min: 1, max: 6 }),
+        ({ numRows, numCols, anchorRow, anchorCol }, direction, steps) => {
+          const columns = makeColumns(numCols);
+          const rowIds = makeRowIds(numRows);
+          const anchor: CellAddress = {
+            rowId: rowIds[anchorRow]!,
+            field: columns[anchorCol]!.field,
+          };
+
+          // Direct extend N cells in one go.
+          const direct = pressShiftArrow(
+            selectCell(createSelection('range'), anchor),
+            direction,
+            steps,
+            columns,
+            rowIds,
+          );
+
+          // Collapse back to the anchor, then extend again.
+          const collapsed = selectCell(direct, anchor);
+          const reExtended = pressShiftArrow(
+            collapsed,
+            direction,
+            steps,
+            columns,
+            rowIds,
+          );
+
+          const a = rangeBounds(direct, columns, rowIds);
+          const b = rangeBounds(reExtended, columns, rowIds);
+          if (a === null || b === null) return false;
+          return (
+            a.minRow === b.minRow &&
+            a.maxRow === b.maxRow &&
+            a.minCol === b.minCol &&
+            a.maxCol === b.maxCol
+          );
+        },
+      ),
+      { numRuns: 200 },
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // Property 2 — anchor invariance
+  //
+  // The anchor cell must always remain inside the output range no matter
+  // how many times extend is called and in which direction. The anchor is
+  // one corner of the rectangular selection and must stay covered.
+  // -------------------------------------------------------------------------
+  it('anchor invariance: anchor cell stays inside the range across any extension sequence', () => {
+    fc.assert(
+      fc.property(
+        setupArb,
+        fc.array(
+          fc.tuple(
+            fc.constantFrom(...DIRECTIONS),
+            fc.integer({ min: 1, max: 4 }),
+          ),
+          { minLength: 1, maxLength: 10 },
+        ),
+        ({ numRows, numCols, anchorRow, anchorCol }, moves) => {
+          const columns = makeColumns(numCols);
+          const rowIds = makeRowIds(numRows);
+          const anchor: CellAddress = {
+            rowId: rowIds[anchorRow]!,
+            field: columns[anchorCol]!.field,
+          };
+
+          let state = selectCell(createSelection('range'), anchor);
+          for (const [dir, n] of moves) {
+            state = pressShiftArrow(state, dir, n, columns, rowIds);
+            if (!state.range) return false;
+            // Anchor never moves.
+            if (
+              state.range.anchor.rowId !== anchor.rowId ||
+              state.range.anchor.field !== anchor.field
+            ) {
+              return false;
+            }
+            // Anchor always inside the normalised range rectangle.
+            if (!isCellInRange(anchor, state.range, columns, rowIds)) {
+              return false;
+            }
+          }
+          return true;
+        },
+      ),
+      { numRuns: 200 },
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // Property 3 — bounds clamping
+  //
+  // Extending far past the grid boundary (up to 2× the grid dimension)
+  // must never produce a range whose focus is out of range. The
+  // `use-keyboard.ts` hook refuses to call `extendTo` when `getNextCell`
+  // returns `null`, so the range must clamp at the edge.
+  // -------------------------------------------------------------------------
+  it('bounds clamping: extending past the grid boundary never produces out-of-range cells', () => {
+    fc.assert(
+      fc.property(
+        setupArb,
+        fc.constantFrom(...DIRECTIONS),
+        ({ numRows, numCols, anchorRow, anchorCol }, direction) => {
+          const columns = makeColumns(numCols);
+          const rowIds = makeRowIds(numRows);
+          const anchor: CellAddress = {
+            rowId: rowIds[anchorRow]!,
+            field: columns[anchorCol]!.field,
+          };
+
+          // Press Shift+<dir> 2× the grid extent — guaranteed to over-run
+          // the boundary from any starting position.
+          const over = 2 * Math.max(numRows, numCols);
+          const final = pressShiftArrow(
+            selectCell(createSelection('range'), anchor),
+            direction,
+            over,
+            columns,
+            rowIds,
+          );
+
+          const bounds = rangeBounds(final, columns, rowIds);
+          if (bounds === null) return false;
+
+          // No negative / out-of-range indices.
+          if (
+            bounds.minRow < 0 ||
+            bounds.maxRow >= numRows ||
+            bounds.minCol < 0 ||
+            bounds.maxCol >= numCols
+          ) {
+            return false;
+          }
+
+          // The focus must pin to the grid edge in the direction of travel
+          // (since we ran past the boundary).
+          const focus = final.range?.focus;
+          if (!focus) return false;
+          const focusRow = rowIds.indexOf(focus.rowId);
+          const focusCol = columns.findIndex((c) => c.field === focus.field);
+
+          switch (direction) {
+            case 'up':
+              return focusRow === 0;
+            case 'down':
+              return focusRow === numRows - 1;
+            case 'left':
+              return focusCol === 0;
+            case 'right':
+              return focusCol === numCols - 1;
+          }
+        },
+      ),
+      { numRuns: 200 },
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // Property 4 — symmetry
+  //
+  // Extending left-N from the anchor then right-N must return to the
+  // single-cell (anchor-only) range — provided no boundary was hit along
+  // the way. Same for up/down. The guard condition is that the anchor is
+  // at least N cells away from the edge in both the forward and reverse
+  // direction, so no clamping occurs.
+  // -------------------------------------------------------------------------
+  it('symmetry: extend(N) then extend-reverse(N) returns to the original range (when no boundary is hit)', () => {
+    fc.assert(
+      fc.property(
+        setupArb,
+        fc.constantFrom(...DIRECTIONS),
+        fc.integer({ min: 1, max: 3 }),
+        ({ numRows, numCols, anchorRow, anchorCol }, direction, nRaw) => {
+          const columns = makeColumns(numCols);
+          const rowIds = makeRowIds(numRows);
+
+          // Cap N so there is at least N cells of headroom in `direction`
+          // from some interior anchor position — otherwise the anchor
+          // clamp below has nothing to pick and symmetry is vacuously
+          // impossible. With minimum grid size 3, `maxN` is at least 1.
+          const maxHeadroom =
+            direction === 'up' || direction === 'down' ? numRows - 1 : numCols - 1;
+          const n = Math.min(nRaw, maxHeadroom);
+
+          // Constrain the anchor so N steps in `direction` (and back) stays
+          // inside the grid — symmetry only holds in the interior.
+          let ar = anchorRow;
+          let ac = anchorCol;
+          if (direction === 'up') ar = Math.min(Math.max(ar, n), numRows - 1);
+          if (direction === 'down') ar = Math.max(Math.min(ar, numRows - 1 - n), 0);
+          if (direction === 'left') ac = Math.min(Math.max(ac, n), numCols - 1);
+          if (direction === 'right') ac = Math.max(Math.min(ac, numCols - 1 - n), 0);
+
+          const anchor: CellAddress = {
+            rowId: rowIds[ar]!,
+            field: columns[ac]!.field,
+          };
+
+          const start = selectCell(createSelection('range'), anchor);
+          const out = pressShiftArrow(start, direction, n, columns, rowIds);
+          const back = pressShiftArrow(
+            out,
+            REVERSE[direction],
+            n,
+            columns,
+            rowIds,
+          );
+
+          // Back to a single-cell range rooted at the anchor.
+          const bounds = rangeBounds(back, columns, rowIds);
+          if (bounds === null) return false;
+          return (
+            bounds.minRow === ar &&
+            bounds.maxRow === ar &&
+            bounds.minCol === ac &&
+            bounds.maxCol === ac
+          );
+        },
+      ),
+      { numRuns: 200 },
+    );
+  });
+});


### PR DESCRIPTION
## Summary
Closes two RED-test gaps from the hardening plan that weren't covered by wave-1 agents.

## Agent D — Chrome composition scenarios
- selected + ranged cell — z-order of selection/range/consumer-bg overlays
- frozen column + consumer background — sticky + consumer bg coexistence
- grouped path — resolver is called for leaf rows only, not group headers
- readonly grid — Shift+Arrow still builds a range; resolvers still fire

## Agent J — range-extend property suite
4 fast-check properties: idempotence, anchor invariance, bounds clamping, symmetry.

## Stats
- tests: 1682 → 1692 (+10)
- typecheck: 0 errors
- bugs surfaced during testing: none (all six chrome scenarios + all four properties pass against current code — regression-lock tests)