### PR TITLE
catchup: axe-core a11y scans + usePasswordInput shared hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
     "typedoc": "^0.28.19",
     "typescript": "~5.7.3",
     "vite": "~6.1.0",
-    "vitest": "~3.0.5"
+    "vitest": "~3.0.5",
+    "vitest-axe": "^0.1.0"
   },
   "eslintConfig": {
     "extends": [

--- a/packages/react/src/__tests__/a11y-axe.test.tsx
+++ b/packages/react/src/__tests__/a11y-axe.test.tsx
@@ -1,0 +1,204 @@
+/**
+ * axe-core accessibility scans for the DataGrid across five representative
+ * configurations.
+ *
+ * These tests complement the targeted ARIA/focus tests in `cell-a11y.test.tsx`
+ * by running the full axe-core ruleset over a rendered grid. They catch
+ * regressions that are hard to spot with hand-written assertions: missing
+ * landmarks, duplicate ids across the tree, empty buttons, incorrectly nested
+ * roles, etc.
+ *
+ * Scope:
+ *   1. Minimal DataGrid (5 rows, 3 cols, default renderers, no chrome).
+ *   2. DataGrid with chrome columns (controls + row numbers).
+ *   3. DataGrid with a row expanded into a sub-grid.
+ *   4. DataGrid with filter menu open on a column.
+ *   5. DataGrid with the ghost row pinned to the bottom.
+ *
+ * The `color-contrast` rule is disabled because jsdom cannot compute actual
+ * computed colors (no layout engine); all other rules run with axe-core's
+ * defaults. A violation in any configuration fails the test and the matcher
+ * prints a full selector + help-URL report.
+ */
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, fireEvent, act } from '@testing-library/react';
+import { axe } from 'vitest-axe';
+import { toHaveNoViolations } from 'vitest-axe/matchers';
+import type { ColumnDef } from '@istracked/datagrid-core';
+
+import { DataGrid } from '../DataGrid';
+import { cellRendererMap } from '../cells';
+
+expect.extend({ toHaveNoViolations });
+
+// ---------------------------------------------------------------------------
+// Fixtures & helpers
+// ---------------------------------------------------------------------------
+
+type Row = { id: string; name: string; age: number; email: string };
+
+function makeRows(): Row[] {
+  return [
+    { id: '1', name: 'Alice', age: 30, email: 'alice@example.com' },
+    { id: '2', name: 'Bob', age: 25, email: 'bob@example.com' },
+    { id: '3', name: 'Charlie', age: 35, email: 'charlie@example.com' },
+    { id: '4', name: 'Dana', age: 40, email: 'dana@example.com' },
+    { id: '5', name: 'Eve', age: 28, email: 'eve@example.com' },
+  ];
+}
+
+const plainColumns: ColumnDef<Row>[] = [
+  { id: 'name', field: 'name', title: 'Name' },
+  { id: 'age', field: 'age', title: 'Age', cellType: 'numeric' },
+  { id: 'email', field: 'email', title: 'Email' },
+];
+
+/**
+ * axe-core ruleset tuned for jsdom.  `color-contrast` is the only rule we
+ * disable; every other default rule is in effect.  jsdom does not run a
+ * layout engine, so the computed colours needed for contrast evaluation are
+ * unreliable and produce false-positive violations regardless of token wiring.
+ */
+const axeOptions = {
+  rules: {
+    'color-contrast': { enabled: false },
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Scans
+// ---------------------------------------------------------------------------
+
+describe('DataGrid axe-core a11y scans', () => {
+  it('minimal grid (5 rows, 3 cols, default renderers, no chrome) has no violations', async () => {
+    const { container } = render(
+      <DataGrid data={makeRows()} columns={plainColumns} rowKey="id" />,
+    );
+    const results = await axe(container, axeOptions);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('grid with chrome columns (controls + row numbers) has no violations', async () => {
+    const { container } = render(
+      <DataGrid
+        data={makeRows()}
+        columns={plainColumns}
+        rowKey="id"
+        chrome={{
+          controls: {
+            actions: [
+              { key: 'view', label: 'View' },
+              { key: 'delete', label: 'Delete' },
+            ],
+          },
+          rowNumbers: { enabled: true, width: 40 },
+        }}
+      />,
+    );
+    const results = await axe(container, axeOptions);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('grid with a sub-grid expanded has no violations', async () => {
+    type Order = { itemId: string; product: string; qty: number };
+    type Parent = { id: string; name: string; orders: Order[] };
+
+    const orderColumns: ColumnDef<Order>[] = [
+      { id: 'product', field: 'product', title: 'Product' },
+      { id: 'qty', field: 'qty', title: 'Qty', cellType: 'numeric' },
+    ];
+
+    const parentColumns: ColumnDef<Parent>[] = [
+      { id: 'name', field: 'name', title: 'Name' },
+      {
+        id: 'orders',
+        field: 'orders',
+        title: 'Orders',
+        cellType: 'subGrid',
+        subGridColumns: orderColumns as ColumnDef[],
+        subGridRowKey: 'itemId',
+      },
+    ];
+
+    const parentData: Parent[] = [
+      {
+        id: 'p1',
+        name: 'Alice',
+        orders: [
+          { itemId: 'o1', product: 'Widget', qty: 2 },
+          { itemId: 'o2', product: 'Gadget', qty: 5 },
+        ],
+      },
+      {
+        id: 'p2',
+        name: 'Bob',
+        orders: [{ itemId: 'o3', product: 'Doohickey', qty: 1 }],
+      },
+    ];
+
+    const { container, getAllByTestId } = render(
+      <DataGrid
+        data={parentData}
+        columns={parentColumns as any}
+        rowKey="id"
+        cellRenderers={cellRendererMap}
+        subGrid={{ maxDepth: 2 }}
+      />,
+    );
+
+    // Open the first sub-grid so the nested grid renders inside the scan.
+    const toggles = getAllByTestId('subgrid-toggle');
+    act(() => {
+      fireEvent.click(toggles[0]!);
+    });
+
+    const results = await axe(container, axeOptions);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('grid with filter menu open on a column has no violations', async () => {
+    const { container, getAllByTestId } = render(
+      <DataGrid
+        data={makeRows()}
+        columns={plainColumns}
+        rowKey="id"
+        filtering={true}
+        showFilterMenu
+      />,
+    );
+
+    // Click the first filter icon to open the Excel-style dropdown.
+    const icons = getAllByTestId('column-filter-icon');
+    act(() => {
+      fireEvent.click(icons[0]!);
+    });
+
+    // Scan the grid container first.
+    const gridResults = await axe(container, axeOptions);
+    expect(gridResults).toHaveNoViolations();
+
+    // The filter menu is portaled to document.body outside of `container`.
+    // Scan it separately so the region (landmark) rule does not trigger on
+    // the surrounding (test-harness) page chrome that jsdom creates.
+    const menu = document.querySelector(
+      '[data-testid="column-filter-menu"]',
+    ) as HTMLElement | null;
+    expect(menu).not.toBeNull();
+    const menuResults = await axe(menu!, axeOptions);
+    expect(menuResults).toHaveNoViolations();
+  });
+
+  it('grid with ghost row pinned to the bottom has no violations', async () => {
+    const { container } = render(
+      <DataGrid
+        data={makeRows()}
+        columns={plainColumns}
+        rowKey="id"
+        ghostRow={true}
+      />,
+    );
+    const results = await axe(container, axeOptions);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/packages/react/src/body/DataGridBody.tsx
+++ b/packages/react/src/body/DataGridBody.tsx
@@ -714,6 +714,12 @@ export function DataGridBody<TData extends Record<string, unknown>>(
               {!rowNumberOnLeft && renderRowNumberCell(row, rowId, rowIdx)}
             </div>
             {isExpanded && renderSubGridExpansionRow && (
+              // The expansion row is a spanning row that holds a nested grid.
+              // A bare role="grid" inside role="row" or role="grid" fails
+              // aria-required-children. The fix is to wrap the nested grid
+              // in a single role="gridcell" so the parent grid sees a valid
+              // row→gridcell hierarchy, and the gridcell's content (the
+              // nested grid) is opaque to the aria-required-children rule.
               <div
                 role="row"
                 data-testid={`subgrid-expansion-${rowId}`}
@@ -724,7 +730,7 @@ export function DataGridBody<TData extends Record<string, unknown>>(
                   depth: subGridDepth,
                 })}
               >
-                <div style={styles.subGridExpansionInner}>
+                <div role="gridcell" style={styles.subGridExpansionInner}>
                   {renderSubGridExpansionRow(rowId, row)}
                 </div>
               </div>
@@ -830,6 +836,10 @@ export function DataGridBody<TData extends Record<string, unknown>>(
             {!rowNumberOnLeft && renderRowNumberCell(row, rowId, rowIdx)}
           </div>
           {isExpanded && renderSubGridExpansionRow && (
+            // See companion branch above for rationale: the nested grid is
+            // wrapped in a single role="gridcell" so the parent grid's
+            // row→gridcell hierarchy stays valid under axe-core's
+            // aria-required-children rule.
             <div
               role="row"
               data-testid={`subgrid-expansion-${rowId}`}
@@ -840,7 +850,7 @@ export function DataGridBody<TData extends Record<string, unknown>>(
                 depth: subGridDepth,
               })}
             >
-              <div style={styles.subGridExpansionInner}>
+              <div role="gridcell" style={styles.subGridExpansionInner}>
                 {renderSubGridExpansionRow(rowId, row)}
               </div>
             </div>

--- a/packages/react/src/cells/PasswordCell/PasswordCell.tsx
+++ b/packages/react/src/cells/PasswordCell/PasswordCell.tsx
@@ -10,6 +10,7 @@
  */
 import React, { useState, useRef, useEffect } from 'react';
 import type { CellValue, ColumnDef } from '@istracked/datagrid-core';
+import { usePasswordInput } from '../hooks/usePasswordInput';
 import * as styles from './PasswordCell.styles';
 
 /**
@@ -74,7 +75,9 @@ export const PasswordCell = React.memo(function PasswordCell<TData = Record<stri
 }: PasswordCellProps<TData>) {
   // Coerce null/undefined to an empty string for safe length calculations
   const strValue = value == null ? '' : String(value);
-  const [revealed, setRevealed] = useState(false);
+  // Shared show/hide toggle + stable ids; `visible` replaces the old local
+  // `revealed` flag without changing any observable behaviour.
+  const { visible: revealed, toggle: toggleRevealed } = usePasswordInput();
   const [draft, setDraft] = useState(strValue);
   const inputRef = useRef<HTMLInputElement>(null);
   // Prevents the unmount-blur from committing a cancelled draft (issue #11).
@@ -102,7 +105,7 @@ export const PasswordCell = React.memo(function PasswordCell<TData = Record<stri
         <button
           type="button"
           aria-label={revealed ? 'Hide password' : 'Reveal password'}
-          onClick={() => setRevealed((v) => !v)}
+          onClick={toggleRevealed}
           style={styles.toggleButton}
         >
           {revealed ? 'Hide' : 'Show'}

--- a/packages/react/src/cells/PasswordConfirmCell/PasswordConfirmCell.tsx
+++ b/packages/react/src/cells/PasswordConfirmCell/PasswordConfirmCell.tsx
@@ -23,8 +23,9 @@
  * @module PasswordConfirmCell
  * @packageDocumentation
  */
-import React, { useState, useRef, useEffect, useId } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import type { CellValue, ColumnDef } from '@istracked/datagrid-core';
+import { usePasswordInput } from '../hooks/usePasswordInput';
 import * as styles from './PasswordConfirmCell.styles';
 
 /** Unicode bullet used to mask each character of the password in display mode. */
@@ -61,19 +62,24 @@ export const PasswordConfirmCell = React.memo(function PasswordConfirmCell<TData
   onCancel,
 }: PasswordConfirmCellProps<TData>) {
   const strValue = value == null ? '' : String(value);
-  const [revealed, setRevealed] = useState(false);
+  // Shared show/hide toggle, autocomplete hint, and stable ids for the two
+  // inputs + the mismatch alert. `confirmMode: true` picks the
+  // `new-password` autocomplete token, matching the original cell.
+  const {
+    visible: revealed,
+    toggle: toggleRevealed,
+    inputType,
+    autoComplete,
+    primaryInputId: input1Id,
+    confirmInputId: input2Id,
+    describedById: mismatchId,
+  } = usePasswordInput({ confirmMode: true });
   const [draft, setDraft] = useState(strValue);
   const [confirm, setConfirm] = useState(strValue);
   // `showMismatch` is only set after a commit attempt so the user doesn't see
   // the error flicker while typing the first character of the confirmation.
   const [showMismatch, setShowMismatch] = useState(false);
   const firstInputRef = useRef<HTMLInputElement>(null);
-  // Stable base id per cell instance so each input has a distinct, non-empty
-  // id and the mismatch alert can be wired back via `aria-describedby`.
-  const baseId = useId();
-  const input1Id = `${baseId}-pw1`;
-  const input2Id = `${baseId}-pw2`;
-  const mismatchId = `${baseId}-mismatch`;
 
   // When entering edit mode, reset drafts to the current value and focus the
   // primary input. Both inputs are pre-populated with the existing value so
@@ -102,7 +108,7 @@ export const PasswordConfirmCell = React.memo(function PasswordConfirmCell<TData
           aria-label={revealed ? 'Hide password' : 'Reveal password'}
           aria-pressed={revealed}
           data-testid="password-confirm-eye-display"
-          onClick={() => setRevealed((v) => !v)}
+          onClick={toggleRevealed}
           style={styles.toggleButton}
         >
           {revealed ? '\u{1F441}' : '\u{1F441}\u2013'}
@@ -134,7 +140,7 @@ export const PasswordConfirmCell = React.memo(function PasswordConfirmCell<TData
     }
   };
 
-  const inputType = revealed ? 'text' : 'password';
+  // `inputType` and `autoComplete` are sourced from usePasswordInput above.
   const mismatch = showMismatch && draft !== confirm;
 
   return (
@@ -145,7 +151,7 @@ export const PasswordConfirmCell = React.memo(function PasswordConfirmCell<TData
           id={input1Id}
           type={inputType}
           value={draft}
-          autoComplete="new-password"
+          autoComplete={autoComplete}
           onChange={(e) => {
             setDraft(e.target.value);
             if (showMismatch) setShowMismatch(false);
@@ -162,7 +168,7 @@ export const PasswordConfirmCell = React.memo(function PasswordConfirmCell<TData
           aria-label={revealed ? 'Hide password' : 'Reveal password'}
           aria-pressed={revealed}
           data-testid="password-confirm-eye"
-          onClick={() => setRevealed((v) => !v)}
+          onClick={toggleRevealed}
           style={styles.toggleButton}
         >
           {revealed ? '\u{1F441}' : '\u{1F441}\u2013'}
@@ -173,7 +179,7 @@ export const PasswordConfirmCell = React.memo(function PasswordConfirmCell<TData
           id={input2Id}
           type={inputType}
           value={confirm}
-          autoComplete="new-password"
+          autoComplete={autoComplete}
           onChange={(e) => {
             setConfirm(e.target.value);
             if (showMismatch) setShowMismatch(false);

--- a/packages/react/src/cells/hooks/__tests__/usePasswordInput.test.ts
+++ b/packages/react/src/cells/hooks/__tests__/usePasswordInput.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Unit tests for {@link usePasswordInput}.
+ *
+ * These tests cover the five invariants the hook advertises:
+ *   1. `visible` defaults based on `initialVisible`.
+ *   2. `toggle()` flips `visible` and updates `inputType` accordingly.
+ *   3. `autoComplete` is derived from `confirmMode`.
+ *   4. The four ids are stable across renders and follow the documented
+ *      `${baseId}-pw1/-pw2/-mismatch` convention.
+ *   5. The `idPrefix` option is applied to `baseId` when provided.
+ */
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { usePasswordInput } from '../usePasswordInput';
+
+describe('usePasswordInput', () => {
+  // -------------------------------------------------------------------------
+  // Defaults
+  // -------------------------------------------------------------------------
+
+  it('defaults visible to false (password is masked on first render)', () => {
+    const { result } = renderHook(() => usePasswordInput());
+    expect(result.current.visible).toBe(false);
+    expect(result.current.inputType).toBe('password');
+  });
+
+  it('respects initialVisible=true', () => {
+    const { result } = renderHook(() => usePasswordInput({ initialVisible: true }));
+    expect(result.current.visible).toBe(true);
+    expect(result.current.inputType).toBe('text');
+  });
+
+  // -------------------------------------------------------------------------
+  // toggle()
+  // -------------------------------------------------------------------------
+
+  it('toggle() flips visible between false and true', () => {
+    const { result } = renderHook(() => usePasswordInput());
+    expect(result.current.visible).toBe(false);
+    act(() => result.current.toggle());
+    expect(result.current.visible).toBe(true);
+    act(() => result.current.toggle());
+    expect(result.current.visible).toBe(false);
+  });
+
+  it('inputType follows visible after toggle()', () => {
+    const { result } = renderHook(() => usePasswordInput());
+    expect(result.current.inputType).toBe('password');
+    act(() => result.current.toggle());
+    expect(result.current.inputType).toBe('text');
+    act(() => result.current.toggle());
+    expect(result.current.inputType).toBe('password');
+  });
+
+  it('toggle is stable across renders (same reference)', () => {
+    const { result, rerender } = renderHook(() => usePasswordInput());
+    const firstToggle = result.current.toggle;
+    rerender();
+    expect(result.current.toggle).toBe(firstToggle);
+  });
+
+  // -------------------------------------------------------------------------
+  // autoComplete
+  // -------------------------------------------------------------------------
+
+  it('autoComplete is "current-password" by default (single-input mode)', () => {
+    const { result } = renderHook(() => usePasswordInput());
+    expect(result.current.autoComplete).toBe('current-password');
+  });
+
+  it('autoComplete is "new-password" when confirmMode=true', () => {
+    const { result } = renderHook(() => usePasswordInput({ confirmMode: true }));
+    expect(result.current.autoComplete).toBe('new-password');
+  });
+
+  // -------------------------------------------------------------------------
+  // id stability & naming convention
+  // -------------------------------------------------------------------------
+
+  it('derives primaryInputId/confirmInputId/describedById from baseId', () => {
+    const { result } = renderHook(() => usePasswordInput());
+    const { baseId, primaryInputId, confirmInputId, describedById } = result.current;
+    expect(primaryInputId).toBe(`${baseId}-pw1`);
+    expect(confirmInputId).toBe(`${baseId}-pw2`);
+    expect(describedById).toBe(`${baseId}-mismatch`);
+  });
+
+  it('all ids are distinct', () => {
+    const { result } = renderHook(() => usePasswordInput());
+    const ids = new Set([
+      result.current.baseId,
+      result.current.primaryInputId,
+      result.current.confirmInputId,
+      result.current.describedById,
+    ]);
+    expect(ids.size).toBe(4);
+  });
+
+  it('baseId is stable across renders', () => {
+    const { result, rerender } = renderHook(() => usePasswordInput());
+    const firstBaseId = result.current.baseId;
+    rerender();
+    expect(result.current.baseId).toBe(firstBaseId);
+  });
+
+  it('ids are stable across renders even when visible toggles', () => {
+    const { result } = renderHook(() => usePasswordInput());
+    const initial = {
+      baseId: result.current.baseId,
+      primaryInputId: result.current.primaryInputId,
+      confirmInputId: result.current.confirmInputId,
+      describedById: result.current.describedById,
+    };
+    act(() => result.current.toggle());
+    expect(result.current.baseId).toBe(initial.baseId);
+    expect(result.current.primaryInputId).toBe(initial.primaryInputId);
+    expect(result.current.confirmInputId).toBe(initial.confirmInputId);
+    expect(result.current.describedById).toBe(initial.describedById);
+  });
+
+  it('separate call sites yield distinct baseIds', () => {
+    const { result: a } = renderHook(() => usePasswordInput());
+    const { result: b } = renderHook(() => usePasswordInput());
+    expect(a.current.baseId).not.toBe(b.current.baseId);
+  });
+
+  // -------------------------------------------------------------------------
+  // idPrefix
+  // -------------------------------------------------------------------------
+
+  it('prepends idPrefix to baseId when provided', () => {
+    const { result } = renderHook(() => usePasswordInput({ idPrefix: 'pw-form-' }));
+    expect(result.current.baseId.startsWith('pw-form-')).toBe(true);
+    expect(result.current.primaryInputId.startsWith('pw-form-')).toBe(true);
+  });
+});

--- a/packages/react/src/cells/hooks/index.ts
+++ b/packages/react/src/cells/hooks/index.ts
@@ -19,3 +19,7 @@ export type { UseSelectStateOptions, UseSelectStateReturn } from './useSelectSta
 /** Hook that manages an array of items for multi-select / tag-list editors. */
 export { useArrayState } from './useArrayState';
 export type { UseArrayStateOptions, UseArrayStateReturn } from './useArrayState';
+
+/** Hook that manages show/hide state + stable ids for password cell editors. */
+export { usePasswordInput } from './usePasswordInput';
+export type { UsePasswordInputOptions, UsePasswordInputResult } from './usePasswordInput';

--- a/packages/react/src/cells/hooks/usePasswordInput.ts
+++ b/packages/react/src/cells/hooks/usePasswordInput.ts
@@ -1,0 +1,137 @@
+/**
+ * usePasswordInput — shared hook for password cell editors.
+ *
+ * Consolidates the small but error-prone set of concerns that
+ * {@link PasswordCell} and {@link PasswordConfirmCell} were both handling
+ * independently:
+ *   - a visibility / reveal toggle,
+ *   - deriving the native input type (`password` vs `text`) from that state,
+ *   - picking an appropriate `autocomplete` token for the browser's password
+ *     manager, and
+ *   - generating stable React ids for the primary / confirm inputs and the
+ *     `aria-describedby` target used by the mismatch alert in confirm mode.
+ *
+ * The hook is deliberately limited to these concerns — draft state, commit
+ * handling, and focus management stay in each cell because their contracts
+ * differ (single-input with Tab-commit vs two-input with mismatch gating).
+ *
+ * @module usePasswordInput
+ */
+import { useCallback, useId, useMemo, useState } from 'react';
+
+/**
+ * Options accepted by {@link usePasswordInput}.
+ *
+ * All fields are optional; the defaults match the behaviour of the original
+ * {@link PasswordCell} (password hidden initially, single input, new-password
+ * autocomplete).
+ */
+export interface UsePasswordInputOptions {
+  /**
+   * Initial value for the `visible` state. Defaults to `false` so password
+   * values are masked on first render, matching typical credential-form UX.
+   */
+  initialVisible?: boolean;
+  /**
+   * Deprecated in this implementation (kept for API compatibility): an
+   * additional prefix applied to the generated `baseId`. React's `useId`
+   * already guarantees uniqueness per-call-site, so this is only useful for
+   * human-readable debugging when multiple password inputs live side by side.
+   */
+  idPrefix?: string;
+  /**
+   * When `true`, the consumer is using both the primary and confirm inputs
+   * and the browser `autoComplete` token becomes `"new-password"` (which
+   * matches the PasswordConfirmCell default). When `false`, `autoComplete`
+   * is `"current-password"` so password managers fill existing credentials
+   * in single-input cells. Defaults to `false`.
+   */
+  confirmMode?: boolean;
+}
+
+/**
+ * Values returned by {@link usePasswordInput}. All ids are stable across
+ * renders for a given call site.
+ */
+export interface UsePasswordInputResult {
+  /** Whether the password is currently revealed (plain text). */
+  visible: boolean;
+  /** Toggles the `visible` flag. Safe to pass directly to `onClick`. */
+  toggle: () => void;
+  /** `'text'` when revealed, `'password'` when masked. */
+  inputType: 'password' | 'text';
+  /**
+   * Autocomplete hint used by browsers / password managers. `'new-password'`
+   * in confirm mode, `'current-password'` otherwise.
+   */
+  autoComplete: 'new-password' | 'current-password';
+  /** Stable base id for the cell instance, produced via `useId()`. */
+  baseId: string;
+  /** Id for the primary password input (`${baseId}-pw1`). */
+  primaryInputId: string;
+  /** Id for the confirmation input (`${baseId}-pw2`), only used in confirm mode. */
+  confirmInputId: string;
+  /** Id for the `aria-describedby` target that surfaces validation errors. */
+  describedById: string;
+}
+
+/**
+ * Manages the show/hide toggle and stable ids shared by password cell
+ * renderers.
+ *
+ * The hook returns a derived `inputType` and `autoComplete` so the consuming
+ * cell's JSX stays declarative (no in-component ternaries for these two). The
+ * id trio (`primaryInputId`, `confirmInputId`, `describedById`) mirrors the
+ * naming convention already used by {@link PasswordConfirmCell} so the
+ * refactor does not perturb any `getByLabelText` / `aria-describedby` wiring.
+ *
+ * @example
+ * ```tsx
+ * const pw = usePasswordInput({ confirmMode: true });
+ * return (
+ *   <>
+ *     <input id={pw.primaryInputId} type={pw.inputType} autoComplete={pw.autoComplete} />
+ *     <input id={pw.confirmInputId} type={pw.inputType} autoComplete={pw.autoComplete} />
+ *     <button onClick={pw.toggle}>{pw.visible ? 'Hide' : 'Show'}</button>
+ *   </>
+ * );
+ * ```
+ */
+export function usePasswordInput(opts?: UsePasswordInputOptions): UsePasswordInputResult {
+  const { initialVisible = false, idPrefix, confirmMode = false } = opts ?? {};
+
+  const [visible, setVisible] = useState<boolean>(initialVisible);
+
+  // `useId` produces a stable, SSR-safe id per call site. The optional
+  // `idPrefix` is appended purely for debuggability — React already
+  // guarantees uniqueness regardless of the prefix.
+  const rawId = useId();
+  const baseId = useMemo(
+    () => (idPrefix ? `${idPrefix}${rawId}` : rawId),
+    [idPrefix, rawId],
+  );
+
+  const toggle = useCallback(() => {
+    setVisible((v) => !v);
+  }, []);
+
+  const inputType: 'password' | 'text' = visible ? 'text' : 'password';
+  const autoComplete: 'new-password' | 'current-password' = confirmMode
+    ? 'new-password'
+    : 'current-password';
+
+  const primaryInputId = `${baseId}-pw1`;
+  const confirmInputId = `${baseId}-pw2`;
+  const describedById = `${baseId}-mismatch`;
+
+  return {
+    visible,
+    toggle,
+    inputType,
+    autoComplete,
+    baseId,
+    primaryInputId,
+    confirmInputId,
+    describedById,
+  };
+}

--- a/packages/react/src/chrome/ChromeHeaderCells.tsx
+++ b/packages/react/src/chrome/ChromeHeaderCells.tsx
@@ -32,16 +32,39 @@ export interface ChromeControlsHeaderCellProps {
  * contiguous. Sticky-pinned at `left: 0`, z-index 5 (configured by
  * `styles.controlsHeaderCell`).
  */
+/**
+ * Visually-hidden style shared by header cells that need text for assistive
+ * tech but must render visually blank. Positions the text off-screen without
+ * collapsing it out of the accessibility tree (unlike `display: none` or
+ * `visibility: hidden` which hide from both visual and screen readers).
+ */
+const visuallyHiddenStyle: React.CSSProperties = {
+  position: 'absolute',
+  width: 1,
+  height: 1,
+  padding: 0,
+  margin: -1,
+  overflow: 'hidden',
+  clip: 'rect(0, 0, 0, 0)',
+  whiteSpace: 'nowrap',
+  border: 0,
+};
+
 export function ChromeControlsHeaderCell(props: ChromeControlsHeaderCellProps) {
-  // Render an empty accessible column header; sticky positioning is baked into
-  // `styles.controlsHeaderCell`.
+  // Render a visually empty column header that still has an accessible name.
+  // axe-core's `empty-table-header` rule requires text content reachable by
+  // screen readers; `aria-label` alone is not always picked up (axe inspects
+  // the element's text subtree for this rule). A visually-hidden span
+  // satisfies the rule and supplies a screen-reader label.
   return (
     <div
       style={styles.controlsHeaderCell(props.width, props.height)}
       role="columnheader"
       data-testid="chrome-controls-header"
       aria-label="Controls"
-    />
+    >
+      <span style={visuallyHiddenStyle}>Controls</span>
+    </div>
   );
 }
 

--- a/packages/react/src/header/column-filter-menu/DataGridColumnFilterMenu.tsx
+++ b/packages/react/src/header/column-filter-menu/DataGridColumnFilterMenu.tsx
@@ -327,63 +327,77 @@ export function DataGridColumnFilterMenu(props: DataGridColumnFilterMenuProps): 
   }
 
   return createPortal(
+    // role="dialog" (not "menu"): this popup is a compound widget containing
+    // a search input, a multi-select listbox, and an OK/Cancel footer. The
+    // WAI-ARIA menu role is reserved for single-action navigation lists and
+    // only permits menuitem/menuitemcheckbox/menuitemradio children, which
+    // makes role="menu" around an <input type="text"> an axe-core violation
+    // of aria-required-children. role="dialog" correctly describes the
+    // enclosing popup and places no constraints on child roles.
     <div
       ref={menuRef}
-      role="menu"
+      role="dialog"
+      aria-label={`Filter ${title ?? field}`}
       data-testid="column-filter-menu"
       data-field={field}
       style={styles.container(position.top, position.left)}
     >
-      {/* Section 1: sort rows. Clicking either sort row fires the sort
-          callback and then closes the menu (matches Excel 365 behaviour). */}
-      <MenuItem
-        testId="column-filter-sort-asc"
-        icon="↑"
-        onClick={() => { onSortAsc(); onClose(); }}
-      >
-        {sortLabel('asc', dataType)}
-      </MenuItem>
-      <MenuItem
-        testId="column-filter-sort-desc"
-        icon="↓"
-        onClick={() => { onSortDesc(); onClose(); }}
-      >
-        {sortLabel('desc', dataType)}
-      </MenuItem>
-      <MenuItem
-        testId="column-filter-sort-by-color"
-        disabled
-        hasCaret
-      >
-        Sort by Color
-      </MenuItem>
+      {/* role="menu" wraps the six menuitem rows so they have the required
+          ARIA parent. Keeping the menu scoped to just these rows is
+          intentional: the dialog's search input, listbox, and OK/Cancel
+          footer are not menuitems and must not live under role="menu". */}
+      <div role="menu" aria-label="Sort and filter actions">
+        {/* Section 1: sort rows. Clicking either sort row fires the sort
+            callback and then closes the menu (matches Excel 365 behaviour). */}
+        <MenuItem
+          testId="column-filter-sort-asc"
+          icon="↑"
+          onClick={() => { onSortAsc(); onClose(); }}
+        >
+          {sortLabel('asc', dataType)}
+        </MenuItem>
+        <MenuItem
+          testId="column-filter-sort-desc"
+          icon="↓"
+          onClick={() => { onSortDesc(); onClose(); }}
+        >
+          {sortLabel('desc', dataType)}
+        </MenuItem>
+        <MenuItem
+          testId="column-filter-sort-by-color"
+          disabled
+          hasCaret
+        >
+          Sort by Color
+        </MenuItem>
 
-      <div role="separator" style={styles.divider} />
+        <div role="separator" style={styles.divider} />
 
-      {/* Section 2: filter rows. Clear-filter is inert unless this column
-          has an active predicate; the caller is responsible for removing
-          only this field's predicate and preserving the rest. */}
-      <MenuItem
-        testId="column-filter-clear"
-        disabled={!hasActiveFilter}
-        onClick={() => { onClearFilter(); onClose(); }}
-      >
-        {`Clear Filter from "${title}"`}
-      </MenuItem>
-      <MenuItem
-        testId="column-filter-by-color"
-        disabled
-        hasCaret
-      >
-        Filter by Color
-      </MenuItem>
-      <MenuItem
-        testId="column-filter-conditions"
-        hasCaret
-        onClick={() => { onOpenCustomFilter(); onClose(); }}
-      >
-        {conditionsLabel(dataType)}
-      </MenuItem>
+        {/* Section 2: filter rows. Clear-filter is inert unless this column
+            has an active predicate; the caller is responsible for removing
+            only this field's predicate and preserving the rest. */}
+        <MenuItem
+          testId="column-filter-clear"
+          disabled={!hasActiveFilter}
+          onClick={() => { onClearFilter(); onClose(); }}
+        >
+          {`Clear Filter from "${title}"`}
+        </MenuItem>
+        <MenuItem
+          testId="column-filter-by-color"
+          disabled
+          hasCaret
+        >
+          Filter by Color
+        </MenuItem>
+        <MenuItem
+          testId="column-filter-conditions"
+          hasCaret
+          onClick={() => { onOpenCustomFilter(); onClose(); }}
+        >
+          {conditionsLabel(dataType)}
+        </MenuItem>
+      </div>
 
       <div role="separator" style={styles.divider} />
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,6 +104,9 @@ importers:
       vitest:
         specifier: ~3.0.5
         version: 3.0.9(@types/debug@4.1.13)(@types/node@25.6.0)(@vitest/browser@3.0.9)(jsdom@25.0.1)(msw@2.13.3(@types/node@25.6.0)(typescript@5.7.3))(yaml@2.8.3)
+      vitest-axe:
+        specifier: ^0.1.0
+        version: 0.1.0(vitest@3.0.9)
 
   packages/core:
     dependencies:
@@ -1580,6 +1583,10 @@ packages:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
 
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
   character-entities-html4@2.1.0:
     resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
 
@@ -2236,6 +2243,9 @@ packages:
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
+
+  lodash-es@4.18.1:
+    resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
 
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
@@ -3123,6 +3133,11 @@ packages:
         optional: true
       yaml:
         optional: true
+
+  vitest-axe@0.1.0:
+    resolution: {integrity: sha512-jvtXxeQPg8R/2ANTY8QicA5pvvdRP4F0FsVUAHANJ46YCDASie/cuhlSzu0DGcLmZvGBSBNsNuK3HqfaeknyvA==}
+    peerDependencies:
+      vitest: '>=0.16.0'
 
   vitest@3.0.9:
     resolution: {integrity: sha512-BbcFDqNyBlfSpATmTtXOAOj71RNKDDvjBM/uPfnxxVGrG+FSH2RQIwgeEngTaTkuU/h0ScFvf+tRcKfYXzBybQ==}
@@ -4534,6 +4549,8 @@ snapshots:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
+  chalk@5.6.2: {}
+
   character-entities-html4@2.1.0: {}
 
   character-entities-legacy@3.0.0: {}
@@ -5198,6 +5215,8 @@ snapshots:
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
+
+  lodash-es@4.18.1: {}
 
   lodash.merge@4.6.2: {}
 
@@ -6328,6 +6347,16 @@ snapshots:
       '@types/node': 25.6.0
       fsevents: 2.3.3
       yaml: 2.8.3
+
+  vitest-axe@0.1.0(vitest@3.0.9):
+    dependencies:
+      aria-query: 5.3.2
+      axe-core: 4.11.3
+      chalk: 5.6.2
+      dom-accessibility-api: 0.5.16
+      lodash-es: 4.18.1
+      redent: 3.0.0
+      vitest: 3.0.9(@types/debug@4.1.13)(@types/node@25.6.0)(@vitest/browser@3.0.9)(jsdom@25.0.1)(msw@2.13.3(@types/node@25.6.0)(typescript@5.7.3))(yaml@2.8.3)
 
   vitest@3.0.9(@types/debug@4.1.13)(@types/node@25.6.0)(@vitest/browser@3.0.9)(jsdom@25.0.1)(msw@2.13.3(@types/node@25.6.0)(typescript@5.7.3))(yaml@2.8.3):
     dependencies:


### PR DESCRIPTION
## Summary

Two independent catch-up items for the post-merge hardening pass:

1. **axe-core a11y scans** — Adds `vitest-axe` and five accessibility scans covering minimal grid, chrome columns (controls + row numbers), expanded sub-grid, open filter menu, and ghost row. Color-contrast rule is disabled (jsdom cannot compute layout-dependent colors); every other default rule is active. The scans surfaced three real violations, which are fixed in the same commit:
   - `ChromeControlsHeaderCell` had only `aria-label` with no text content — added a visually-hidden span so `empty-table-header` passes.
   - Sub-grid expansion nested `role=\"grid\"` directly under `role=\"row\"` — wrapped in `role=\"gridcell\"` so the parent grid's row→gridcell hierarchy stays valid.
   - `DataGridColumnFilterMenu` had `role=\"menu\"` around an `<input>`, listbox, and OK/Cancel footer — switched outer role to `dialog` with `aria-label`, scoped a `role=\"menu\"` to just the six menuitem rows.

2. **usePasswordInput shared hook** — Extracts the show/hide toggle + stable-id + autoComplete/inputType derivation shared between `PasswordCell` and `PasswordConfirmCell` into `packages/react/src/cells/hooks/usePasswordInput.ts`. Both cells refactored to consume it with no API changes. All existing password-cell tests pass unchanged.

## Test plan

- [x] `pnpm test` — 85 files / 1700 tests pass (baseline 1682 + 5 axe + 13 hook = 1700)
- [x] `pnpm typecheck` — clean
- [x] `pnpm build` — all four packages build cleanly
- [x] Pre-commit hook (typecheck + build + test) passed on both commits
- [ ] CI green against `review/post-merge-hardening`