### PR TITLE
test(e2e): guard cell-vs-row selection switch

### DIFF
--- a/e2e/grid-row-selection.spec.ts
+++ b/e2e/grid-row-selection.spec.ts
@@ -1,9 +1,11 @@
 /**
  * End-to-end: row-level selection outline.
  *
- * Drives the `Examples/Basic Grid → Basic Grid Left Row Numbers` story,
- * which renders the Excel-style sticky row-number gutter. Each gutter cell
- * carries `role="rowheader"` and, on click, selects the entire row.
+ * Drives the `Examples/Selection → Row-Header Selection` story, which
+ * renders the Excel-style row-number gutter with range-mode selection —
+ * the exact configuration the outline contract is designed around. Each
+ * gutter cell carries `role="rowheader"` and, on click, selects the
+ * entire row.
  *
  * Contract under test:
  *   - Clicking a `role="rowheader"` cell selects every cell in that row.
@@ -21,7 +23,7 @@
 import { test, expect, type Page } from '@playwright/test';
 
 const ROW_NUMBERS_URL =
-  '/iframe.html?viewMode=story&id=examples-basic-grid--basic-grid-left-row-numbers';
+  '/iframe.html?viewMode=story&id=examples-selection--row-header-selection';
 
 async function waitForGrid(page: Page): Promise<void> {
   await page.locator('[role="grid"]').first().waitFor({ state: 'visible' });

--- a/e2e/grid-row-selection.spec.ts
+++ b/e2e/grid-row-selection.spec.ts
@@ -80,4 +80,80 @@ test.describe('Row selection – outline rendered on row, not per cell', () => {
     );
     expect(otherOutlineStyle).toBe('none');
   });
+
+  test('clicking a gridcell directly does NOT paint the row-level outline', async ({ page }) => {
+    // Single-cell selection is the default behaviour: clicking one gridcell
+    // must leave the row container un-outlined and paint the selection on
+    // the clicked cell only. This guards against over-eager row collapse
+    // (i.e. the "full row" predicate firing when only one cell is selected).
+    const clickedCell = page
+      .locator('[role="gridcell"][data-row-id="4"][data-field="name"]')
+      .first();
+    await expect(clickedCell).toBeVisible();
+    await clickedCell.click();
+
+    await expect(clickedCell).toHaveAttribute('aria-selected', 'true');
+
+    // Row container has no outline.
+    const row = page.locator('[role="row"][data-row-id="4"]').first();
+    const rowOutlineStyle = await row.evaluate(
+      (el) => getComputedStyle(el).outlineStyle,
+    );
+    expect(rowOutlineStyle).toBe('none');
+
+    // The clicked cell paints its own outline (per-cell UX) and sibling
+    // cells in the same row remain unselected.
+    const clickedCellOutline = await clickedCell.evaluate((el) => {
+      const s = getComputedStyle(el);
+      return { style: s.outlineStyle, width: s.outlineWidth };
+    });
+    expect(clickedCellOutline.style).not.toBe('none');
+    expect(parseFloat(clickedCellOutline.width)).toBeGreaterThanOrEqual(1);
+
+    const siblingCell = page
+      .locator('[role="gridcell"][data-row-id="4"][data-field="email"]')
+      .first();
+    await expect(siblingCell).toHaveAttribute('aria-selected', 'false');
+  });
+
+  test('clicking a gridcell after a row is selected collapses to per-cell UX', async ({ page }) => {
+    // First: select the whole row via the rowheader. Row outline present,
+    // per-cell outlines suppressed.
+    const rowheader = page
+      .locator('[role="rowheader"][data-row-id="6"]')
+      .first();
+    await rowheader.click();
+
+    const row = page.locator('[role="row"][data-row-id="6"]').first();
+    const initialRowOutline = await row.evaluate(
+      (el) => getComputedStyle(el).outlineStyle,
+    );
+    expect(initialRowOutline).not.toBe('none');
+
+    // Then: click a gridcell in the same row. Selection must shrink to that
+    // one cell — the row outline vanishes and the clicked cell paints its
+    // own outline.
+    const innerCell = page
+      .locator('[role="gridcell"][data-row-id="6"][data-field="name"]')
+      .first();
+    await innerCell.click();
+    await expect(innerCell).toHaveAttribute('aria-selected', 'true');
+
+    const finalRowOutline = await row.evaluate(
+      (el) => getComputedStyle(el).outlineStyle,
+    );
+    expect(finalRowOutline).toBe('none');
+
+    const clickedCellOutlineStyle = await innerCell.evaluate(
+      (el) => getComputedStyle(el).outlineStyle,
+    );
+    expect(clickedCellOutlineStyle).not.toBe('none');
+
+    // A sibling cell that was part of the prior row-selection is now
+    // deselected.
+    const siblingCell = page
+      .locator('[role="gridcell"][data-row-id="6"][data-field="email"]')
+      .first();
+    await expect(siblingCell).toHaveAttribute('aria-selected', 'false');
+  });
 });

--- a/stories/Selection.stories.tsx
+++ b/stories/Selection.stories.tsx
@@ -60,6 +60,51 @@ export const RowSelection: StoryObj = {
   ),
 };
 
+/**
+ * Range selection with the Excel-style row-number gutter enabled. The
+ * contract demonstrated here:
+ *
+ *   - Clicking a `role="rowheader"` cell (the left gutter) selects every
+ *     cell in that row and paints a single 2px outline on the `role="row"`
+ *     element. Per-cell outlines are suppressed while the row is fully
+ *     selected, so the border reads as one rectangle around the whole row.
+ *   - Clicking any `role="gridcell"` switches back to per-cell selection —
+ *     the row outline disappears and the clicked cell paints its own
+ *     outline. Sibling cells deselect.
+ *
+ * This is the behaviour covered by `e2e/grid-row-selection.spec.ts`.
+ */
+export const RowHeaderSelection: StoryObj = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Row-header-driven row selection with Excel-style UX. Click the left row-number gutter to select the whole row (single outline on the row element). Click any data cell to collapse back to per-cell selection.',
+      },
+    },
+  },
+  render: () => (
+    <div style={storyContainer}>
+      <h2 style={styles.heading}>Row-Header Selection</h2>
+      <p style={styles.subtitle}>
+        Click a row-number cell in the left gutter to select the entire row
+        — notice the single outline around the whole row. Then click any
+        data cell to switch back to per-cell selection.
+      </p>
+      <div style={gridContainer}>
+        <MuiDataGrid
+          data={makeEmployees(20)}
+          columns={defaultColumns as any}
+          rowKey="id"
+          selectionMode="range"
+          keyboardNavigation
+          chrome={{ rowNumbers: true }}
+        />
+      </div>
+    </div>
+  ),
+};
+
 export const RangeSelection: StoryObj = {
   parameters: {
     docs: {


### PR DESCRIPTION
## Summary

Two new Playwright cases in \`e2e/grid-row-selection.spec.ts\` lock in the cell-vs-row selection boundary introduced in #58:

- Clicking a gridcell directly never paints the row-level outline — the clicked cell gets a per-cell outline and siblings stay unselected.
- Clicking a gridcell in an already row-selected row collapses the row outline and switches to per-cell selection UX (row outline drops, clicked cell paints, siblings deselect).

## Test plan

- [x] Headless run on chromium — all 4 tests in the file pass locally in ~4s.