### PR TITLE
refactor(types): drop as-any casts on chrome-resolver call path

### DIFF
--- a/packages/core/src/transposed.ts
+++ b/packages/core/src/transposed.ts
@@ -19,6 +19,27 @@ import type {
 } from './types';
 
 /**
+ * Internal-only row shape produced by {@link createTransposedConfig}.
+ *
+ * The row builder assigns three marker fields onto every row:
+ *   - `__field_label`   — the human-readable label for the row (field)
+ *   - `__field_id`      — the stable field id (used as `rowKey`)
+ *   - `__field_config`  — the original {@link TransposedField} definition
+ *
+ * `TData` is user-supplied and does not generally declare these fields, so
+ * the resolvers inside this module intersect `TData` with this shape where
+ * they read them. The structural intersection replaces the former
+ * `as unknown as { __field_label?: unknown }` double cast with a single
+ * declaration of exactly what we depend on, keeping the rest of `TData`
+ * opaque.
+ */
+interface TransposedInternalRow {
+  __field_label?: unknown;
+  __field_id?: unknown;
+  __field_config?: TransposedField;
+}
+
+/**
  * Creates a {@link GridConfig} from a {@link TransposedGridConfig}.
  *
  * The resulting grid has:
@@ -112,7 +133,13 @@ export function createTransposedConfig<TData = Record<string, unknown>>(
           position: 'left',
         },
         getChromeCellContent: (row: TData) => {
-          const label = (row as unknown as { __field_label?: unknown }).__field_label;
+          // The transposed-grid internals populate every row with a
+          // `__field_label` marker (see the row builder above). `TData` is
+          // user-supplied and may not reflect that, so we narrow via a
+          // structural type rather than `unknown`/`any` — the shape we
+          // actually depend on is declared, the rest of `TData` stays
+          // opaque.
+          const { __field_label: label } = row as TData & TransposedInternalRow;
           return {
             text: typeof label === 'string' ? label : String(label ?? ''),
           };

--- a/packages/react/src/DataGrid.tsx
+++ b/packages/react/src/DataGrid.tsx
@@ -182,16 +182,23 @@ export interface CellRendererProps<TData = Record<string, unknown>> {
 // snapshot under `src/styles/tokens/`.
 // ---------------------------------------------------------------------------
 
-const LIGHT_THEME: Record<string, string> = lightThemeTokens;
+// Theme token maps are keyed by CSS custom-property names (`--dg-*`). The
+// ambient augmentation in `./styles/css-vars.d.ts` opens `csstype.Properties`
+// (and therefore `React.CSSProperties`) to accept this key shape, which
+// lets us drop the previous `as unknown as React.CSSProperties` double
+// assertions — the structural assignment is now honest.
+type CSSVariableMap = Record<`--${string}`, string>;
 
-const DARK_THEME: Record<string, string> = darkThemeTokens;
+const LIGHT_THEME: CSSVariableMap = lightThemeTokens as CSSVariableMap;
+
+const DARK_THEME: CSSVariableMap = darkThemeTokens as CSSVariableMap;
 
 export function resolveThemeStyle(
   theme: 'light' | 'dark' | Record<string, string> | undefined,
 ): React.CSSProperties {
   if (!theme) return {};
-  if (theme === 'light') return { ...LIGHT_THEME } as unknown as React.CSSProperties;
-  if (theme === 'dark') return { ...DARK_THEME } as unknown as React.CSSProperties;
+  if (theme === 'light') return { ...LIGHT_THEME };
+  if (theme === 'dark') return { ...DARK_THEME };
   // A string preset we do not recognise (e.g. `"excel365"`) is handled
   // entirely via CSS — the grid root receives `data-theme="…"` and the
   // matching stylesheet provides the tokens. Returning the string itself
@@ -202,7 +209,12 @@ export function resolveThemeStyle(
   // for the same reason — callers treat the result as a writable
   // `React.CSSProperties` bag and must not receive a frozen/exotic object.
   if (typeof theme === 'string') return {};
-  return { ...theme } as unknown as React.CSSProperties;
+  // Consumer-supplied token maps come in as `Record<string, string>` for the
+  // public API surface; we narrow to the CSS-variable keyspace at this
+  // boundary. Keys not matching `--*` are simply treated as unknown CSS
+  // properties by React DOM and emit the usual dev-time warning — no
+  // runtime fallout.
+  return { ...(theme as CSSVariableMap) };
 }
 
 export { LIGHT_THEME, DARK_THEME };

--- a/packages/react/src/__tests__/chrome-resolver-memoization.test.tsx
+++ b/packages/react/src/__tests__/chrome-resolver-memoization.test.tsx
@@ -57,6 +57,59 @@ const _wrongReturnType: ChromeColumnsConfig<_RowForTypes> = {
 };
 void _wrongReturnType;
 
+// ────────────────────────────────────────────────────────────────────────────
+// PR4 type assertions — the chrome-resolver call path must be typeable without
+// `as any` / `as unknown` casts. If the upstream types regress (e.g. the
+// WeakMap cache generic loses its row/resolver key types), these assignments
+// would silently fall back to `any` and hide bugs; we lock the shape here.
+// ────────────────────────────────────────────────────────────────────────────
+
+// A resolver typed against a concrete row narrows `row` inside the closure.
+const _typedBackground: NonNullable<ChromeColumnsConfig<_RowForTypes>['getRowBackground']> = (
+  row,
+  rowId,
+  rowIndex,
+) => {
+  // `row` is narrowed to _RowForTypes — these property reads must compile
+  // without any cast.
+  const _name: string = row.name;
+  const _amount: number = row.amount;
+  const _rowId: string = rowId;
+  const _rowIndex: number = rowIndex;
+  void _name;
+  void _amount;
+  void _rowId;
+  void _rowIndex;
+  return null;
+};
+void _typedBackground;
+
+// A WeakMap keyed by the row object carries the row type through to its
+// value map without needing an `as unknown as object` cast in consumer code.
+type _RowCache = WeakMap<_RowForTypes, Map<typeof _typedBackground, unknown>>;
+const _cache: _RowCache = new WeakMap();
+void _cache;
+
+// The positional resolver signature must accept three arguments where the
+// first is the row, the second the rowId string, and the third the
+// zero-based rowIndex. Passing a wrong-shape row must be a compile error.
+// The assertions below are wrapped in a never-invoked function so they are
+// compile-time-only: `tsc` checks them, but the runtime never executes
+// the body.
+type _Positional = NonNullable<ChromeColumnsConfig<_RowForTypes>['getRowBorder']>;
+function _compileOnlyCallShape(fn: _Positional): void {
+  const _okReturn: ReturnType<_Positional> = fn(
+    { id: '1', name: 'a', amount: 0 },
+    'rid',
+    0,
+  );
+  void _okReturn;
+  // Wrong-shape row: missing required `amount` — must be a type error.
+  // @ts-expect-error `amount` is required on _RowForTypes
+  fn({ id: '1', name: 'a' }, 'rid', 0);
+}
+void _compileOnlyCallShape;
+
 type TestRow = { id: string; name: string; value: number };
 
 function makeData(count = 3): TestRow[] {

--- a/packages/react/src/body/DataGridBody.tsx
+++ b/packages/react/src/body/DataGridBody.tsx
@@ -305,7 +305,19 @@ export function DataGridBody<TData extends Record<string, unknown>>(
   //
   // `useRef` ensures the cache survives across renders; `.current` is never
   // reassigned, only mutated.
-  const resolverCacheRef = useRef<WeakMap<object, Map<Function, unknown>>>(new WeakMap());
+  //
+  // Typing notes:
+  //   * `TData extends Record<string, unknown>` at the component level, so
+  //     a row reference is already a non-primitive object — it satisfies
+  //     the `WeakMap` key constraint (`WeakKey`) without any cast.
+  //   * The inner `Map`'s key is a chrome-resolver function. Resolvers have
+  //     distinct signatures per slot (`getRowBackground` vs `getRowBorder`
+  //     vs `getChromeCellContent`), but we only use them as map identities —
+  //     the generic `ChromeResolverFn` alias makes that explicit without
+  //     narrowing to any single return shape, and removes the previous
+  //     `as unknown as Function` casts.
+  type ChromeResolverFn = (row: TData, rowId: string, rowIndex: number) => unknown;
+  const resolverCacheRef = useRef<WeakMap<TData, Map<ChromeResolverFn, unknown>>>(new WeakMap());
   const getCachedResolverResult = <TReturn,>(
     resolver: ((row: TData, rowId: string, rowIndex: number) => TReturn) | undefined,
     row: TData,
@@ -313,17 +325,21 @@ export function DataGridBody<TData extends Record<string, unknown>>(
     rowIndex: number,
   ): TReturn | undefined => {
     if (!resolver) return undefined;
-    const rowKey = row as unknown as object;
-    let byResolver = resolverCacheRef.current.get(rowKey);
+    let byResolver = resolverCacheRef.current.get(row);
     if (!byResolver) {
       byResolver = new Map();
-      resolverCacheRef.current.set(rowKey, byResolver);
+      resolverCacheRef.current.set(row, byResolver);
     }
-    if (byResolver.has(resolver as unknown as Function)) {
-      return byResolver.get(resolver as unknown as Function) as TReturn;
+    // The cache is keyed by resolver identity. Every `ChromeResolverFn`
+    // candidate (`getRowBackground`, `getRowBorder`, `getChromeCellContent`)
+    // shares the `(row, rowId, rowIndex) => T` shape and narrows to the
+    // caller's `TReturn` on retrieval.
+    const key: ChromeResolverFn = resolver;
+    if (byResolver.has(key)) {
+      return byResolver.get(key) as TReturn;
     }
     const value = resolver(row, rowId, rowIndex);
-    byResolver.set(resolver as unknown as Function, value);
+    byResolver.set(key, value);
     return value;
   };
 

--- a/packages/react/src/styles/css-vars.d.ts
+++ b/packages/react/src/styles/css-vars.d.ts
@@ -1,0 +1,30 @@
+/**
+ * CSS custom-property augmentation for `React.CSSProperties`.
+ *
+ * The grid's theme resolution (`resolveThemeStyle`) returns a flat map of
+ * `--dg-*` custom properties that callers spread onto a React element's
+ * `style` prop. `csstype.Properties` (the base of `React.CSSProperties`) is
+ * closed by design and does not include an index signature for CSS custom
+ * properties, which previously forced `as unknown as React.CSSProperties`
+ * double-assertions inside {@link ../DataGrid.resolveThemeStyle}.
+ *
+ * This module augments the CSS property set with the standard CSS-variable
+ * key pattern (`--<ident>`) so token maps typed as
+ * `Record<`--${string}`, string>` flow into `React.CSSProperties` positions
+ * without any `as unknown` hop. Standard CSS property keys retain their
+ * closed typing — only CSS-custom-property keys are opened.
+ *
+ * This file is ambient; it is picked up by every compilation that includes
+ * `packages/react/src/**`.
+ */
+import 'csstype';
+
+declare module 'csstype' {
+  interface Properties {
+    // Index signature restricted to CSS custom-property names. This is the
+    // same shape widely used in the React ecosystem to allow `--foo` keys
+    // on `style={{ '--foo': 'bar' }}` without weakening the rest of the
+    // property set.
+    [cssVariable: `--${string}`]: string | number | undefined;
+  }
+}


### PR DESCRIPTION
## Summary

Narrowed `as any` / `as unknown` cleanup scoped strictly to the chrome-resolver call path (`getRowBorder`, `getRowBackground`, `getChromeCellContent`, `resolveThemeStyle`, and the per-row WeakMap cache). Out-of-scope casts elsewhere in `packages/` are intentionally left in place for future PRs.

## Casts removed (file:line → reason safe)

- `packages/react/src/DataGrid.tsx:193` → `{ ...LIGHT_THEME } as unknown as React.CSSProperties` dropped. The new `packages/react/src/styles/css-vars.d.ts` augments `csstype.Properties` with a CSS custom-property key signature (`--${string}`), which is the standard React-ecosystem idiom. `LIGHT_THEME` is typed as `Record<`--${string}`, string>` and flows into `React.CSSProperties` honestly — no double cast needed.
- `packages/react/src/DataGrid.tsx:194` → same treatment for the dark preset.
- `packages/react/src/DataGrid.tsx:205` → custom token map path: consumers still pass `Record<string, string>` (unchanged public API) and we narrow to the CSS-variable keyspace at the function boundary with a single `as CSSVariableMap`, removing the `as unknown` hop.
- `packages/react/src/body/DataGridBody.tsx:308, 316, 322, 323, 326` → the resolver `WeakMap` cache now keys on `TData` (which already satisfies the `WeakKey` / `Record<string, unknown>` constraint at the component level) and its inner `Map` keys on a `ChromeResolverFn` alias shared by all three resolver slots. The four `as unknown as object` / `as unknown as Function` casts disappear while the cache semantics are unchanged.
- `packages/core/src/transposed.ts:115` → the transposed-grid `getChromeCellContent` resolver previously reached for `row as unknown as { __field_label?: unknown }`. A new `TransposedInternalRow` structural type declares exactly the three internal marker fields the transposed config writes onto each row, and the resolver narrows via `row as TData & TransposedInternalRow` — a single honest intersection in place of the former double-unknown cast.

## Casts deliberately left behind with TODO

None. Every cast on the narrow chrome-resolver call path was eliminable. Off-path casts (`GhostRow model` forwarding at `DataGridBody.tsx:888/901/930`, `GridContext` provider value at `DataGrid.tsx:1147`, cellRenderers sub-grid forwarding at `DataGrid.tsx:1110`, `props.onValidationError` at `DataGrid.tsx:595`, and the transposed data-construction cast at `transposed.ts:117`) are outside this PR's scope and were not touched.

## Type-level regression coverage

`packages/react/src/__tests__/chrome-resolver-memoization.test.tsx` gains:

- `_typedBackground` — asserts `row` / `rowId` / `rowIndex` narrow correctly inside a typed resolver closure.
- `_RowCache` alias — locks the `WeakMap<TData, Map<Resolver, unknown>>` shape so a regression in the cache generic is a compile error.
- `_compileOnlyCallShape` — a never-invoked helper that both exercises a correctly-shaped positional call and carries a `@ts-expect-error`-guarded wrong-shape call (missing required field). Wrapped in a function so the runtime test file stays at its original 3 specs.

## Stats

- typecheck: 0 errors
- tests: 1682 / 1682 green (no regressions; unchanged test count — new assertions are compile-time only)
- build: green
- on-path `as any` / `as unknown` count delta: **-8** across `packages/`

## Commits

- `e57d5877` — refactor(types): drop as-any casts on chrome-resolver call path

---
**Closes**: #50

**Playwright coverage**: none directly — type-only refactor covered by existing vitest contracts (compile-time assertions in `packages/react/src/__tests__/chrome-resolver-memoization.test.tsx` lock the `WeakMap<TData, Map<Resolver, unknown>>` cache shape and resolver narrowing via `@ts-expect-error`-guarded negative cases).