### PR TITLE
ci: add Playwright e2e + Chromatic visual regression

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,131 @@
+name: E2E + Visual Regression
+
+on:
+  push:
+    branches: [ main, develop ]
+  pull_request:
+    branches: [ main ]
+
+# Two jobs: `playwright` for headless end-to-end coverage of the grid,
+# and `chromatic` for visual-regression snapshots of every story.
+#
+# The `chromatic` job is guarded behind the repo-level secret
+# `CHROMATIC_PROJECT_TOKEN`. When the secret is not set (e.g. forks or
+# brand-new checkouts), the job is skipped — it MUST NOT fail the build
+# under those conditions. Chromatic itself runs with `--exit-zero-on-changes`
+# so baseline updates are never merge-blocking; reviewers accept/reject
+# changes through the Chromatic web UI.
+#
+# Add `playwright / e2e` to the branch-protection required checks on `main`
+# once this workflow has a passing run. The existing `verify-precommit-parity`
+# check stays in place; this is additive.
+jobs:
+  playwright:
+    name: e2e
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [22.x]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install pnpm
+      uses: pnpm/action-setup@v4
+
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'pnpm'
+
+    - name: Install dependencies
+      run: pnpm install --frozen-lockfile
+
+    - name: Cache Playwright browsers
+      id: playwright-cache
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/ms-playwright
+        key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+
+    - name: Install Playwright Chromium
+      if: steps.playwright-cache.outputs.cache-hit != 'true'
+      run: pnpm exec playwright install --with-deps chromium
+
+    - name: Install Playwright system deps (cache hit path)
+      if: steps.playwright-cache.outputs.cache-hit == 'true'
+      run: pnpm exec playwright install-deps chromium
+
+    - name: Build workspace packages
+      # Storybook resolves `@istracked/datagrid-*` via Vite aliases to the
+      # package `src` directories (see .storybook/main.ts) so the build is
+      # not strictly required for E2E. It is kept here to surface build
+      # breakages early rather than only at runtime inside the iframe.
+      run: pnpm run build
+
+    - name: Run Playwright tests
+      run: pnpm exec playwright test
+      env:
+        CI: 'true'
+
+    - name: Upload Playwright HTML report
+      if: failure()
+      uses: actions/upload-artifact@v4
+      with:
+        name: playwright-report
+        path: playwright-report/
+        retention-days: 14
+
+    - name: Upload Playwright test artifacts
+      if: failure()
+      uses: actions/upload-artifact@v4
+      with:
+        name: playwright-test-results
+        path: test-results/
+        retention-days: 14
+
+  chromatic:
+    name: visual
+    runs-on: ubuntu-latest
+    # Skip entirely when the project token is absent. Forks, first-run
+    # clones, or any environment without the secret pass through without
+    # failing. `secrets` can only be referenced inside `if` expressions
+    # as a value check — a missing secret evaluates to an empty string.
+    if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        # Chromatic needs the full commit history to infer the baseline
+        # from the last accepted commit on the base branch.
+        fetch-depth: 0
+
+    - name: Install pnpm
+      uses: pnpm/action-setup@v4
+
+    - name: Use Node.js 22.x
+      uses: actions/setup-node@v4
+      with:
+        node-version: 22.x
+        cache: 'pnpm'
+
+    - name: Install dependencies
+      run: pnpm install --frozen-lockfile
+
+    - name: Guard – confirm CHROMATIC_PROJECT_TOKEN is present
+      id: token-check
+      run: |
+        if [ -z "${{ secrets.CHROMATIC_PROJECT_TOKEN }}" ]; then
+          echo "token_present=false" >> "$GITHUB_OUTPUT"
+          echo "::warning::CHROMATIC_PROJECT_TOKEN secret is not set; skipping Chromatic upload."
+        else
+          echo "token_present=true" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Run Chromatic
+      if: steps.token-check.outputs.token_present == 'true'
+      run: pnpm run chromatic
+      env:
+        CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -12,6 +12,46 @@ A high-performance, fully-featured datagrid component library for React 19. Buil
 
 ---
 
+## Table of Contents
+
+- [Development](#development)
+  - [Prerequisites](#prerequisites)
+  - [Setup](#setup)
+  - [NPM Commands](#npm-commands)
+  - [End-to-end tests (Playwright)](#end-to-end-tests-playwright)
+  - [Visual regression (Chromatic)](#visual-regression-chromatic)
+  - [Branch protection](#branch-protection)
+  - [Playground](#playground)
+  - [Storybook](#storybook)
+  - [Project Structure](#project-structure)
+  - [Test Suite](#test-suite)
+  - [Tech Stack](#tech-stack)
+- [Packages](#packages)
+- [Features](#features)
+  - [Core Engine](#core-engine)
+  - [React Components](#react-components)
+  - [State Management (Jotai Atoms)](#state-management-jotai-atoms)
+  - [15 Cell Types](#15-cell-types)
+  - [Extensions](#extensions)
+  - [MUI Theme Bridge](#mui-theme-bridge)
+- [Quick Start](#quick-start)
+  - [Chrome Columns](#chrome-columns)
+  - [Master-Detail](#master-detail)
+  - [Ghost Row](#ghost-row)
+  - [Extensions](#extensions-1)
+  - [MUI Integration](#mui-integration)
+  - [Imperative Control via Hooks](#imperative-control-via-hooks)
+  - [Fine-Grained Atom Subscriptions](#fine-grained-atom-subscriptions)
+- [Configuration Reference](#configuration-reference)
+  - [DataGrid Props](#datagrid-props)
+  - [Event Callbacks](#event-callbacks)
+  - [Column Definition](#column-definition)
+  - [Grid Event Types](#grid-event-types)
+  - [Writing Extensions](#writing-extensions)
+- [License](#license)
+
+---
+
 ## Development
 
 ### Prerequisites
@@ -53,7 +93,7 @@ pnpm install
 | `pnpm run test:e2e:install` | Install the Chromium browser binary Playwright uses (run once per machine) |
 | `pnpm run chromatic` | Upload Storybook to [Chromatic](https://www.chromatic.com/) for visual-regression review (requires `CHROMATIC_PROJECT_TOKEN`) |
 
-#### End-to-end tests
+### End-to-end tests (Playwright)
 
 The `e2e/` directory contains Playwright specs that drive a real browser
 against the Storybook instance:
@@ -67,7 +107,7 @@ against the Storybook instance:
   markdown links) must not produce live `javascript:` hrefs or inline
   event handlers.
 
-Local workflow:
+#### Running the suite
 
 ```bash
 pnpm install
@@ -80,7 +120,103 @@ The Playwright config spins up `storybook dev -p 6006` as its
 you do not need to pre-start Storybook. When a dev server is already
 running locally it is reused instead of a second being spawned.
 
-#### Visual regression (Chromatic)
+Useful flags:
+
+```bash
+pnpm exec playwright test --headed              # open a real Chromium window
+pnpm exec playwright test --debug               # step-through with the Playwright inspector
+pnpm exec playwright test --ui                  # interactive time-travel UI mode
+pnpm exec playwright test e2e/grid-keyboard     # target a single spec file
+pnpm exec playwright test -g "commits on Enter" # filter by test title (grep)
+pnpm exec playwright test --repeat-each=10      # flake hunt by running each test 10×
+```
+
+#### Viewing the HTML report
+
+After any run Playwright writes an HTML report to `playwright-report/`.
+Open it with:
+
+```bash
+pnpm exec playwright show-report
+```
+
+This launches a local server (default `http://localhost:9323`) and opens
+the report in your browser. The report includes per-test traces, video,
+screenshots, network logs, and console output when captured. On CI the
+same directory is uploaded as an artifact on failure — download the
+`playwright-report` artifact from the failed job and run `show-report`
+against the unzipped directory:
+
+```bash
+pnpm exec playwright show-report ./playwright-report
+```
+
+#### Recording new tests with codegen
+
+Playwright's built-in generator drives the browser and emits test code as
+you click, type, and navigate:
+
+```bash
+# 1) start Storybook separately so codegen can attach to it
+pnpm run storybook
+
+# 2) in a second terminal, open codegen against the story you want to cover
+pnpm exec playwright codegen http://localhost:6006/iframe.html?id=basic-grid--default
+```
+
+As you interact with the page, codegen writes selectors (preferring
+`getByRole` / `getByLabel` / `getByTestId` over CSS) and actions to a
+side panel. Copy the generated test body into a new `e2e/*.spec.ts` file,
+then run it with `pnpm exec playwright test e2e/<your-spec>.spec.ts`.
+
+Tip: prefer role-based selectors from the generator's suggestions — they
+survive layout refactors and exercise a11y wiring, which is exactly what
+the existing `grid-subgrid.spec.ts` relies on.
+
+#### Recording tests with the Playwright CRX Chrome extension
+
+The [Playwright CRX](https://chrome.google.com/webstore/detail/playwright-crx) Chrome
+extension is a browser-resident variant of `codegen` that records tests
+against pages you open normally — useful when a deploy preview, a remote
+staging build, or a live product environment is easier to exercise than
+starting Storybook locally, and when you want to click through the same
+flow your end users hit.
+
+1. Install the extension from the Chrome Web Store. Pin it to the
+   toolbar so the record button is always visible.
+2. Navigate to the page you want to cover. For this repo that is
+   typically `http://localhost:6006/iframe.html?id=<story-id>` after
+   `pnpm run storybook`, or a deployed Storybook/Chromatic preview URL.
+3. Click the Playwright CRX icon, then **Record**. Interact with the page
+   exactly as a user would — click cells, press keys, drag handles, open
+   menus. The extension panel streams the generated Playwright script in
+   real time.
+4. When finished, click **Copy** in the panel and paste the generated
+   test into a new file under `e2e/` (e.g. `e2e/grid-my-flow.spec.ts`).
+   Wrap it in the standard test harness:
+
+   ```ts
+   import { test, expect } from '@playwright/test';
+
+   test('my recorded flow', async ({ page }) => {
+     // paste codegen output here
+   });
+   ```
+
+5. Run it with `pnpm exec playwright test e2e/grid-my-flow.spec.ts` and
+   tighten selectors / assertions by hand where the generator chose
+   something brittle (e.g. nth-child CSS). Prefer `getByRole`,
+   `getByLabel`, and `getByTestId`.
+6. Replace any hard-coded absolute URLs from the recorder with the
+   config-relative `page.goto('/iframe.html?id=…')` so the spec survives
+   port changes and CI.
+
+Because CRX runs in the same profile as your live browser session, do
+not paste cookies, auth tokens, or session storage into committed specs.
+Use Playwright storage-state fixtures for anything that needs auth, and
+commit only the scripted navigation.
+
+### Visual regression (Chromatic)
 
 `pnpm run chromatic` uploads the full Storybook to Chromatic for
 per-story visual diffing. Chromatic runs with `--exit-zero-on-changes`,
@@ -93,7 +229,7 @@ and variables → Actions → New repository secret*. When the secret is
 absent the Chromatic job is skipped with a warning — builds never fail
 for missing-token reasons.
 
-#### Branch protection
+### Branch protection
 
 Recommended required checks on `main`:
 
@@ -103,7 +239,7 @@ Recommended required checks on `main`:
 The `visual` job is intentionally left optional so forks without the
 Chromatic token can still pass CI.
 
-#### Per-Package Commands (run from any `packages/*` directory)
+### Per-Package Commands
 
 Each package (`core`, `react`, `extensions`, `mui`) exposes the same two scripts:
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,59 @@ pnpm install
 | `pnpm run validate` | Full CI validation: type-check + build all packages + run all tests |
 | `pnpm run docs` | Generate API documentation with TypeDoc |
 | `pnpm run docs:open` | Generate API docs and open them in the browser |
+| `pnpm run test:e2e` | Run the Playwright end-to-end suite against Storybook (auto-starts Storybook) |
+| `pnpm run test:e2e:install` | Install the Chromium browser binary Playwright uses (run once per machine) |
+| `pnpm run chromatic` | Upload Storybook to [Chromatic](https://www.chromatic.com/) for visual-regression review (requires `CHROMATIC_PROJECT_TOKEN`) |
+
+#### End-to-end tests
+
+The `e2e/` directory contains Playwright specs that drive a real browser
+against the Storybook instance:
+
+- `e2e/grid-keyboard.spec.ts` — arrow-key navigation, Enter/Tab commit,
+  Escape cancel on an editable text cell.
+- `e2e/grid-subgrid.spec.ts` — sub-grid expansion, `aria-labelledby`
+  linkage between the nested grid and its parent cell, keyboard
+  reachability.
+- `e2e/grid-xss.spec.ts` — hostile RichText payloads (raw HTML and
+  markdown links) must not produce live `javascript:` hrefs or inline
+  event handlers.
+
+Local workflow:
+
+```bash
+pnpm install
+pnpm run test:e2e:install   # one-off: downloads Chromium
+pnpm run test:e2e            # boots Storybook and runs all specs headless
+```
+
+The Playwright config spins up `storybook dev -p 6006` as its
+`webServer`, so a single `pnpm run test:e2e` invocation is sufficient —
+you do not need to pre-start Storybook. When a dev server is already
+running locally it is reused instead of a second being spawned.
+
+#### Visual regression (Chromatic)
+
+`pnpm run chromatic` uploads the full Storybook to Chromatic for
+per-story visual diffing. Chromatic runs with `--exit-zero-on-changes`,
+so visual changes surface in the Chromatic review UI rather than
+blocking the merge.
+
+The corresponding GitHub Actions job is gated behind a repository secret
+named `CHROMATIC_PROJECT_TOKEN`. Configure it under *Settings → Secrets
+and variables → Actions → New repository secret*. When the secret is
+absent the Chromatic job is skipped with a warning — builds never fail
+for missing-token reasons.
+
+#### Branch protection
+
+Recommended required checks on `main`:
+
+- `verify-precommit-parity / verify` (existing)
+- `E2E + Visual Regression / e2e` (added by this PR)
+
+The `visual` job is intentionally left optional so forks without the
+Chromatic token can still pass CI.
 
 #### Per-Package Commands (run from any `packages/*` directory)
 

--- a/e2e/grid-keyboard.spec.ts
+++ b/e2e/grid-keyboard.spec.ts
@@ -1,0 +1,126 @@
+/**
+ * End-to-end: keyboard navigation inside the grid.
+ *
+ * Drives the `Examples/Basic Grid → Default` story (50 employees, cell
+ * selection, `keyboardNavigation` enabled, text-editable `name` column).
+ *
+ * Assertions target concrete DOM state only — `aria-selected`, cell text
+ * content, and `data-editing`. No screenshots.
+ *
+ * Flow exercised:
+ *   1. Click the first cell in the `name` column → it becomes selected.
+ *   2. Press ArrowDown → selection moves to the next row in the same column.
+ *   3. Press Enter → cell enters edit mode.
+ *   4. Type a new value → commit with Enter → new value appears in the DOM
+ *      and edit mode exits.
+ *   5. Click another cell → press Enter → type → press Escape → the original
+ *      value is preserved (cancellation works).
+ */
+import { test, expect, type Locator, type Page } from '@playwright/test';
+
+// Storybook renders each story inside a <iframe id="storybook-preview-iframe">
+// on the manager page. Targeting `/iframe.html` directly skips the manager
+// chrome and gives us the story root as the document body, which makes
+// key events land on the grid without any indirection.
+const BASIC_GRID_URL = '/iframe.html?viewMode=story&id=examples-basic-grid--default';
+
+/** Returns the first gridcell locator for the given row id / field. */
+function cell(page: Page, rowId: string, field: string): Locator {
+  // `data-row-id` / `data-field` are rendered by DataGridBody.tsx on every
+  // gridcell div. Pairing them yields a deterministic locator that ignores
+  // virtualisation-induced DOM reordering.
+  return page.locator(
+    `[role="gridcell"][data-row-id="${rowId}"][data-field="${field}"]`,
+  );
+}
+
+test.describe('Basic Grid – keyboard navigation', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(BASIC_GRID_URL);
+    // Wait for the grid root to render; `role="grid"` is on the DataGrid
+    // container in DataGrid.tsx.
+    await page.locator('[role="grid"]').first().waitFor({ state: 'visible' });
+  });
+
+  test('ArrowDown moves selection down one row', async ({ page }) => {
+    const first = cell(page, '1', 'name');
+    await first.click();
+    await expect(first).toHaveAttribute('aria-selected', 'true');
+
+    // Move focus to the grid root so ArrowDown is captured by the grid
+    // keyboard handler rather than by the document scroll behaviour.
+    await page.locator('[role="grid"]').first().focus();
+    await page.keyboard.press('ArrowDown');
+
+    const second = cell(page, '2', 'name');
+    await expect(second).toHaveAttribute('aria-selected', 'true');
+    await expect(first).toHaveAttribute('aria-selected', 'false');
+  });
+
+  test('Enter enters edit mode and a second Enter commits the new value', async ({ page }) => {
+    const target = cell(page, '3', 'name');
+    await target.click();
+    await expect(target).toHaveAttribute('aria-selected', 'true');
+
+    // Capture the pre-edit value so we can confirm it actually changes.
+    const originalText = (await target.innerText()).trim();
+
+    // Enter → edit mode. TextCell.tsx renders an <input> inside the cell.
+    await page.locator('[role="grid"]').first().focus();
+    await page.keyboard.press('Enter');
+    const input = target.locator('input[type="text"]');
+    await expect(input).toBeVisible();
+
+    // Select-all then type a new value, then commit with Enter.
+    await input.press('Control+a');
+    const newValue = `E2E-Name-${Date.now()}`;
+    await input.pressSequentially(newValue, { delay: 5 });
+    await input.press('Enter');
+
+    // After commit, the <input> disappears and the cell renders the new text.
+    await expect(input).toHaveCount(0);
+    await expect(target).toContainText(newValue);
+    expect(newValue).not.toBe(originalText);
+  });
+
+  test('Escape cancels the edit and preserves the original value', async ({ page }) => {
+    const target = cell(page, '5', 'name');
+    await target.click();
+    await expect(target).toHaveAttribute('aria-selected', 'true');
+
+    const originalText = (await target.innerText()).trim();
+
+    await page.locator('[role="grid"]').first().focus();
+    await page.keyboard.press('Enter');
+    const input = target.locator('input[type="text"]');
+    await expect(input).toBeVisible();
+
+    await input.press('Control+a');
+    await input.pressSequentially('garbage-should-not-commit', { delay: 2 });
+    await input.press('Escape');
+
+    await expect(input).toHaveCount(0);
+    // Original value is preserved verbatim.
+    await expect(target).toContainText(originalText);
+    await expect(target).not.toContainText('garbage-should-not-commit');
+  });
+
+  test('Tab commits the draft value (Enter-parity per issue #10)', async ({ page }) => {
+    const target = cell(page, '7', 'name');
+    await target.click();
+    await expect(target).toHaveAttribute('aria-selected', 'true');
+
+    await page.locator('[role="grid"]').first().focus();
+    await page.keyboard.press('Enter');
+    const input = target.locator('input[type="text"]');
+    await expect(input).toBeVisible();
+
+    await input.press('Control+a');
+    const newValue = `tab-commit-${Date.now()}`;
+    await input.pressSequentially(newValue, { delay: 2 });
+    await input.press('Tab');
+
+    await expect(input).toHaveCount(0);
+    await expect(target).toContainText(newValue);
+  });
+});

--- a/e2e/grid-subgrid.spec.ts
+++ b/e2e/grid-subgrid.spec.ts
@@ -1,0 +1,116 @@
+/**
+ * End-to-end: sub-grid expansion + ARIA wiring (WS-G hardening).
+ *
+ * Drives the `Examples/Sub-Grid → BasicSubGrid` story which puts a
+ * `cellType: "subGrid"` column on each parent row. WS-G wires the nested
+ * grid's DOM id and `aria-labelledby` in `DataGrid.tsx` (lines 1101-1123):
+ *
+ *   - Nested grid id:         `${parentGridId}-row-${rowId}-subgrid`
+ *   - Nested grid aria-label: the parent cell id
+ *
+ * The story uses `MuiDataGrid` which plugs in `MuiSubGridCell` as the
+ * toggle renderer. The parent grid and its nested grid wiring is the same
+ * regardless of which toggle cell is used — the id / aria-labelledby pair
+ * lives in the parent `DataGrid` component itself.
+ *
+ * Assertions here are against live DOM only: attribute values, element
+ * counts, and focus reachability after Tab.
+ */
+import { test, expect, type Page } from '@playwright/test';
+
+const SUBGRID_URL = '/iframe.html?viewMode=story&id=examples-sub-grid--basic-sub-grid';
+
+async function waitForGrid(page: Page): Promise<void> {
+  await page.locator('[role="grid"]').first().waitFor({ state: 'visible' });
+}
+
+test.describe('Sub-grid – ARIA wiring + expansion', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(SUBGRID_URL);
+    await waitForGrid(page);
+  });
+
+  test('clicking the expander mounts a nested grid with the expected id format', async ({ page }) => {
+    // Exactly one parent grid exists before any toggle is clicked. The
+    // count of `[role="grid"]` must increase when we expand a row.
+    const initialGridCount = await page.locator('[role="grid"]').count();
+    expect(initialGridCount).toBe(1);
+
+    const firstToggle = page.locator('[data-testid="subgrid-toggle"]').first();
+    await expect(firstToggle).toBeVisible();
+    await expect(firstToggle).toHaveAttribute('data-expanded', 'false');
+
+    await firstToggle.click();
+    await expect(firstToggle).toHaveAttribute('data-expanded', 'true');
+
+    // After expansion the nested grid is mounted — there are now >= 2 grids.
+    const gridsAfter = page.locator('[role="grid"]');
+    await expect(gridsAfter).toHaveCount(2);
+
+    // The nested grid's id must match the WS-G contract:
+    //   `${parentGridId}-row-${rowId}-subgrid`
+    const nestedGridId = await gridsAfter.nth(1).getAttribute('id');
+    expect(nestedGridId).toBeTruthy();
+    expect(nestedGridId!).toMatch(/-row-.+-subgrid$/);
+  });
+
+  test('nested grid carries aria-labelledby pointing at an in-DOM parent cell id', async ({ page }) => {
+    const firstToggle = page.locator('[data-testid="subgrid-toggle"]').first();
+    await firstToggle.click();
+
+    const gridsAfter = page.locator('[role="grid"]');
+    await expect(gridsAfter).toHaveCount(2);
+
+    const nested = gridsAfter.nth(1);
+    const labelledBy = await nested.getAttribute('aria-labelledby');
+    expect(labelledBy, 'nested grid must expose aria-labelledby').toBeTruthy();
+
+    // The referenced parent cell id must follow the WS-G format:
+    //   `${parentGridId}-row-${rowId}-cell-${field}`
+    expect(labelledBy!).toMatch(/-row-.+-cell-/);
+
+    // Additionally the nested grid id must not equal the parent grid id
+    // (self-reference would silently break announcements).
+    const parentId = await gridsAfter.nth(0).getAttribute('id');
+    const nestedId = await nested.getAttribute('id');
+    expect(nestedId).not.toBe(parentId);
+  });
+
+  test('expanded sub-grid renders inner cells and Tab reaches a grid', async ({ page }) => {
+    const firstToggle = page.locator('[data-testid="subgrid-toggle"]').first();
+    await firstToggle.click();
+
+    const nested = page.locator('[role="grid"]').nth(1);
+    await expect(nested).toBeVisible();
+
+    // Inner grid must render its own gridcells — proves the nested DataGrid
+    // actually mounted and received the nested row data.
+    const innerCells = nested.locator('[role="gridcell"]');
+    await expect(innerCells.first()).toBeVisible();
+    expect(await innerCells.count()).toBeGreaterThan(0);
+
+    // "Focus trap" substitute: from the expander, Tab must eventually land
+    // on some element whose ancestor chain includes a `role="grid"` — we
+    // tolerate either the nested grid root (tabIndex=0) or any focused
+    // descendant of any grid. Without a dedicated focus trap we just want
+    // to confirm Tab-ability doesn't escape the grids immediately.
+    await firstToggle.focus();
+    let reachedGrid = false;
+    for (let i = 0; i < 15; i++) {
+      reachedGrid = await page.evaluate(() => {
+        let node = document.activeElement as HTMLElement | null;
+        while (node) {
+          if (node.getAttribute && node.getAttribute('role') === 'grid') return true;
+          node = node.parentElement;
+        }
+        return false;
+      });
+      if (reachedGrid) break;
+      await page.keyboard.press('Tab');
+    }
+    expect(
+      reachedGrid,
+      'Tab from the expander must reach a grid (outer or nested) within a handful of presses',
+    ).toBe(true);
+  });
+});

--- a/e2e/grid-xss.spec.ts
+++ b/e2e/grid-xss.spec.ts
@@ -1,0 +1,165 @@
+/**
+ * End-to-end: RichText cell XSS hardening (WS-A/B contract at the UI level).
+ *
+ * Drives the `Examples/Cell Types → AllCellTypes` story which contains an
+ * editable `richText` column rendered by `RichTextCell`. The cell stores
+ * GitHub-Flavored Markdown and renders it via `react-markdown` +
+ * `remark-gfm`, deliberately WITHOUT `rehype-raw` so embedded HTML is
+ * treated as plain text.
+ *
+ * This spec types two different hostile payloads into the cell and, after
+ * the draft is committed, scans the rendered DOM for any javascript:
+ * href or inline on* event handler. Both must be absent.
+ *
+ *   Payload 1 (raw HTML — the example from the task spec):
+ *       <a href="javascript:alert(1)">x</a>
+ *     Expected: no <a> element with `javascript:` href, no inline event
+ *     handler, and no unescaped `javascript:` string in the rendered HTML.
+ *
+ *   Payload 2 (markdown link with a hostile URL):
+ *       [x](javascript:alert(1))
+ *     Expected: react-markdown's default urlTransform replaces the scheme
+ *     with `#` (or similar neutered value), so the rendered <a> href does
+ *     not start with `javascript:`.
+ */
+import { test, expect, type Locator, type Page } from '@playwright/test';
+
+const CELL_TYPES_URL = '/iframe.html?viewMode=story&id=examples-cell-types--all-cell-types';
+
+function richTextCell(page: Page, rowId: string): Locator {
+  return page.locator(
+    `[role="gridcell"][data-row-id="${rowId}"][data-field="richText"]`,
+  );
+}
+
+async function commitPayload(page: Page, cell: Locator, payload: string): Promise<void> {
+  // Enter edit mode via double-click: the grid config on this story uses
+  // `selectionMode: "cell"` + `keyboardNavigation`, and RichTextCell starts
+  // editing only when the grid flips its editing state. Double-click is the
+  // gesture wired up in DataGridBody.tsx `onDoubleClick`.
+  await cell.dblclick();
+  const textarea = cell.locator('textarea').first();
+  await expect(textarea).toBeVisible();
+
+  // Replace draft with the hostile payload.
+  await textarea.press('Control+a');
+  await textarea.press('Delete');
+  // Use fill() for the payload to avoid any accidental key-binding triggers
+  // (Ctrl+B, Ctrl+I, Ctrl+K) that the cell listens for.
+  await textarea.fill(payload);
+
+  // Blur to commit. RichTextCell.tsx commits on blur (unless the new focus
+  // target is an in-toolbar button).
+  await page.locator('[role="grid"]').first().click({ position: { x: 2, y: 2 } });
+  await expect(textarea).toHaveCount(0);
+}
+
+test.describe('RichText cell – XSS hardening', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(CELL_TYPES_URL);
+    await page.locator('[role="grid"]').first().waitFor({ state: 'visible' });
+  });
+
+  test('raw HTML <a href="javascript:"> is not rendered as a live link', async ({ page }) => {
+    const cell = richTextCell(page, '1');
+    await expect(cell).toBeVisible();
+
+    const hostile = '<a href="javascript:alert(1)">x</a>';
+    await commitPayload(page, cell, hostile);
+
+    // Scan the rendered markdown body for hostile surface area.
+    const rendered = cell.locator('[data-testid="richtext-rendered"]');
+    await expect(rendered).toBeVisible();
+
+    // 1. No anchor element with a javascript: href. react-markdown is
+    //    deliberately wired without `rehype-raw`, so raw HTML tags in the
+    //    markdown source are not rendered as tags — they come through as
+    //    escaped text. The hostile `<a>` must therefore not exist as an
+    //    actual element in the live DOM.
+    const jsAnchor = rendered.locator('a[href^="javascript:" i]');
+    await expect(jsAnchor).toHaveCount(0);
+
+    // 2. No live element carries an inline on*= handler attribute. Walk
+    //    the rendered DOM and collect all attribute names from every
+    //    element — comparing against the live attribute list rather than
+    //    the innerHTML string avoids false positives from escaped text
+    //    content like `&lt;a onclick=...&gt;`.
+    const hostileAttrs = await rendered.evaluate((root) => {
+      const offenders: string[] = [];
+      const walker = document.createTreeWalker(root, NodeFilter.SHOW_ELEMENT);
+      let node: Element | null = root;
+      while (node) {
+        for (const attr of Array.from((node as Element).attributes ?? [])) {
+          if (/^on/i.test(attr.name)) {
+            offenders.push(`${(node as Element).tagName.toLowerCase()}[${attr.name}=${attr.value}]`);
+          }
+        }
+        node = walker.nextNode() as Element | null;
+      }
+      return offenders;
+    });
+    expect(
+      hostileAttrs,
+      'rendered DOM must not carry any on*= inline event handlers',
+    ).toEqual([]);
+
+    // 3. No live element has a href starting with `javascript:` (any
+    //    tag — not just <a>).
+    const hostileHrefs = await rendered.evaluate((root) => {
+      const hits: string[] = [];
+      root.querySelectorAll('[href]').forEach((el) => {
+        const href = el.getAttribute('href') ?? '';
+        if (/^\s*javascript:/i.test(href)) {
+          hits.push(`${el.tagName.toLowerCase()}[href=${href}]`);
+        }
+      });
+      return hits;
+    });
+    expect(
+      hostileHrefs,
+      'rendered DOM must not carry any element with a javascript: href',
+    ).toEqual([]);
+  });
+
+  test('markdown link with javascript: scheme is neutered', async ({ page }) => {
+    const cell = richTextCell(page, '2');
+    await expect(cell).toBeVisible();
+
+    const hostile = '[click me](javascript:alert(1))';
+    await commitPayload(page, cell, hostile);
+
+    const rendered = cell.locator('[data-testid="richtext-rendered"]');
+    await expect(rendered).toBeVisible();
+
+    // react-markdown v10's default urlTransform replaces unsafe schemes
+    // with the empty string / `#`, so the resulting <a href> must not
+    // start with `javascript:`.
+    const anchors = rendered.locator('a');
+    const count = await anchors.count();
+    for (let i = 0; i < count; i++) {
+      const href = await anchors.nth(i).getAttribute('href');
+      expect(
+        href == null || !/^\s*javascript:/i.test(href),
+        `anchor ${i} href must not be a javascript: URL; got: ${href}`,
+      ).toBe(true);
+    }
+
+    // Inline-handler sweep as defence-in-depth (attribute walk, not a
+    // string search, so escaped text in code blocks never trips us up).
+    const hostileAttrs = await rendered.evaluate((root) => {
+      const offenders: string[] = [];
+      const walker = document.createTreeWalker(root, NodeFilter.SHOW_ELEMENT);
+      let node: Element | null = root;
+      while (node) {
+        for (const attr of Array.from((node as Element).attributes ?? [])) {
+          if (/^on/i.test(attr.name)) {
+            offenders.push(`${(node as Element).tagName.toLowerCase()}[${attr.name}]`);
+          }
+        }
+        node = walker.nextNode() as Element | null;
+      }
+      return offenders;
+    });
+    expect(hostileAttrs).toEqual([]);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -22,7 +22,10 @@
     "build-storybook": "storybook build",
     "validate": "tsc --noEmit && pnpm run build && vitest run packages/",
     "docs": "typedoc",
-    "docs:open": "typedoc && open docs/index.html"
+    "docs:open": "typedoc && open docs/index.html",
+    "test:e2e": "playwright test",
+    "test:e2e:install": "playwright install --with-deps chromium",
+    "chromatic": "chromatic --exit-zero-on-changes"
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^5.1.2",
@@ -30,6 +33,7 @@
     "@emotion/styled": "^11.14.1",
     "@mui/icons-material": "^7.0.0",
     "@mui/material": "^9.0.0",
+    "@playwright/test": "^1.59.1",
     "@storybook/addon-a11y": "^10.3.5",
     "@storybook/addon-docs": "^10.3.5",
     "@storybook/addon-onboarding": "^10.3.5",
@@ -42,6 +46,7 @@
     "@types/react-dom": "~19.0.3",
     "@vitest/browser": "3.0.9",
     "@vitest/coverage-v8": "3.0.9",
+    "chromatic": "^13.3.5",
     "eslint": "~9.19.0",
     "eslint-plugin-storybook": "^10.3.5",
     "fake-indexeddb": "^6.0.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,58 @@
+/**
+ * Playwright configuration for the `@istracked/datagrid-monorepo` end-to-end
+ * suite. Specs live under `e2e/` and drive a real browser against the
+ * Storybook instance that renders the grid packages.
+ *
+ * CI note: the `webServer` stanza tells Playwright to boot Storybook on port
+ * 6006 before the test run begins, so GitHub Actions does not need to pre-
+ * start a server. The server is reused locally when it is already running
+ * (typical developer workflow: `pnpm run storybook` in a separate terminal).
+ */
+import { defineConfig, devices } from '@playwright/test';
+
+const STORYBOOK_PORT = Number(process.env.STORYBOOK_PORT ?? 6006);
+const STORYBOOK_URL = `http://localhost:${STORYBOOK_PORT}`;
+
+export default defineConfig({
+  testDir: './e2e',
+  // Single worker keeps story iframes deterministic on CI runners that only
+  // have a couple of cores; Playwright still parallelises across files when
+  // the worker count is raised.
+  fullyParallel: false,
+  workers: 1,
+  retries: process.env.CI ? 2 : 0,
+  forbidOnly: !!process.env.CI,
+  reporter: process.env.CI
+    ? [['html', { open: 'never' }], ['list']]
+    : [['list']],
+  timeout: 30_000,
+  expect: {
+    timeout: 7_500,
+  },
+  use: {
+    baseURL: STORYBOOK_URL,
+    headless: true,
+    actionTimeout: 7_500,
+    navigationTimeout: 30_000,
+    trace: 'retain-on-failure',
+    video: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    // `storybook dev` is fast enough for E2E and supports HMR; the static
+    // build path is available via `pnpm build-storybook && pnpm exec http-server`
+    // for anyone who needs to profile without Vite in the loop.
+    command: `pnpm run storybook -- --ci --port ${STORYBOOK_PORT} --quiet`,
+    url: STORYBOOK_URL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 180_000,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  },
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -48,7 +48,7 @@ export default defineConfig({
     // `storybook dev` is fast enough for E2E and supports HMR; the static
     // build path is available via `pnpm build-storybook && pnpm exec http-server`
     // for anyone who needs to profile without Vite in the loop.
-    command: `pnpm run storybook -- --ci --port ${STORYBOOK_PORT} --quiet`,
+    command: `pnpm exec storybook dev --ci --port ${STORYBOOK_PORT} --quiet`,
     url: STORYBOOK_URL,
     reuseExistingServer: !process.env.CI,
     timeout: 180_000,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@mui/material':
         specifier: ^9.0.0
         version: 9.0.0(@emotion/react@11.14.0(@types/react@19.0.14)(react@19.0.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.0.14)(react@19.0.5))(@types/react@19.0.14)(react@19.0.5))(@types/react@19.0.14)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
+      '@playwright/test':
+        specifier: ^1.59.1
+        version: 1.59.1
       '@storybook/addon-a11y':
         specifier: ^10.3.5
         version: 10.3.5(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.4.2)(react-dom@19.0.5(react@19.0.5))(react@19.0.5))
@@ -59,6 +62,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: 3.0.9
         version: 3.0.9(@vitest/browser@3.0.9)(vitest@3.0.9)
+      chromatic:
+        specifier: ^13.3.5
+        version: 13.3.5
       eslint:
         specifier: ~9.19.0
         version: 9.19.0
@@ -976,6 +982,11 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@playwright/test@1.59.1':
+    resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
@@ -3940,6 +3951,10 @@ snapshots:
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
+
+  '@playwright/test@1.59.1':
+    dependencies:
+      playwright: 1.59.1
 
   '@polka/url@1.0.0-next.29': {}
 


### PR DESCRIPTION
## Summary

Adds a headless end-to-end suite (Playwright) and a visual-regression
job (Chromatic) to the CI pipeline, in a dedicated
`.github/workflows/e2e.yml` that runs alongside the existing
`verify-precommit-parity` job.

## Specs added

- `e2e/grid-keyboard.spec.ts` — arrow-key navigation, Enter / Tab commit
  behaviour on an editable TextCell, Escape cancels and preserves the
  original value. Assertions target `aria-selected` and rendered cell
  text; no screenshots.
- `e2e/grid-subgrid.spec.ts` — sub-grid expansion adds a nested
  `[role=\"grid\"]` element with the WS-G id format
  (`${parentGridId}-row-${rowId}-subgrid`), the nested grid exposes
  `aria-labelledby` pointing at its parent cell id, inner cells
  render, and Tab from the expander reaches a grid element.
- `e2e/grid-xss.spec.ts` — hostile RichText payloads (raw HTML anchor
  with `javascript:` href, markdown link with a `javascript:` URL) must
  not produce live `<a href=\"javascript:...\">` elements or any `on*=`
  inline handlers in the rendered DOM.

All three specs are green on first run against the tip of
`review/post-merge-hardening`.

## CI job additions

- `playwright` job (`e2e`): installs deps, caches the Playwright
  browsers under `~/.cache/ms-playwright`, runs
  `pnpm exec playwright test`, and on failure uploads the HTML report
  and `test-results/` via `actions/upload-artifact@v4`.
- `chromatic` job (`visual`): gated behind the repo secret
  `CHROMATIC_PROJECT_TOKEN`. Runs `pnpm run chromatic` with
  `--exit-zero-on-changes` so baseline updates are reviewed in the
  Chromatic UI rather than blocking the merge. If the secret is absent
  the job emits a warning and exits 0 — fork-safe.

## How to run locally

```bash
pnpm install
pnpm run test:e2e:install   # one-off: downloads Chromium
pnpm run test:e2e            # boots Storybook and runs every spec
pnpm run chromatic           # uploads Storybook to Chromatic (needs token)
```

The Playwright config starts `storybook dev -p 6006` as its
`webServer`, so no pre-started server is required. A running local
Storybook on the same port is reused.

## Required GitHub secrets

- `CHROMATIC_PROJECT_TOKEN` — **optional**. When present, the
  `visual` job uploads Storybook for visual diffing. When absent the
  job is skipped with a warning; CI still passes.

## Recommended branch protection

Required checks on `main`:

- `verify-precommit-parity / verify` (existing)
- `E2E + Visual Regression / e2e` (added here)

`visual` is intentionally left optional so forks without the Chromatic
token still pass.

---
Closes #49