### PR TITLE
chore(mcp): register Playwright MCP server

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "playwright": {
+      "command": "pnpm",
+      "args": ["dlx", "@playwright/mcp@latest"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds `.mcp.json` at the repo root so every collaborator inherits the same Playwright MCP server registration for the project. Paired with the README "Recording new tests" subsection from #56, which references this exact file.

## Config

```json
{
  "mcpServers": {
    "playwright": {
      "command": "pnpm",
      "args": ["dlx", "@playwright/mcp@latest"]
    }
  }
}
```

`pnpm dlx @playwright/mcp@latest` pins nothing locally — the MCP client fetches the latest published version on first use and caches it in pnpm's global store, so there is no additional lockfile entry or devDependency.

## Test plan

- [ ] Open the repo in automation; accept the new server prompt; confirm the Playwright MCP tools are available.
- [ ] Run a one-shot recording per the README instructions to confirm the server connects and the generated spec lands under `e2e/`.