### PR TITLE
feat(selection): row-range selection on rowheader Shift/Cmd+click and keyboard

### DIFF
--- a/e2e/grid-row-selection.spec.ts
+++ b/e2e/grid-row-selection.spec.ts
@@ -1,51 +1,103 @@
 /**
- * End-to-end: row-level selection outline.
+ * End-to-end: row-level selection outline + multi-row row-range semantics.
  *
- * Drives the `Examples/Selection → Row-Header Selection` story, which
- * renders the Excel-style row-number gutter with range-mode selection —
- * the exact configuration the outline contract is designed around. Each
- * gutter cell carries `role="rowheader"` and, on click, selects the
- * entire row.
+ * Row outline rendering uses `box-shadow: inset ...` (not CSS `outline`)
+ * so that a contiguous multi-row range can turn individual sides on or
+ * off — top border on the first row, bottom border on the last, sides on
+ * all, no internal horizontals. Disjoint rows get all four sides each.
  *
- * Contract under test:
- *   - Clicking a `role="rowheader"` cell selects every cell in that row.
- *   - The selected row's outline is drawn once on the `role="row"` element
- *     (via `outline: 2px solid ...; outline-offset: -2px`). Drawing one
- *     rectangle around the row avoids the stacked per-cell borders that
- *     previously produced a thicker, uneven edge.
- *   - Individual child `role="gridcell"` elements in the selected row
- *     suppress their own outline, so the border is not drawn twice.
- *   - Cells in unselected rows are unaffected (their per-cell outline
- *     behaviour for single-cell selection still applies elsewhere).
+ * Primary story driven here is `Examples/Selection → Row Range
+ * Contiguous`, which pairs `selectionMode="range"` with the Excel-style
+ * row-number gutter and `shiftArrowBehavior="rangeSelect"` so every
+ * modifier + keyboard path under test is live. A secondary describe
+ * block stays on `Examples/Selection → Row-Header Selection` to keep the
+ * plain-click regressions from PR #58 locked in.
  *
- * Assertions target computed styles on live DOM — no screenshots.
+ * Assertions read computed `box-shadow` / `outline-style` on live DOM.
  */
-import { test, expect, type Page } from '@playwright/test';
+import { test, expect, type Locator, type Page } from '@playwright/test';
 
-const ROW_NUMBERS_URL =
+const ROW_HEADER_URL =
   '/iframe.html?viewMode=story&id=examples-selection--row-header-selection';
+const ROW_RANGE_URL =
+  '/iframe.html?viewMode=story&id=examples-selection--row-range-contiguous';
 
 async function waitForGrid(page: Page): Promise<void> {
   await page.locator('[role="grid"]').first().waitFor({ state: 'visible' });
 }
 
+// `getComputedStyle(el).boxShadow` normalises to `<color> <x> <y> <blur>
+// <spread> inset` (color first, `inset` last, offsets in `px`). We extract
+// each part's four offset values regardless of where `inset` / the color
+// sits so the assertions match what the browser actually emits.
+type Sides = { top: boolean; right: boolean; bottom: boolean; left: boolean };
+function parseInsetSides(boxShadow: string): Sides {
+  if (!boxShadow || boxShadow === 'none') {
+    return { top: false, right: false, bottom: false, left: false };
+  }
+  const parts = boxShadow.split(/,(?![^(]*\))/).map((p) => p.trim());
+  const offsetsOf = (p: string): [number, number, number, number] | null => {
+    // Strip `inset` and any `rgb(...)` / `rgba(...)` color wrapper, then
+    // pluck the first four signed numeric tokens — these are the four
+    // offset values `<x> <y> <blur> <spread>`.
+    const cleaned = p
+      .replace(/\binset\b/, ' ')
+      .replace(/rgba?\([^)]*\)/, ' ')
+      .trim();
+    const nums = cleaned.match(/-?\d*\.?\d+/g);
+    if (!nums || nums.length < 4) return null;
+    return [
+      parseFloat(nums[0]!),
+      parseFloat(nums[1]!),
+      parseFloat(nums[2]!),
+      parseFloat(nums[3]!),
+    ];
+  };
+  const has = (pred: (o: [number, number, number, number]) => boolean) =>
+    parts.some((p) => {
+      const o = offsetsOf(p);
+      return o !== null && pred(o);
+    });
+  return {
+    // top:    x=0,  y=+2, blur=0, spread=0
+    top: has(([x, y]) => x === 0 && y === 2),
+    // right:  x=-2, y=0
+    right: has(([x, y]) => x === -2 && y === 0),
+    // bottom: x=0,  y=-2
+    bottom: has(([x, y]) => x === 0 && y === -2),
+    // left:   x=+2, y=0
+    left: has(([x, y]) => x === 2 && y === 0),
+  };
+}
+
+async function getRowSides(row: Locator): Promise<Sides> {
+  const boxShadow = await row.evaluate((el) => getComputedStyle(el).boxShadow);
+  return parseInsetSides(boxShadow);
+}
+
+async function rowHasAnySide(row: Locator): Promise<boolean> {
+  const s = await getRowSides(row);
+  return s.top || s.right || s.bottom || s.left;
+}
+
+// ---------------------------------------------------------------------------
+// Plain-click row selection (regression suite from PR #58 / #59)
+// ---------------------------------------------------------------------------
+
 test.describe('Row selection – outline rendered on row, not per cell', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto(ROW_NUMBERS_URL);
+    await page.goto(ROW_HEADER_URL);
     await waitForGrid(page);
   });
 
   test('clicking a rowheader paints the outline on the row element', async ({ page }) => {
-    const rowheader = page
-      .locator('[role="rowheader"][data-row-id="3"]')
-      .first();
+    const rowheader = page.locator('[role="rowheader"][data-row-id="3"]').first();
     await expect(rowheader).toBeVisible();
     await rowheader.click();
 
     const row = page.locator('[role="row"][data-row-id="3"]').first();
     await expect(row).toBeVisible();
 
-    // Every cell in the row is marked selected.
     const cellsInRow = row.locator('[role="gridcell"]');
     const cellCount = await cellsInRow.count();
     expect(cellCount).toBeGreaterThan(0);
@@ -53,17 +105,13 @@ test.describe('Row selection – outline rendered on row, not per cell', () => {
       await expect(cellsInRow.nth(i)).toHaveAttribute('aria-selected', 'true');
     }
 
-    // The row's own outline is drawn (non-`none`, width >= 1px).
-    const rowOutline = await row.evaluate((el) => {
-      const s = getComputedStyle(el);
-      return { style: s.outlineStyle, width: s.outlineWidth };
+    // A single-row selection draws all four sides of the inset shadow.
+    expect(await getRowSides(row)).toEqual({
+      top: true, right: true, bottom: true, left: true,
     });
-    expect(rowOutline.style).not.toBe('none');
-    expect(parseFloat(rowOutline.width)).toBeGreaterThanOrEqual(1);
 
-    // No child gridcell draws its own outline while the row is fully selected.
-    // Checking the first and last cell gives coverage of both edges of the row
-    // without a full scan per test run.
+    // Per-cell outlines are suppressed (first and last cell is a cheap proxy
+    // for the whole row).
     for (const idx of [0, cellCount - 1]) {
       const cellOutlineStyle = await cellsInRow
         .nth(idx)
@@ -77,17 +125,10 @@ test.describe('Row selection – outline rendered on row, not per cell', () => {
     await target.click();
 
     const otherRow = page.locator('[role="row"][data-row-id="5"]').first();
-    const otherOutlineStyle = await otherRow.evaluate(
-      (el) => getComputedStyle(el).outlineStyle,
-    );
-    expect(otherOutlineStyle).toBe('none');
+    expect(await rowHasAnySide(otherRow)).toBe(false);
   });
 
   test('clicking a gridcell directly does NOT paint the row-level outline', async ({ page }) => {
-    // Single-cell selection is the default behaviour: clicking one gridcell
-    // must leave the row container un-outlined and paint the selection on
-    // the clicked cell only. This guards against over-eager row collapse
-    // (i.e. the "full row" predicate firing when only one cell is selected).
     const clickedCell = page
       .locator('[role="gridcell"][data-row-id="4"][data-field="name"]')
       .first();
@@ -96,15 +137,9 @@ test.describe('Row selection – outline rendered on row, not per cell', () => {
 
     await expect(clickedCell).toHaveAttribute('aria-selected', 'true');
 
-    // Row container has no outline.
     const row = page.locator('[role="row"][data-row-id="4"]').first();
-    const rowOutlineStyle = await row.evaluate(
-      (el) => getComputedStyle(el).outlineStyle,
-    );
-    expect(rowOutlineStyle).toBe('none');
+    expect(await rowHasAnySide(row)).toBe(false);
 
-    // The clicked cell paints its own outline (per-cell UX) and sibling
-    // cells in the same row remain unselected.
     const clickedCellOutline = await clickedCell.evaluate((el) => {
       const s = getComputedStyle(el);
       return { style: s.outlineStyle, width: s.outlineWidth };
@@ -119,43 +154,206 @@ test.describe('Row selection – outline rendered on row, not per cell', () => {
   });
 
   test('clicking a gridcell after a row is selected collapses to per-cell UX', async ({ page }) => {
-    // First: select the whole row via the rowheader. Row outline present,
-    // per-cell outlines suppressed.
-    const rowheader = page
-      .locator('[role="rowheader"][data-row-id="6"]')
-      .first();
+    const rowheader = page.locator('[role="rowheader"][data-row-id="6"]').first();
     await rowheader.click();
 
     const row = page.locator('[role="row"][data-row-id="6"]').first();
-    const initialRowOutline = await row.evaluate(
-      (el) => getComputedStyle(el).outlineStyle,
-    );
-    expect(initialRowOutline).not.toBe('none');
+    expect(await rowHasAnySide(row)).toBe(true);
 
-    // Then: click a gridcell in the same row. Selection must shrink to that
-    // one cell — the row outline vanishes and the clicked cell paints its
-    // own outline.
     const innerCell = page
       .locator('[role="gridcell"][data-row-id="6"][data-field="name"]')
       .first();
     await innerCell.click();
     await expect(innerCell).toHaveAttribute('aria-selected', 'true');
 
-    const finalRowOutline = await row.evaluate(
-      (el) => getComputedStyle(el).outlineStyle,
-    );
-    expect(finalRowOutline).toBe('none');
+    expect(await rowHasAnySide(row)).toBe(false);
 
     const clickedCellOutlineStyle = await innerCell.evaluate(
       (el) => getComputedStyle(el).outlineStyle,
     );
     expect(clickedCellOutlineStyle).not.toBe('none');
 
-    // A sibling cell that was part of the prior row-selection is now
-    // deselected.
     const siblingCell = page
       .locator('[role="gridcell"][data-row-id="6"][data-field="email"]')
       .first();
     await expect(siblingCell).toHaveAttribute('aria-selected', 'false');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Shift/Cmd-click row ranges + keyboard extensions
+// ---------------------------------------------------------------------------
+
+test.describe('Row range – Shift+click contiguous and Cmd/Ctrl+click disjoint', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(ROW_RANGE_URL);
+    await waitForGrid(page);
+  });
+
+  test('Shift+click extends to a contiguous row range outlined as one block', async ({ page }) => {
+    const first = page.locator('[role="rowheader"][data-row-id="2"]').first();
+    const last = page.locator('[role="rowheader"][data-row-id="5"]').first();
+    await first.click();
+    await last.click({ modifiers: ['Shift'] });
+
+    const row2 = page.locator('[role="row"][data-row-id="2"]').first();
+    const row3 = page.locator('[role="row"][data-row-id="3"]').first();
+    const row4 = page.locator('[role="row"][data-row-id="4"]').first();
+    const row5 = page.locator('[role="row"][data-row-id="5"]').first();
+    const row6 = page.locator('[role="row"][data-row-id="6"]').first();
+
+    // Outer edges only — top on first, bottom on last, sides on every row
+    // in between, no internal horizontals.
+    expect(await getRowSides(row2)).toEqual({ top: true, right: true, bottom: false, left: true });
+    expect(await getRowSides(row3)).toEqual({ top: false, right: true, bottom: false, left: true });
+    expect(await getRowSides(row4)).toEqual({ top: false, right: true, bottom: false, left: true });
+    expect(await getRowSides(row5)).toEqual({ top: false, right: true, bottom: true, left: true });
+    // Row outside the range has no shadow at all.
+    expect(await rowHasAnySide(row6)).toBe(false);
+  });
+
+  test('Cmd/Ctrl+click toggles a disjoint row with its own four-sided outline', async ({ page }) => {
+    // Plain click row 2, then Cmd/Ctrl+click row 5. Intermediate rows stay
+    // un-selected; both anchor and disjoint row carry the full four sides.
+    const r2 = page.locator('[role="rowheader"][data-row-id="2"]').first();
+    const r5 = page.locator('[role="rowheader"][data-row-id="5"]').first();
+    await r2.click();
+    await r5.click({ modifiers: ['ControlOrMeta'] });
+
+    const row2 = page.locator('[role="row"][data-row-id="2"]').first();
+    const row3 = page.locator('[role="row"][data-row-id="3"]').first();
+    const row4 = page.locator('[role="row"][data-row-id="4"]').first();
+    const row5 = page.locator('[role="row"][data-row-id="5"]').first();
+
+    const all = { top: true, right: true, bottom: true, left: true };
+    expect(await getRowSides(row2)).toEqual(all);
+    expect(await getRowSides(row5)).toEqual(all);
+    expect(await rowHasAnySide(row3)).toBe(false);
+    expect(await rowHasAnySide(row4)).toBe(false);
+  });
+
+  test('Cmd/Ctrl+click a selected row again removes it from the disjoint selection', async ({ page }) => {
+    const r2 = page.locator('[role="rowheader"][data-row-id="2"]').first();
+    const r5 = page.locator('[role="rowheader"][data-row-id="5"]').first();
+    await r2.click();
+    await r5.click({ modifiers: ['ControlOrMeta'] });
+    await r5.click({ modifiers: ['ControlOrMeta'] });
+
+    const row2 = page.locator('[role="row"][data-row-id="2"]').first();
+    const row5 = page.locator('[role="row"][data-row-id="5"]').first();
+    expect(await rowHasAnySide(row2)).toBe(true);
+    expect(await rowHasAnySide(row5)).toBe(false);
+  });
+
+  test('Shift+ArrowDown once extends the row selection down by one row', async ({ page }) => {
+    const r3 = page.locator('[role="rowheader"][data-row-id="3"]').first();
+    await r3.click();
+    await page.locator('[role="grid"]').first().focus();
+    await page.keyboard.press('Shift+ArrowDown');
+
+    const row3 = page.locator('[role="row"][data-row-id="3"]').first();
+    const row4 = page.locator('[role="row"][data-row-id="4"]').first();
+    const row5 = page.locator('[role="row"][data-row-id="5"]').first();
+
+    expect(await getRowSides(row3)).toEqual({ top: true, right: true, bottom: false, left: true });
+    expect(await getRowSides(row4)).toEqual({ top: false, right: true, bottom: true, left: true });
+    expect(await rowHasAnySide(row5)).toBe(false);
+  });
+
+  test('Shift+ArrowDown twice extends the row selection down by two rows', async ({ page }) => {
+    const r3 = page.locator('[role="rowheader"][data-row-id="3"]').first();
+    await r3.click();
+    await page.locator('[role="grid"]').first().focus();
+    await page.keyboard.press('Shift+ArrowDown');
+    await page.keyboard.press('Shift+ArrowDown');
+
+    const row3 = page.locator('[role="row"][data-row-id="3"]').first();
+    const row4 = page.locator('[role="row"][data-row-id="4"]').first();
+    const row5 = page.locator('[role="row"][data-row-id="5"]').first();
+    const row6 = page.locator('[role="row"][data-row-id="6"]').first();
+
+    expect(await getRowSides(row3)).toEqual({ top: true, right: true, bottom: false, left: true });
+    expect(await getRowSides(row4)).toEqual({ top: false, right: true, bottom: false, left: true });
+    expect(await getRowSides(row5)).toEqual({ top: false, right: true, bottom: true, left: true });
+    expect(await rowHasAnySide(row6)).toBe(false);
+  });
+
+  test('Shift+ArrowUp shrinks an extended range back', async ({ page }) => {
+    const r3 = page.locator('[role="rowheader"][data-row-id="3"]').first();
+    await r3.click();
+    await page.locator('[role="grid"]').first().focus();
+    await page.keyboard.press('Shift+ArrowDown');
+    await page.keyboard.press('Shift+ArrowDown');
+    await page.keyboard.press('Shift+ArrowUp');
+
+    const row3 = page.locator('[role="row"][data-row-id="3"]').first();
+    const row4 = page.locator('[role="row"][data-row-id="4"]').first();
+    const row5 = page.locator('[role="row"][data-row-id="5"]').first();
+
+    expect(await getRowSides(row3)).toEqual({ top: true, right: true, bottom: false, left: true });
+    expect(await getRowSides(row4)).toEqual({ top: false, right: true, bottom: true, left: true });
+    expect(await rowHasAnySide(row5)).toBe(false);
+  });
+
+  test('Shift+ArrowLeft and Shift+ArrowRight are no-ops while a row is selected', async ({ page }) => {
+    const r3 = page.locator('[role="rowheader"][data-row-id="3"]').first();
+    await r3.click();
+    await page.locator('[role="grid"]').first().focus();
+    const before = await getRowSides(
+      page.locator('[role="row"][data-row-id="3"]').first(),
+    );
+
+    await page.keyboard.press('Shift+ArrowLeft');
+    await page.keyboard.press('Shift+ArrowRight');
+
+    const after = await getRowSides(
+      page.locator('[role="row"][data-row-id="3"]').first(),
+    );
+    expect(after).toEqual(before);
+
+    // No sibling row gained any shadow.
+    for (const id of ['2', '4']) {
+      expect(await rowHasAnySide(page.locator(`[role="row"][data-row-id="${id}"]`).first())).toBe(false);
+    }
+  });
+
+  test('plain ArrowDown moves the row selection to the next row', async ({ page }) => {
+    const r3 = page.locator('[role="rowheader"][data-row-id="3"]').first();
+    await r3.click();
+    await page.locator('[role="grid"]').first().focus();
+    await page.keyboard.press('ArrowDown');
+
+    const row3 = page.locator('[role="row"][data-row-id="3"]').first();
+    const row4 = page.locator('[role="row"][data-row-id="4"]').first();
+    expect(await rowHasAnySide(row3)).toBe(false);
+    expect(await getRowSides(row4)).toEqual({
+      top: true, right: true, bottom: true, left: true,
+    });
+  });
+
+  test('plain ArrowLeft and ArrowRight are no-ops while a row is selected', async ({ page }) => {
+    const r3 = page.locator('[role="rowheader"][data-row-id="3"]').first();
+    await r3.click();
+    await page.locator('[role="grid"]').first().focus();
+    const before = await getRowSides(
+      page.locator('[role="row"][data-row-id="3"]').first(),
+    );
+
+    await page.keyboard.press('ArrowLeft');
+    await page.keyboard.press('ArrowRight');
+
+    const after = await getRowSides(
+      page.locator('[role="row"][data-row-id="3"]').first(),
+    );
+    expect(after).toEqual(before);
+  });
+
+  test('Escape clears the row selection', async ({ page }) => {
+    const r3 = page.locator('[role="rowheader"][data-row-id="3"]').first();
+    await r3.click();
+    await page.locator('[role="grid"]').first().focus();
+    await page.keyboard.press('Escape');
+
+    expect(await rowHasAnySide(page.locator('[role="row"][data-row-id="3"]').first())).toBe(false);
   });
 });

--- a/packages/core/src/__tests__/selection.test.ts
+++ b/packages/core/src/__tests__/selection.test.ts
@@ -17,6 +17,7 @@ import {
   getEndJumpCell,
   isCellValueEmpty,
   isRowFullySelected,
+  getRowSelectionBorders,
 } from '../selection';
 import { CellAddress, ColumnDef } from '../types';
 
@@ -534,5 +535,125 @@ describe('isRowFullySelected', () => {
   it('returns false when columns list is empty', () => {
     const s = selectRow(createSelection('row'), 'r1', cols);
     expect(isRowFullySelected(s, 'r1', [])).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isRowFullySelected — 4-arg form walks state.ranges
+// ---------------------------------------------------------------------------
+
+const rows4 = ['r1', 'r2', 'r3', 'r4'];
+
+function makeFullRowRange(rowId: string) {
+  return {
+    anchor: { rowId, field: 'name' },
+    focus: { rowId, field: 'city' },
+  };
+}
+
+function makeContiguousRangeState(fromRowId: string, toRowId: string) {
+  const range = {
+    anchor: { rowId: fromRowId, field: 'name' },
+    focus: { rowId: toRowId, field: 'city' },
+  };
+  return { range, mode: 'row' as const, ranges: [range] };
+}
+
+describe('isRowFullySelected — legacy 3-arg form unchanged', () => {
+  it('returns true for a single row range on the tested row', () => {
+    const s = selectRow(createSelection('row'), 'r2', cols);
+    expect(isRowFullySelected(s, 'r2', cols)).toBe(true);
+  });
+
+  it('returns false for a different row', () => {
+    const s = selectRow(createSelection('row'), 'r1', cols);
+    expect(isRowFullySelected(s, 'r2', cols)).toBe(false);
+  });
+
+  it('returns false when range is null', () => {
+    const s = createSelection('row');
+    expect(isRowFullySelected(s, 'r1', cols)).toBe(false);
+  });
+});
+
+describe('isRowFullySelected — 4-arg walks ranges — contiguous multi-row', () => {
+  it('rows inside the range are true, outside is false', () => {
+    const state = makeContiguousRangeState('r1', 'r3');
+    expect(isRowFullySelected(state, 'r1', cols, rows4)).toBe(true);
+    expect(isRowFullySelected(state, 'r2', cols, rows4)).toBe(true);
+    expect(isRowFullySelected(state, 'r3', cols, rows4)).toBe(true);
+    expect(isRowFullySelected(state, 'r4', cols, rows4)).toBe(false);
+  });
+});
+
+describe('isRowFullySelected — 4-arg walks ranges — disjoint rows', () => {
+  it('only the rows with their own range are true', () => {
+    const state = {
+      range: makeFullRowRange('r4'),
+      mode: 'row' as const,
+      ranges: [makeFullRowRange('r1'), makeFullRowRange('r4')],
+    };
+    expect(isRowFullySelected(state, 'r1', cols, rows4)).toBe(true);
+    expect(isRowFullySelected(state, 'r2', cols, rows4)).toBe(false);
+    expect(isRowFullySelected(state, 'r3', cols, rows4)).toBe(false);
+    expect(isRowFullySelected(state, 'r4', cols, rows4)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getRowSelectionBorders
+// ---------------------------------------------------------------------------
+
+describe('getRowSelectionBorders', () => {
+  it('returns null when the row is not in any covering range', () => {
+    const state = makeContiguousRangeState('r1', 'r2');
+    expect(getRowSelectionBorders(state, 'r3', cols, rows4)).toBeNull();
+    expect(getRowSelectionBorders(state, 'r4', cols, rows4)).toBeNull();
+  });
+
+  it('single-row range → all four sides true', () => {
+    const state = { range: makeFullRowRange('r2'), mode: 'row' as const, ranges: [makeFullRowRange('r2')] };
+    const borders = getRowSelectionBorders(state, 'r2', cols, rows4);
+    expect(borders).toEqual({ top: true, right: true, bottom: true, left: true });
+  });
+
+  it('contiguous 3-row range → correct side flags per position', () => {
+    const state = makeContiguousRangeState('r1', 'r3');
+    // top row: top + sides, no bottom
+    expect(getRowSelectionBorders(state, 'r1', cols, rows4)).toEqual({ top: true, right: true, bottom: false, left: true });
+    // middle row: sides only
+    expect(getRowSelectionBorders(state, 'r2', cols, rows4)).toEqual({ top: false, right: true, bottom: false, left: true });
+    // bottom row: bottom + sides, no top
+    expect(getRowSelectionBorders(state, 'r3', cols, rows4)).toEqual({ top: false, right: true, bottom: true, left: true });
+  });
+
+  it('disjoint singleton rows → all-true on each', () => {
+    const state = {
+      range: makeFullRowRange('r4'),
+      mode: 'row' as const,
+      ranges: [makeFullRowRange('r1'), makeFullRowRange('r4')],
+    };
+    expect(getRowSelectionBorders(state, 'r1', cols, rows4)).toEqual({ top: true, right: true, bottom: true, left: true });
+    expect(getRowSelectionBorders(state, 'r4', cols, rows4)).toEqual({ top: true, right: true, bottom: true, left: true });
+    expect(getRowSelectionBorders(state, 'r2', cols, rows4)).toBeNull();
+    expect(getRowSelectionBorders(state, 'r3', cols, rows4)).toBeNull();
+  });
+
+  it('mixed: contiguous range r1..r2 plus disjoint r4', () => {
+    const contiguous = { anchor: { rowId: 'r1', field: 'name' }, focus: { rowId: 'r2', field: 'city' } };
+    const singleton4 = makeFullRowRange('r4');
+    const state = {
+      range: singleton4,
+      mode: 'row' as const,
+      ranges: [contiguous, singleton4],
+    };
+    // r1: top of contiguous range
+    expect(getRowSelectionBorders(state, 'r1', cols, rows4)).toEqual({ top: true, right: true, bottom: false, left: true });
+    // r2: bottom of contiguous range
+    expect(getRowSelectionBorders(state, 'r2', cols, rows4)).toEqual({ top: false, right: true, bottom: true, left: true });
+    // r3: not in any range
+    expect(getRowSelectionBorders(state, 'r3', cols, rows4)).toBeNull();
+    // r4: singleton
+    expect(getRowSelectionBorders(state, 'r4', cols, rows4)).toEqual({ top: true, right: true, bottom: true, left: true });
   });
 });

--- a/packages/core/src/grid-model.ts
+++ b/packages/core/src/grid-model.ts
@@ -29,7 +29,7 @@ import { applySorting, toggleSort } from './sorting';
 import { applyFiltering } from './filtering';
 import {
   createSelection, SelectionState, selectCell, selectRow, selectColumn,
-  extendSelection, clearSelection, selectAll, toggleRowSelection,
+  extendSelection, extendRowSelection, clearSelection, selectAll, toggleRowSelection,
 } from './selection';
 import {
   createEditingState, EditingState, beginEdit as beginEditState,
@@ -60,6 +60,7 @@ export interface GridModel<TData = Record<string, unknown>> {
   selectRowByKey(rowId: string): void;
   selectColumnByField(field: string): void;
   extendTo(cell: CellAddress): void;
+  extendRowSelection(rowId: string): void;
   selectAllCells(): void;
   clearSelectionState(): void;
   setColumnWidth(field: string, width: number): void;
@@ -382,6 +383,12 @@ export function createGridModel<TData extends Record<string, unknown>>(
 
     extendTo(cell: CellAddress) {
       state = { ...state, selection: extendSelection(state.selection, cell) };
+      notify();
+    },
+
+    extendRowSelection(rowId: string) {
+      const cols = getVisibleColumns(state.columns);
+      state = { ...state, selection: extendRowSelection(state.selection, rowId, cols) };
       notify();
     },
 

--- a/packages/core/src/selection.ts
+++ b/packages/core/src/selection.ts
@@ -432,32 +432,120 @@ export function getPrevCellInRow(current: CellAddress, columns: ColumnDef<any>[]
 }
 
 /**
+ * Per-side border flags for a row-selection outline.
+ */
+export interface RowOutlineSides {
+  top: boolean;
+  right: boolean;
+  bottom: boolean;
+  left: boolean;
+}
+
+/**
  * Returns `true` when the current selection range covers every column in the
  * given row — i.e. the anchor and focus are both on `rowId` and span from the
  * first to the last column field (in either order).
  *
- * This is the predicate used to decide whether to paint the row-level outline
- * instead of per-cell outlines (CSS-only row-selection outline, path #1).
+ * When `rowIds` is supplied the function walks every range in `state.ranges`
+ * so disjoint multi-row selections (Ctrl+click) are handled correctly.
+ * When `rowIds` is omitted the fast path checks only `state.range` — backward
+ * compatible with all existing callers.
  *
  * @param state - Current selection state.
  * @param rowId - The row to test.
  * @param columns - Full list of column definitions.
- * @returns `true` when the active range is a full-row selection for `rowId`.
+ * @param rowIds - Optional ordered list of all row identifiers; enables multi-range walk.
+ * @returns `true` when any range in the selection is a full-row selection for `rowId`.
  */
 export function isRowFullySelected(
   state: SelectionState,
   rowId: string,
   columns: ColumnDef<any>[],
+  rowIds?: string[],
 ): boolean {
-  if (!state.range || columns.length === 0) return false;
-  const { anchor, focus } = state.range;
-  if (anchor.rowId !== rowId || focus.rowId !== rowId) return false;
+  if (columns.length === 0) return false;
   const firstField = columns[0]!.field;
   const lastField = columns[columns.length - 1]!.field;
+
+  function isFullRowRange(range: CellRange): boolean {
+    const rowIdx = rowIds ? rowIds.indexOf(rowId) : -1;
+    const anchorRowIdx = rowIds ? rowIds.indexOf(range.anchor.rowId) : -1;
+    const focusRowIdx = rowIds ? rowIds.indexOf(range.focus.rowId) : -1;
+    const minRow = Math.min(anchorRowIdx, focusRowIdx);
+    const maxRow = Math.max(anchorRowIdx, focusRowIdx);
+    const rowInRange = rowIds
+      ? rowIdx >= minRow && rowIdx <= maxRow
+      : range.anchor.rowId === rowId && range.focus.rowId === rowId;
+    if (!rowInRange) return false;
+    return (
+      (range.anchor.field === firstField && range.focus.field === lastField) ||
+      (range.anchor.field === lastField && range.focus.field === firstField)
+    );
+  }
+
+  if (rowIds !== undefined) {
+    return state.ranges.some(isFullRowRange);
+  }
+
+  // Legacy 3-arg fast path: only check state.range.
+  if (!state.range) return false;
+  const { anchor, focus } = state.range;
+  if (anchor.rowId !== rowId || focus.rowId !== rowId) return false;
   return (
     (anchor.field === firstField && focus.field === lastField) ||
     (anchor.field === lastField && focus.field === firstField)
   );
+}
+
+/**
+ * Returns the per-side border flags for the row-selection outline for `rowId`,
+ * or `null` when the row is not covered by any full-row range.
+ *
+ * Contiguous multi-row ranges suppress internal horizontal borders (top on all
+ * rows except the first, bottom on all rows except the last).  Disjoint
+ * single-row ranges each get all four sides.
+ */
+export function getRowSelectionBorders(
+  state: SelectionState,
+  rowId: string,
+  columns: ColumnDef<any>[],
+  rowIds: string[],
+): RowOutlineSides | null {
+  if (columns.length === 0 || rowIds.length === 0) return null;
+  const firstField = columns[0]!.field;
+  const lastField = columns[columns.length - 1]!.field;
+  const rowIdx = rowIds.indexOf(rowId);
+  if (rowIdx === -1) return null;
+
+  function isFullRowCovering(range: CellRange): boolean {
+    const anchorRowIdx = rowIds.indexOf(range.anchor.rowId);
+    const focusRowIdx = rowIds.indexOf(range.focus.rowId);
+    const minRow = Math.min(anchorRowIdx, focusRowIdx);
+    const maxRow = Math.max(anchorRowIdx, focusRowIdx);
+    if (rowIdx < minRow || rowIdx > maxRow) return false;
+    return (
+      (range.anchor.field === firstField && range.focus.field === lastField) ||
+      (range.anchor.field === lastField && range.focus.field === firstField)
+    );
+  }
+
+  const covering = state.ranges.filter(isFullRowCovering);
+  if (covering.length === 0) return null;
+
+  let top = false;
+  let bottom = false;
+
+  for (const range of covering) {
+    const anchorRowIdx = rowIds.indexOf(range.anchor.rowId);
+    const focusRowIdx = rowIds.indexOf(range.focus.rowId);
+    const minRow = Math.min(anchorRowIdx, focusRowIdx);
+    const maxRow = Math.max(anchorRowIdx, focusRowIdx);
+    const isSingleton = minRow === maxRow;
+    if (isSingleton || rowIdx === minRow) top = true;
+    if (isSingleton || rowIdx === maxRow) bottom = true;
+  }
+
+  return { top, right: true, bottom, left: true };
 }
 
 /**

--- a/packages/core/src/selection.ts
+++ b/packages/core/src/selection.ts
@@ -71,9 +71,10 @@ export function selectRow(state: SelectionState, rowId: string, columns: ColumnD
   // Determine the first and last column fields
   const firstCol = columns[0]?.field ?? '';
   const lastCol = columns[columns.length - 1]?.field ?? '';
-  const newRange = {
+  const newRange: CellRange = {
     anchor: { rowId, field: firstCol },
     focus: { rowId, field: lastCol },
+    kind: 'row',
   };
   return {
     ...state,
@@ -121,7 +122,46 @@ export function selectColumn(state: SelectionState, field: string, rowIds: strin
  */
 export function extendSelection(state: SelectionState, cell: CellAddress): SelectionState {
   if (state.mode === 'none' || !state.range) return state;
-  const newRange = { anchor: state.range.anchor, focus: cell };
+  // Preserve the current range's `kind` so extending a row-kind selection
+  // (e.g. rowheader Shift+Arrow) yields another row-kind range rather than
+  // silently degrading to a generic cell range.
+  const newRange: CellRange = state.range.kind
+    ? { anchor: state.range.anchor, focus: cell, kind: state.range.kind }
+    : { anchor: state.range.anchor, focus: cell };
+  const updatedRanges = state.ranges.length > 0
+    ? [...state.ranges.slice(0, -1), newRange]
+    : [newRange];
+  return { ...state, range: newRange, ranges: updatedRanges };
+}
+
+/**
+ * Extends the current row selection down/up to `rowId`, snapping the anchor
+ * to the first column and the focus to the last column so the resulting
+ * range covers every cell in the spanned rows. Tags the new range with
+ * `kind: 'row'` so the renderer treats it as a row-level outline regardless
+ * of the grid's `selectionMode`.
+ *
+ * When no prior range exists, falls back to selecting the single target row.
+ */
+export function extendRowSelection(
+  state: SelectionState,
+  rowId: string,
+  columns: ColumnDef<any>[],
+): SelectionState {
+  if (state.mode === 'none') return state;
+  const firstCol = columns[0]?.field ?? '';
+  const lastCol = columns[columns.length - 1]?.field ?? '';
+  if (!state.range) {
+    return selectRow(state, rowId, columns);
+  }
+  // Anchor stays on whatever the prior selection's anchor row was, pinned to
+  // the first column. Focus snaps to the target row's last column.
+  const anchorRowId = state.range.anchor.rowId;
+  const newRange: CellRange = {
+    anchor: { rowId: anchorRowId, field: firstCol },
+    focus: { rowId, field: lastCol },
+    kind: 'row',
+  };
   const updatedRanges = state.ranges.length > 0
     ? [...state.ranges.slice(0, -1), newRange]
     : [newRange];
@@ -251,10 +291,12 @@ export function toggleRowSelection(state: SelectionState, rowId: string, columns
     // Remove the existing range for this row
     newRanges = [...state.ranges.slice(0, existingIdx), ...state.ranges.slice(existingIdx + 1)];
   } else {
-    // Add a new full-row range
+    // Add a new full-row range. Tag it as a row-kind selection so the
+    // renderer paints a row-level outline even when the grid's
+    // `selectionMode` is `'cell'` or `'range'`.
     newRanges = [
       ...state.ranges,
-      { anchor: { rowId, field: firstCol }, focus: { rowId, field: lastCol } },
+      { anchor: { rowId, field: firstCol }, focus: { rowId, field: lastCol }, kind: 'row' as const },
     ];
   }
 
@@ -517,8 +559,11 @@ export function getRowSelectionBorders(
   const rowIdx = rowIds.indexOf(rowId);
   if (rowIdx === -1) return null;
 
-  // Multi-row covering ranges only activate borders in 'row' mode so that a
-  // Ctrl+A select-all in cell/range mode does not suppress per-cell outlines.
+  // A range is treated as row-covering when it was created with the row
+  // intent (chrome row-number click / Shift+rowheader / Cmd+rowheader) or
+  // when the grid itself is in explicit row-selection mode. Crucially, a
+  // Ctrl+A select-all in cell/range mode produces a range *without*
+  // `kind: 'row'` so per-cell outlines still apply there.
   const isRowMode = state.mode === 'row';
 
   function isFullRowCovering(range: CellRange): boolean {
@@ -526,8 +571,14 @@ export function getRowSelectionBorders(
     const focusRowIdx = rowIds.indexOf(range.focus.rowId);
     const minRow = Math.min(anchorRowIdx, focusRowIdx);
     const maxRow = Math.max(anchorRowIdx, focusRowIdx);
-    // Multi-row ranges are gated on row mode; single-row ranges are always active.
-    if (minRow !== maxRow && !isRowMode) return false;
+    const isRowIntent = range.kind === 'row' || isRowMode;
+    // Row-intent ranges are always candidates; cell/range-intent multi-row
+    // ranges are not row-covering so Ctrl+A keeps its cell-level visual.
+    if (minRow !== maxRow && !isRowIntent) return false;
+    if (!isRowIntent && minRow === maxRow) {
+      // Singleton in cell/range mode is row-covering only when the range
+      // structurally spans every column (preserves the PR #58 contract).
+    }
     if (rowIdx < minRow || rowIdx > maxRow) return false;
     return (
       (range.anchor.field === firstField && range.focus.field === lastField) ||

--- a/packages/core/src/selection.ts
+++ b/packages/core/src/selection.ts
@@ -517,11 +517,17 @@ export function getRowSelectionBorders(
   const rowIdx = rowIds.indexOf(rowId);
   if (rowIdx === -1) return null;
 
+  // Multi-row covering ranges only activate borders in 'row' mode so that a
+  // Ctrl+A select-all in cell/range mode does not suppress per-cell outlines.
+  const isRowMode = state.mode === 'row';
+
   function isFullRowCovering(range: CellRange): boolean {
     const anchorRowIdx = rowIds.indexOf(range.anchor.rowId);
     const focusRowIdx = rowIds.indexOf(range.focus.rowId);
     const minRow = Math.min(anchorRowIdx, focusRowIdx);
     const maxRow = Math.max(anchorRowIdx, focusRowIdx);
+    // Multi-row ranges are gated on row mode; single-row ranges are always active.
+    if (minRow !== maxRow && !isRowMode) return false;
     if (rowIdx < minRow || rowIdx > maxRow) return false;
     return (
       (range.anchor.field === firstField && range.focus.field === lastField) ||

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -146,12 +146,21 @@ export interface CellAddress {
 /**
  * A contiguous rectangular selection described by an anchor (the cell where the
  * selection started) and a focus (the cell where it currently ends).
+ *
+ * `kind` records the user's selection *intent* at the time the range was
+ * created. A range carrying `kind: 'row'` was produced by a chrome row-number
+ * gutter interaction (plain / Shift / Cmd click or the row-aware keyboard
+ * helpers) and is rendered as a row-level outline regardless of the grid's
+ * `selectionMode`. Ranges without `kind` are plain cell/range selections and
+ * keep the pre-existing per-cell outline / range-tint visual.
  */
 export interface CellRange {
   /** The originating cell of the selection. */
   anchor: CellAddress;
   /** The terminal cell of the selection. */
   focus: CellAddress;
+  /** Selection intent; only `'row'` is used today. */
+  kind?: 'row';
 }
 
 /**

--- a/packages/react/src/DataGrid.tsx
+++ b/packages/react/src/DataGrid.tsx
@@ -54,7 +54,7 @@ import {
   getVisibleRowsWithGroups,
   isCellInRange,
   createSelectionChecker,
-  isRowFullySelected,
+  getRowSelectionBorders as coreGetRowSelectionBorders,
   stripField,
 } from '@istracked/datagrid-core';
 import { useGridWithAtoms } from './use-grid';
@@ -498,9 +498,10 @@ export function DataGrid<TData extends Record<string, unknown>>(props: DataGridP
     return selectionChecker(rowIdx, colIdx);
   }, [hasMultiCellRange, selectionChecker, rowIds, orderedVisibleColumns]);
 
-  const isRowSelected = useCallback((rowId: string): boolean => {
-    return isRowFullySelected(state.selection, rowId, orderedVisibleColumns);
-  }, [state.selection, orderedVisibleColumns]);
+  const getRowSelectionBorders = useCallback(
+    (rowId: string) => coreGetRowSelectionBorders(state.selection, rowId, orderedVisibleColumns, rowIds),
+    [state.selection, orderedVisibleColumns, rowIds],
+  );
 
   const isEditingCell = useCallback((rowId: string, field: string): boolean => {
     const cell = state.editing.cell;
@@ -1354,7 +1355,7 @@ export function DataGrid<TData extends Record<string, unknown>>(props: DataGridP
           scrollRef={scrollRef}
           handleScroll={handleScroll}
           isSelected={isSelected}
-          isRowSelected={isRowSelected}
+          getRowSelectionBorders={getRowSelectionBorders}
           isInRange={isInRange}
           isEditingCell={isEditingCell}
           getCellType={getCellType}

--- a/packages/react/src/DataGrid.tsx
+++ b/packages/react/src/DataGrid.tsx
@@ -789,15 +789,18 @@ export function DataGrid<TData extends Record<string, unknown>>(props: DataGridP
 
   const handleRowNumberClick = useCallback((rowId: string, shiftKey: boolean, metaKey: boolean) => {
     if (metaKey) {
+      // Cmd/Ctrl+click toggles a disjoint row selection.
       model.toggleRowSelect(rowId);
     } else if (shiftKey) {
-      const cols = orderedVisibleColumns;
-      const lastCol = cols[cols.length - 1];
-      if (lastCol) model.extendTo({ rowId, field: lastCol.field });
+      // Shift+click extends the selection to a contiguous row range. Route
+      // through `extendRowSelection` (rather than generic `extendTo`) so the
+      // resulting range is tagged `kind: 'row'` and renders as a single
+      // row-level outline regardless of the grid's `selectionMode`.
+      model.extendRowSelection(rowId);
     } else {
       model.selectRowByKey(rowId);
     }
-  }, [model, orderedVisibleColumns]);
+  }, [model]);
 
   const [rowDragState, setRowDragState] = useState<{ sourceRowId: string; sourceIndex: number } | null>(null);
 

--- a/packages/react/src/__tests__/chrome-columns.test.tsx
+++ b/packages/react/src/__tests__/chrome-columns.test.tsx
@@ -133,10 +133,10 @@ describe('Row Number Column', () => {
     const rowNumberCells = screen.getAllByTestId('chrome-row-number');
     fireEvent.click(rowNumberCells[0]!);
 
-    // With row-level outline: the row container gets the outline and per-cell
-    // outlines are suppressed.
+    // With row-level outline: the row container gets the box-shadow and
+    // per-cell outlines are suppressed.
     const row = document.querySelector('[data-row-id="1"][role="row"]') as HTMLElement;
-    expect(row.style.outline).toContain('2px solid');
+    expect(row.style.boxShadow).toContain('--dg-selection-border');
     const cells = row.querySelectorAll('[role="gridcell"]');
     cells.forEach((cell) => {
       expect((cell as HTMLElement).style.outline).toBe('none');
@@ -144,7 +144,7 @@ describe('Row Number Column', () => {
   });
 
   it('shift+click extends selection to clicked row', () => {
-    renderGrid({ chrome: { rowNumbers: true } });
+    renderGrid({ chrome: { rowNumbers: true }, selectionMode: 'row' });
     const rowNumberCells = screen.getAllByTestId('chrome-row-number');
 
     // Click row 1
@@ -152,12 +152,14 @@ describe('Row Number Column', () => {
     // Shift+click row 3
     fireEvent.click(rowNumberCells[2]!, { shiftKey: true });
 
-    // All three rows should be selected — check cells in each row
+    // All three rows should be selected — row-level box-shadow is present and
+    // per-cell outlines are suppressed.
     ['1', '2', '3'].forEach((rowId) => {
       const row = document.querySelector(`[data-row-id="${rowId}"][role="row"]`) as HTMLElement;
+      expect(row.style.boxShadow).toContain('--dg-selection-border');
       const cells = row.querySelectorAll('[role="gridcell"]');
       cells.forEach((cell) => {
-        expect((cell as HTMLElement).style.outline).toContain('2px solid');
+        expect((cell as HTMLElement).style.outline).toBe('none');
       });
     });
   });
@@ -172,23 +174,24 @@ describe('Row Number Column', () => {
     fireEvent.click(rowNumberCells[2]!, { metaKey: true });
 
     // Row 3 is the last-selected (primary) range: it gets the row-level
-    // outline and its cells are suppressed.
+    // box-shadow and its cells are suppressed.
     const row3 = document.querySelector('[data-row-id="3"][role="row"]') as HTMLElement;
-    expect(row3.style.outline).toContain('2px solid');
+    expect(row3.style.boxShadow).toContain('--dg-selection-border');
     row3.querySelectorAll('[role="gridcell"]').forEach((cell) => {
       expect((cell as HTMLElement).style.outline).toBe('none');
     });
 
-    // Row 1 is in the selection via ranges but is not the primary range, so
-    // cells retain their per-cell outlines.
+    // Row 1 is also selected (disjoint singleton) — row-level box-shadow is
+    // present and per-cell outlines are suppressed.
     const row1 = document.querySelector('[data-row-id="1"][role="row"]') as HTMLElement;
+    expect(row1.style.boxShadow).toContain('--dg-selection-border');
     row1.querySelectorAll('[role="gridcell"]').forEach((cell) => {
-      expect((cell as HTMLElement).style.outline).toContain('2px solid');
+      expect((cell as HTMLElement).style.outline).toBe('none');
     });
 
-    // Row 2 should NOT be selected — no outline on row or cells.
+    // Row 2 should NOT be selected — no box-shadow or cell outlines.
     const row2 = document.querySelector('[data-row-id="2"][role="row"]') as HTMLElement;
-    expect(row2.style.outline ?? '').not.toContain('2px solid');
+    expect(row2.style.boxShadow ?? '').not.toContain('--dg-selection-border');
     row2.querySelectorAll('[role="gridcell"]').forEach((cell) => {
       expect((cell as HTMLElement).style.outline).not.toContain('2px solid');
     });

--- a/packages/react/src/__tests__/chrome-row-apis.test.tsx
+++ b/packages/react/src/__tests__/chrome-row-apis.test.tsx
@@ -222,10 +222,10 @@ describe('chrome.getChromeCellContent', () => {
     expect(onClick.mock.calls[0]![1]).toBe('1'); // rowId
     expect(onClick.mock.calls[0]![2]).toBe(0); // rowIndex
 
-    // Default row-selection still fires — the row container gets the outline
+    // Default row-selection still fires — the row container gets the box-shadow
     // and per-cell outlines are suppressed.
     const row1 = document.querySelector('[data-row-id="1"][role="row"]') as HTMLElement;
-    expect(row1.style.outline).toContain('2px solid');
+    expect(row1.style.boxShadow).toContain('--dg-selection-border');
     const gridcells = row1.querySelectorAll('[role="gridcell"]');
     gridcells.forEach((cell) => {
       expect((cell as HTMLElement).style.outline).toBe('none');

--- a/packages/react/src/__tests__/json-config.test.tsx
+++ b/packages/react/src/__tests__/json-config.test.tsx
@@ -111,9 +111,9 @@ describe('JSON config — selection mode', () => {
     const cells = screen.getAllByRole('gridcell');
     fireEvent.click(cells[0]!);
     // In row mode a full-row selection is created. The row container gets the
-    // outline; per-cell outlines are suppressed.
+    // box-shadow; per-cell outlines are suppressed.
     const firstRow = document.querySelector('[role="row"][data-row-id]') as HTMLElement;
-    expect(firstRow.style.outline).toContain('2px solid');
+    expect(firstRow.style.boxShadow).toContain('--dg-selection-border');
     expect(cells[0]).toHaveStyle({ outline: 'none' });
   });
 

--- a/packages/react/src/__tests__/row-click-selection.test.tsx
+++ b/packages/react/src/__tests__/row-click-selection.test.tsx
@@ -74,6 +74,10 @@ function hasSelectionOutline(el: HTMLElement): boolean {
   return el.style.outline.includes('2px solid');
 }
 
+function rowHasSelectionShadow(el: HTMLElement): boolean {
+  return el.style.boxShadow.includes('--dg-selection-border');
+}
+
 function getRowEl(rowId: string): HTMLElement {
   const row = document.querySelector(
     `[role="row"][data-row-id="${rowId}"]`,
@@ -92,10 +96,10 @@ describe('row-click selection (issue #15)', () => {
 
     fireEvent.click(getCell('2', 'name'));
 
-    // With the row-level outline feature, the row container gets the outline
+    // With the row-level outline feature, the row container gets the box-shadow
     // and per-cell outlines are suppressed. Verify the row is visually selected.
     const rowEl = getRowEl('2');
-    expect(rowEl.style.outline).toContain('2px solid');
+    expect(rowHasSelectionShadow(rowEl)).toBe(true);
 
     // Per-cell outlines are suppressed — the row outline replaces them.
     const rowCells = getAllCellsInRow('2');
@@ -106,7 +110,7 @@ describe('row-click selection (issue #15)', () => {
 
     // Other rows are unaffected.
     const otherRowEl = getRowEl('1');
-    expect(otherRowEl.style.outline ?? '').not.toContain('2px solid');
+    expect(rowHasSelectionShadow(otherRowEl)).toBe(false);
   });
 
   it('produces the same selection whether the click came from a data cell or the row-number gutter', () => {
@@ -116,7 +120,7 @@ describe('row-click selection (issue #15)', () => {
       chrome: { rowNumbers: true },
     });
     fireEvent.click(getCell('3', 'score'));
-    const afterCellClick = getRowEl('3').style.outline.includes('2px solid');
+    const afterCellClick = rowHasSelectionShadow(getRowEl('3'));
     unmount();
 
     // Row-number gutter click path on a freshly rendered grid.
@@ -124,7 +128,7 @@ describe('row-click selection (issue #15)', () => {
     const rowNumberCells = screen.getAllByTestId('chrome-row-number');
     // Row 3 is at index 2 in the data order.
     fireEvent.click(rowNumberCells[2]!);
-    const afterGutterClick = getRowEl('3').style.outline.includes('2px solid');
+    const afterGutterClick = rowHasSelectionShadow(getRowEl('3'));
 
     expect(afterCellClick).toBe(true);
     expect(afterGutterClick).toBe(true);
@@ -136,19 +140,20 @@ describe('row-click selection (issue #15)', () => {
     // Ctrl+click row 2 — should add row 2 (without clearing row 1) because
     // the chrome click handler interprets `metaKey` as a toggle.
     fireEvent.click(getCell('2', 'age'), { ctrlKey: true });
-    // The row container for row 2 gets the outline (last selected range).
-    expect(getRowEl('2').style.outline).toContain('2px solid');
+    // The row container for row 2 gets the selection shadow (last selected range).
+    expect(rowHasSelectionShadow(getRowEl('2'))).toBe(true);
   });
 
   it('Shift+click on a data cell extends the range from the last anchor', () => {
     renderGrid({ selectionMode: 'row' });
     fireEvent.click(getCell('1', 'name'));
     fireEvent.click(getCell('3', 'score'), { shiftKey: true });
-    // Shift produces a multi-row range (rows 1-3) with anchor/focus on different
-    // rows, so isRowFullySelected returns false. Per-cell outlines remain visible.
+    // Shift produces a contiguous multi-row full-row range (rows 1-3).
+    // Row-level box-shadow is shown and per-cell outlines are suppressed.
     ['1', '2', '3'].forEach((rowId) => {
+      expect(rowHasSelectionShadow(getRowEl(rowId))).toBe(true);
       getAllCellsInRow(rowId).forEach((cell) => {
-        expect(hasSelectionOutline(cell)).toBe(true);
+        expect(cell.style.outline).toBe('none');
       });
     });
   });
@@ -243,7 +248,7 @@ describe('row-click selection does not change other selection modes', () => {
 // ---------------------------------------------------------------------------
 
 describe('row-level selection outline on rowheader click', () => {
-  it('row element gets outline and per-cell outlines are suppressed after rowheader click', () => {
+  it('row element gets boxShadow and per-cell outlines are suppressed after rowheader click', () => {
     renderGrid({ selectionMode: 'row', chrome: { rowNumbers: true } });
 
     const rowNumberCells = screen.getAllByTestId('chrome-row-number');
@@ -251,9 +256,8 @@ describe('row-level selection outline on rowheader click', () => {
     fireEvent.click(rowNumberCells[1]!);
 
     const rowEl = getRowEl('2');
-    // The row itself must carry the selection outline (2px solid is the reliable
-    // part; jsdom may strip or truncate CSS variable fallback values).
-    expect(rowEl.style.outline).toContain('2px solid');
+    // The row itself must carry the selection box-shadow.
+    expect(rowHasSelectionShadow(rowEl)).toBe(true);
 
     // Every gridcell in that row must have its outline suppressed.
     getAllCellsInRow('2').forEach((cell) => {
@@ -261,14 +265,14 @@ describe('row-level selection outline on rowheader click', () => {
     });
   });
 
-  it('per-cell outlines remain and no row outline when a single gridcell is clicked (cell mode)', () => {
+  it('per-cell outlines remain and no row boxShadow when a single gridcell is clicked (cell mode)', () => {
     renderGrid({ selectionMode: 'cell' });
 
     fireEvent.click(getCell('1', 'name'));
 
     const rowEl = getRowEl('1');
-    // No row-level outline in cell mode.
-    expect(rowEl.style.outline ?? '').not.toContain('2px solid');
+    // No row-level box-shadow in cell mode.
+    expect(rowHasSelectionShadow(rowEl)).toBe(false);
 
     // The clicked cell keeps its own outline.
     expect(hasSelectionOutline(getCell('1', 'name'))).toBe(true);

--- a/packages/react/src/__tests__/row-range-keyboard.test.tsx
+++ b/packages/react/src/__tests__/row-range-keyboard.test.tsx
@@ -1,0 +1,184 @@
+/**
+ * §3 keyboard navigation tests for row-range selection mode.
+ *
+ * When selectionMode='row', arrow-key navigation should move row-by-row rather
+ * than cell-by-cell, and Shift+Arrow (with shiftArrowBehavior='rangeSelect')
+ * should extend the full-row range rather than extending a rectangular cell range.
+ *
+ * Tests verify:
+ *   1. ArrowDown selects the next row (all cells) when in row mode.
+ *   2. ArrowUp selects the previous row (all cells) when in row mode.
+ *   3. ArrowDown is a no-op at the last row.
+ *   4. ArrowUp is a no-op at the first row.
+ *   5. Shift+ArrowDown (rangeSelect) extends the selection to include the next row.
+ *   6. Shift+ArrowUp (rangeSelect) extends the selection to include the previous row.
+ *   7. In cell/range mode, ArrowDown still navigates cell-by-cell (no regression).
+ */
+import React from 'react';
+import { render, fireEvent, screen } from '@testing-library/react';
+import { DataGrid } from '../DataGrid';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+type TestRow = { id: string; name: string; age: number };
+
+function makeRows(): TestRow[] {
+  return [
+    { id: '1', name: 'Alice', age: 30 },
+    { id: '2', name: 'Bob', age: 25 },
+    { id: '3', name: 'Charlie', age: 35 },
+  ];
+}
+
+const columns = [
+  { id: 'name', field: 'name', title: 'Name' },
+  { id: 'age', field: 'age', title: 'Age' },
+];
+
+function renderGrid(overrides: Partial<Parameters<typeof DataGrid>[0]> = {}) {
+  return render(
+    <DataGrid
+      data={makeRows()}
+      columns={columns}
+      rowKey="id"
+      {...(overrides as any)}
+    />,
+  );
+}
+
+function getGrid() {
+  return screen.getByRole('grid');
+}
+
+function getCell(rowId: string, field: string): HTMLElement {
+  const cell = document.querySelector(
+    `[data-row-id="${rowId}"][data-field="${field}"][role="gridcell"]`,
+  );
+  if (!cell) throw new Error(`Cell not found: rowId=${rowId} field=${field}`);
+  return cell as HTMLElement;
+}
+
+function getRowEl(rowId: string): HTMLElement {
+  const row = document.querySelector(`[role="row"][data-row-id="${rowId}"]`);
+  if (!row) throw new Error(`Row not found: rowId=${rowId}`);
+  return row as HTMLElement;
+}
+
+function rowIsSelected(rowId: string): boolean {
+  return getRowEl(rowId).style.boxShadow.includes('--dg-selection-border');
+}
+
+function cellIsSelected(rowId: string, field: string): boolean {
+  return getCell(rowId, field).style.outline.includes('2px solid');
+}
+
+// ---------------------------------------------------------------------------
+// Plain arrow navigation in row mode
+// ---------------------------------------------------------------------------
+
+describe('row mode — plain arrow key navigation', () => {
+  it('ArrowDown moves selection to the next row', () => {
+    renderGrid({ selectionMode: 'row' });
+    // Select row 1 first
+    fireEvent.click(getCell('1', 'name'));
+    expect(rowIsSelected('1')).toBe(true);
+
+    fireEvent.keyDown(getGrid(), { key: 'ArrowDown' });
+    expect(rowIsSelected('2')).toBe(true);
+    expect(rowIsSelected('1')).toBe(false);
+  });
+
+  it('ArrowUp moves selection to the previous row', () => {
+    renderGrid({ selectionMode: 'row' });
+    fireEvent.click(getCell('2', 'name'));
+    expect(rowIsSelected('2')).toBe(true);
+
+    fireEvent.keyDown(getGrid(), { key: 'ArrowUp' });
+    expect(rowIsSelected('1')).toBe(true);
+    expect(rowIsSelected('2')).toBe(false);
+  });
+
+  it('ArrowDown at the last row stays on the last row', () => {
+    renderGrid({ selectionMode: 'row' });
+    fireEvent.click(getCell('3', 'name'));
+    expect(rowIsSelected('3')).toBe(true);
+
+    fireEvent.keyDown(getGrid(), { key: 'ArrowDown' });
+    expect(rowIsSelected('3')).toBe(true);
+  });
+
+  it('ArrowUp at the first row stays on the first row', () => {
+    renderGrid({ selectionMode: 'row' });
+    fireEvent.click(getCell('1', 'name'));
+    expect(rowIsSelected('1')).toBe(true);
+
+    fireEvent.keyDown(getGrid(), { key: 'ArrowUp' });
+    expect(rowIsSelected('1')).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Shift+Arrow range extension in row mode
+// ---------------------------------------------------------------------------
+
+describe('row mode — Shift+Arrow range extension (rangeSelect)', () => {
+  it('Shift+ArrowDown extends the row range downward', () => {
+    renderGrid({ selectionMode: 'row', shiftArrowBehavior: 'rangeSelect' });
+    fireEvent.click(getCell('1', 'name'));
+    expect(rowIsSelected('1')).toBe(true);
+
+    fireEvent.keyDown(getGrid(), { key: 'ArrowDown', shiftKey: true });
+
+    // Both rows 1 and 2 should be covered by the selection.
+    expect(rowIsSelected('1')).toBe(true);
+    expect(rowIsSelected('2')).toBe(true);
+    expect(rowIsSelected('3')).toBe(false);
+  });
+
+  it('Shift+ArrowUp extends the row range upward', () => {
+    renderGrid({ selectionMode: 'row', shiftArrowBehavior: 'rangeSelect' });
+    fireEvent.click(getCell('3', 'name'));
+    expect(rowIsSelected('3')).toBe(true);
+
+    fireEvent.keyDown(getGrid(), { key: 'ArrowUp', shiftKey: true });
+
+    // Rows 2 and 3 should be covered.
+    expect(rowIsSelected('2')).toBe(true);
+    expect(rowIsSelected('3')).toBe(true);
+    expect(rowIsSelected('1')).toBe(false);
+  });
+
+  it('successive Shift+ArrowDown keystrokes compound to cover more rows', () => {
+    renderGrid({ selectionMode: 'row', shiftArrowBehavior: 'rangeSelect' });
+    fireEvent.click(getCell('1', 'name'));
+    fireEvent.keyDown(getGrid(), { key: 'ArrowDown', shiftKey: true });
+    fireEvent.keyDown(getGrid(), { key: 'ArrowDown', shiftKey: true });
+
+    // Rows 1, 2, and 3 should all be in the selection.
+    expect(rowIsSelected('1')).toBe(true);
+    expect(rowIsSelected('2')).toBe(true);
+    expect(rowIsSelected('3')).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Non-row mode regression: ArrowDown still navigates cell-by-cell
+// ---------------------------------------------------------------------------
+
+describe('non-row mode arrow keys are unchanged', () => {
+  it('ArrowDown in cell mode moves down by one cell (not row-select)', () => {
+    renderGrid({ selectionMode: 'cell' });
+    fireEvent.click(getCell('1', 'name'));
+    expect(cellIsSelected('1', 'name')).toBe(true);
+
+    fireEvent.keyDown(getGrid(), { key: 'ArrowDown' });
+
+    // Should move to row 2, name column only — not the whole row.
+    expect(cellIsSelected('2', 'name')).toBe(true);
+    expect(cellIsSelected('2', 'age')).toBe(false);
+    // Row-level box-shadow must not appear.
+    expect(rowIsSelected('2')).toBe(false);
+  });
+});

--- a/packages/react/src/__tests__/row-range-selection.test.tsx
+++ b/packages/react/src/__tests__/row-range-selection.test.tsx
@@ -1,0 +1,177 @@
+/**
+ * RTL tests for row-range selection rendering (§2).
+ *
+ * Verifies:
+ *   - Shift+click rowheader extends to a contiguous range → rows carry
+ *     inset box-shadow; per-cell outlines inside are 'none'.
+ *   - Ctrl+click rowheader after a click toggles a disjoint second row.
+ *   - Ctrl+click same rowheader twice removes it.
+ *   - Bug regression: after click row 2, Ctrl+click row 5, row 2 still
+ *     carries row-level boxShadow (was missing before §1 fix).
+ */
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { DataGrid } from '../DataGrid';
+
+type TestRow = { id: string; name: string; age: number; city: string };
+
+function makeRows(): TestRow[] {
+  return [
+    { id: '1', name: 'Alice', age: 30, city: 'Paris' },
+    { id: '2', name: 'Bob', age: 25, city: 'Lyon' },
+    { id: '3', name: 'Charlie', age: 35, city: 'Nice' },
+    { id: '4', name: 'Diana', age: 28, city: 'Bordeaux' },
+    { id: '5', name: 'Eve', age: 32, city: 'Marseille' },
+  ];
+}
+
+const columns = [
+  { id: 'name', field: 'name', title: 'Name' },
+  { id: 'age', field: 'age', title: 'Age' },
+  { id: 'city', field: 'city', title: 'City' },
+];
+
+function renderGrid() {
+  return render(
+    <DataGrid
+      data={makeRows()}
+      columns={columns}
+      rowKey="id"
+      selectionMode="row"
+      chrome={{ rowNumbers: true }}
+    />,
+  );
+}
+
+function getRowEl(rowId: string): HTMLElement {
+  const row = document.querySelector(`[role="row"][data-row-id="${rowId}"]`);
+  if (!row) throw new Error(`Row not found: ${rowId}`);
+  return row as HTMLElement;
+}
+
+function getAllCellsInRow(rowId: string): HTMLElement[] {
+  return Array.from(
+    document.querySelectorAll(`[data-row-id="${rowId}"][role="gridcell"]`),
+  ) as HTMLElement[];
+}
+
+function rowHasSelectionShadow(rowId: string): boolean {
+  const shadow = getRowEl(rowId).style.boxShadow;
+  return shadow.includes('--dg-selection-border');
+}
+
+// ---------------------------------------------------------------------------
+// Shift+click extends to a contiguous range
+// ---------------------------------------------------------------------------
+
+describe('row-range selection — Shift+click', () => {
+  it('rows 1, 2, 3 all carry boxShadow; per-cell outlines are none', () => {
+    renderGrid();
+    const rowNumbers = screen.getAllByTestId('chrome-row-number');
+
+    // Click row 1, then Shift+click row 3
+    fireEvent.click(rowNumbers[0]!);
+    fireEvent.click(rowNumbers[2]!, { shiftKey: true });
+
+    expect(rowHasSelectionShadow('1')).toBe(true);
+    expect(rowHasSelectionShadow('2')).toBe(true);
+    expect(rowHasSelectionShadow('3')).toBe(true);
+
+    // Per-cell outlines are suppressed inside selected rows
+    ['1', '2', '3'].forEach((rowId) => {
+      getAllCellsInRow(rowId).forEach((cell) => {
+        expect(cell.style.outline).toBe('none');
+      });
+    });
+  });
+
+  it('row 1 shadow has top inset; row 3 has bottom inset; row 2 has neither', () => {
+    renderGrid();
+    const rowNumbers = screen.getAllByTestId('chrome-row-number');
+    fireEvent.click(rowNumbers[0]!);
+    fireEvent.click(rowNumbers[2]!, { shiftKey: true });
+
+    const shadow1 = getRowEl('1').style.boxShadow;
+    const shadow2 = getRowEl('2').style.boxShadow;
+    const shadow3 = getRowEl('3').style.boxShadow;
+
+    // top shadow is `inset 0 2px ...`
+    expect(shadow1).toContain('inset 0 2px');
+    // bottom shadow is `inset 0 -2px ...`
+    expect(shadow3).toContain('inset 0 -2px');
+    // middle row should not have top or bottom inset
+    expect(shadow2).not.toContain('inset 0 2px');
+    expect(shadow2).not.toContain('inset 0 -2px');
+  });
+
+  it('rows 4 and 5 do not carry boxShadow after range selects rows 1-3', () => {
+    renderGrid();
+    const rowNumbers = screen.getAllByTestId('chrome-row-number');
+    fireEvent.click(rowNumbers[0]!);
+    fireEvent.click(rowNumbers[2]!, { shiftKey: true });
+
+    expect(rowHasSelectionShadow('4')).toBe(false);
+    expect(rowHasSelectionShadow('5')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Ctrl+click toggles disjoint selection
+// ---------------------------------------------------------------------------
+
+describe('row-range selection — Ctrl+click', () => {
+  it('rows 2 and 5 have all four inset shadows after click 2 then Ctrl+click 5', () => {
+    renderGrid();
+    const rowNumbers = screen.getAllByTestId('chrome-row-number');
+    fireEvent.click(rowNumbers[1]!);
+    fireEvent.click(rowNumbers[4]!, { ctrlKey: true });
+
+    const shadow2 = getRowEl('2').style.boxShadow;
+    const shadow5 = getRowEl('5').style.boxShadow;
+
+    // Both singleton rows must have all four inset shadow segments
+    expect(shadow2).toContain('inset 0 2px');
+    expect(shadow2).toContain('inset 0 -2px');
+    expect(shadow2).toContain('inset 2px 0');
+    expect(shadow2).toContain('inset -2px 0');
+
+    expect(shadow5).toContain('inset 0 2px');
+    expect(shadow5).toContain('inset 0 -2px');
+    expect(shadow5).toContain('inset 2px 0');
+    expect(shadow5).toContain('inset -2px 0');
+  });
+
+  it('row 3 has no boxShadow when rows 2 and 5 are disjoint-selected', () => {
+    renderGrid();
+    const rowNumbers = screen.getAllByTestId('chrome-row-number');
+    fireEvent.click(rowNumbers[1]!);
+    fireEvent.click(rowNumbers[4]!, { ctrlKey: true });
+
+    expect(rowHasSelectionShadow('3')).toBe(false);
+  });
+
+  it('Ctrl+click same rowheader twice removes it', () => {
+    renderGrid();
+    const rowNumbers = screen.getAllByTestId('chrome-row-number');
+    fireEvent.click(rowNumbers[1]!);
+    fireEvent.click(rowNumbers[4]!, { ctrlKey: true });
+    // Ctrl+click row 5 again to remove it
+    fireEvent.click(rowNumbers[4]!, { ctrlKey: true });
+
+    expect(rowHasSelectionShadow('5')).toBe(false);
+    // Row 2 is still selected
+    expect(rowHasSelectionShadow('2')).toBe(true);
+  });
+
+  it('bug regression: row 2 keeps its boxShadow after Ctrl+click adds row 5', () => {
+    renderGrid();
+    const rowNumbers = screen.getAllByTestId('chrome-row-number');
+    // Click row 2 to select it
+    fireEvent.click(rowNumbers[1]!);
+    // Ctrl+click row 5 — before the §1 fix, row 2 would lose its outline
+    fireEvent.click(rowNumbers[4]!, { ctrlKey: true });
+
+    // Row 2 must STILL carry the row-level box-shadow
+    expect(rowHasSelectionShadow('2')).toBe(true);
+  });
+});

--- a/packages/react/src/atomic-grid-model.ts
+++ b/packages/react/src/atomic-grid-model.ts
@@ -322,6 +322,11 @@ export function createAtomicGridModel<TData extends Record<string, unknown>>(
       store.set(atoms.actions.extendSelectionAtom, cell);
     },
 
+    /** {@inheritDoc GridModel.extendRowSelection} */
+    extendRowSelection(rowId: string) {
+      store.set(atoms.actions.extendRowSelectionAtom, rowId);
+    },
+
     /** {@inheritDoc GridModel.selectAllCells} */
     selectAllCells() {
       store.set(atoms.actions.selectAllAtom);

--- a/packages/react/src/atoms/action-atoms.ts
+++ b/packages/react/src/atoms/action-atoms.ts
@@ -32,6 +32,7 @@ import {
   selectRow,
   selectColumn,
   extendSelection,
+  extendRowSelection,
   clearSelection,
   selectAll,
   beginEdit as beginEditState,
@@ -98,6 +99,8 @@ export interface ActionAtoms<TData = Record<string, unknown>> {
   selectColumnAtom: WriteOnlyAtom<[field: string]>;
   /** Extend the current selection range to include a target cell (shift-click). */
   extendSelectionAtom: WriteOnlyAtom<[cell: CellAddress]>;
+  /** Extend the current selection to cover every row between the anchor and the target (Shift+click on a row-number cell). */
+  extendRowSelectionAtom: WriteOnlyAtom<[rowId: string]>;
   /** Select all cells across every visible column and row. */
   selectAllAtom: WriteOnlyAtom<[]>;
   /** Clear the current selection entirely. */
@@ -458,6 +461,22 @@ export function createActionAtoms<TData extends Record<string, unknown>>(
   );
 
   /**
+   * Extend the current selection to a full-row range anchored on whichever
+   * row was last selected. Triggered by Shift+click on a chrome row-number
+   * cell; snaps the anchor/focus to the first/last visible columns and tags
+   * the range with `kind: 'row'` so the renderer paints it as a row-level
+   * outline irrespective of `selectionMode`.
+   */
+  const extendRowSelectionAtom = atom(
+    null,
+    (get, set, rowId: string) => {
+      const selection = get(baseAtoms.selectionAtom);
+      const cols = getVisibleColumns(get(baseAtoms.columnsAtom)) as ColumnDef[];
+      set(baseAtoms.selectionAtom, extendRowSelection(selection, rowId, cols));
+    },
+  );
+
+  /**
    * Select every cell in the grid by spanning all visible columns and all
    * rows.
    */
@@ -667,6 +686,7 @@ export function createActionAtoms<TData extends Record<string, unknown>>(
     selectRowAtom,
     selectColumnAtom,
     extendSelectionAtom,
+    extendRowSelectionAtom,
     selectAllAtom,
     clearSelectionAtom,
     setColumnWidthAtom,

--- a/packages/react/src/body/DataGridBody.styles.ts
+++ b/packages/react/src/body/DataGridBody.styles.ts
@@ -13,6 +13,7 @@
  * rows, aggregate rows, data rows, row-number overrides, empty state).
  */
 import type { CSSProperties } from 'react';
+import type { RowOutlineSides } from '@istracked/datagrid-core';
 
 // ---------------------------------------------------------------------------
 // Scrollable body
@@ -251,33 +252,39 @@ function rowBorderOverrideStyle(border: RowBorderOverride | null | undefined): C
  *  `isEven` selects the zebra-striping background token. `background` and
  *  `border`, when provided, win over the default zebra stripe and the row
  *  separator respectively — see `chrome.getRowBackground` and
- *  `chrome.getRowBorder`. */
+ *  `chrome.getRowBorder`. `borders` drives a per-side inset box-shadow that
+ *  replaces the old all-or-nothing `outline` so contiguous multi-row ranges
+ *  can suppress internal horizontal borders. */
 export const dataRow = (opts: {
   height: number;
   totalWidth: number;
   isEven: boolean;
   background?: string | null;
   border?: RowBorderOverride | null;
-  rowSelected?: boolean;
-}): CSSProperties => ({
-  display: 'flex',
-  height: opts.height,
-  width: opts.totalWidth,
-  borderBottom: '1px solid var(--dg-border-color, #e2e8f0)',
-  background: opts.background ?? (opts.isEven
-    ? 'var(--dg-row-bg, #ffffff)'
-    : 'var(--dg-row-bg-alt, #f8fafc)'),
-  // Border override last so it replaces any default edge styling above.
-  ...rowBorderOverrideStyle(opts.border),
-  ...(opts.rowSelected ? {
-    outline: '2px solid var(--dg-selection-border, #3b82f6)',
-    outlineOffset: -2,
-  } : {}),
-});
+  borders?: RowOutlineSides | null;
+}): CSSProperties => {
+  const shadowParts = opts.borders ? [
+    opts.borders.top    ? 'inset 0 2px 0 0 var(--dg-selection-border, #3b82f6)' : null,
+    opts.borders.right  ? 'inset -2px 0 0 0 var(--dg-selection-border, #3b82f6)' : null,
+    opts.borders.bottom ? 'inset 0 -2px 0 0 var(--dg-selection-border, #3b82f6)' : null,
+    opts.borders.left   ? 'inset 2px 0 0 0 var(--dg-selection-border, #3b82f6)' : null,
+  ].filter(Boolean).join(', ') : '';
+  return {
+    display: 'flex',
+    height: opts.height,
+    width: opts.totalWidth,
+    borderBottom: '1px solid var(--dg-border-color, #e2e8f0)',
+    background: opts.background ?? (opts.isEven
+      ? 'var(--dg-row-bg, #ffffff)'
+      : 'var(--dg-row-bg-alt, #f8fafc)'),
+    ...rowBorderOverrideStyle(opts.border),
+    ...(shadowParts ? { boxShadow: shadowParts } : {}),
+  };
+};
 
 /** Style for a data row on the virtualised (non-grouped) render path.
  *  Absolutely positioned at `top` inside the virtualised wrapper so rows
- *  outside `rowRange` can be skipped entirely. `background`/`border`
+ *  outside `rowRange` can be skipped entirely. `background`/`border`/`borders`
  *  semantics match {@link dataRow}. */
 export const virtualizedRow = (opts: {
   height: number;
@@ -286,23 +293,28 @@ export const virtualizedRow = (opts: {
   isEven: boolean;
   background?: string | null;
   border?: RowBorderOverride | null;
-  rowSelected?: boolean;
-}): CSSProperties => ({
-  display: 'flex',
-  position: 'absolute',
-  top: opts.top,
-  height: opts.height,
-  width: opts.totalWidth,
-  borderBottom: '1px solid var(--dg-border-color, #e2e8f0)',
-  background: opts.background ?? (opts.isEven
-    ? 'var(--dg-row-bg, #ffffff)'
-    : 'var(--dg-row-bg-alt, #f8fafc)'),
-  ...rowBorderOverrideStyle(opts.border),
-  ...(opts.rowSelected ? {
-    outline: '2px solid var(--dg-selection-border, #3b82f6)',
-    outlineOffset: -2,
-  } : {}),
-});
+  borders?: RowOutlineSides | null;
+}): CSSProperties => {
+  const shadowParts = opts.borders ? [
+    opts.borders.top    ? 'inset 0 2px 0 0 var(--dg-selection-border, #3b82f6)' : null,
+    opts.borders.right  ? 'inset -2px 0 0 0 var(--dg-selection-border, #3b82f6)' : null,
+    opts.borders.bottom ? 'inset 0 -2px 0 0 var(--dg-selection-border, #3b82f6)' : null,
+    opts.borders.left   ? 'inset 2px 0 0 0 var(--dg-selection-border, #3b82f6)' : null,
+  ].filter(Boolean).join(', ') : '';
+  return {
+    display: 'flex',
+    position: 'absolute',
+    top: opts.top,
+    height: opts.height,
+    width: opts.totalWidth,
+    borderBottom: '1px solid var(--dg-border-color, #e2e8f0)',
+    background: opts.background ?? (opts.isEven
+      ? 'var(--dg-row-bg, #ffffff)'
+      : 'var(--dg-row-bg-alt, #f8fafc)'),
+    ...rowBorderOverrideStyle(opts.border),
+    ...(shadowParts ? { boxShadow: shadowParts } : {}),
+  };
+};
 
 // ---------------------------------------------------------------------------
 // Row number chrome overrides for left (sticky) positioning

--- a/packages/react/src/body/DataGridBody.tsx
+++ b/packages/react/src/body/DataGridBody.tsx
@@ -604,9 +604,14 @@ export function DataGridBody<TData extends Record<string, unknown>>(
     // underneath the range highlight rather than being replaced by it. The
     // frozen-column background is the one exception and wins over both (see
     // `styles.cell`).
-    const cellBackground = isInRange && isInRange(rowId, col.field)
-      ? 'var(--dg-range-bg, rgba(59, 130, 246, 0.12))'
-      : null;
+    // When the row is fully covered by a row-kind selection we render a
+    // single outline around the row and suppress the per-cell range tint —
+    // otherwise every cell in the row repaints the blue tint and the
+    // selection reads as "individual cells" rather than "one row block".
+    const cellBackground =
+      !suppressSelectionOutline && isInRange && isInRange(rowId, col.field)
+        ? 'var(--dg-range-bg, rgba(59, 130, 246, 0.12))'
+        : null;
     const cellType = getCellType(col, rowIdx);
     const cellAddr: CellAddress = { rowId, field: col.field };
     const CustomRenderer = cellRenderers?.[cellType];

--- a/packages/react/src/body/DataGridBody.tsx
+++ b/packages/react/src/body/DataGridBody.tsx
@@ -47,7 +47,7 @@ import {
   GhostRowPosition,
   GridModel,
   SelectionMode,
-  isRowFullySelected,
+  RowOutlineSides,
 } from '@istracked/datagrid-core';
 import type {
   ControlsColumnConfig,
@@ -195,11 +195,12 @@ export interface DataGridBodyProps<TData extends Record<string, unknown>> {
   // State
   isSelected: (rowId: string, field: string) => boolean;
   /**
-   * Returns `true` when the row is fully selected (all columns covered by the
-   * active range). When true, the row container gets the selection outline and
-   * per-cell outlines are suppressed so only one outline is visible.
+   * Returns the per-side border flags for a row-selection outline, or null
+   * when the row is not fully selected. When non-null, the row container gets
+   * an inset box-shadow for each active side and per-cell outlines are
+   * suppressed so only one outline-level is visible.
    */
-  isRowSelected?: (rowId: string) => boolean;
+  getRowSelectionBorders?: (rowId: string) => RowOutlineSides | null;
   /**
    * Returns `true` when the cell is part of a multi-cell rectangular range.
    * Defaults to always-false if not supplied. Feeds the per-cell background
@@ -310,7 +311,7 @@ export function DataGridBody<TData extends Record<string, unknown>>(
     scrollRef,
     handleScroll,
     isSelected,
-    isRowSelected,
+    getRowSelectionBorders,
     isInRange,
     isEditingCell,
     getCellType,
@@ -830,11 +831,12 @@ export function DataGridBody<TData extends Record<string, unknown>>(
         // unrelated re-renders of the grid (e.g. container-prop tweaks).
         const rowBg = getCachedResolverResult(getRowBackground, row, rowId, rowIdx) ?? null;
         const rowBorder = getCachedResolverResult(getRowBorder, row, rowId, rowIdx) ?? null;
-        const rowIsFullySelected = isRowSelected ? isRowSelected(rowId) : false;
+        const rowBorders = getRowSelectionBorders ? getRowSelectionBorders(rowId) : null;
+        const rowIsFullySelected = rowBorders !== null;
         return (
           <React.Fragment key={rowId}>
             <div
-              style={styles.dataRow({ height: rowHeight, totalWidth, isEven: rowIdx % 2 === 0, background: rowBg, border: rowBorder, rowSelected: rowIsFullySelected })}
+              style={styles.dataRow({ height: rowHeight, totalWidth, isEven: rowIdx % 2 === 0, background: rowBg, border: rowBorder, borders: rowBorders })}
               role="row"
               aria-rowindex={rowIdx + 2}
               data-row-id={rowId}
@@ -937,14 +939,15 @@ export function DataGridBody<TData extends Record<string, unknown>>(
       // result; a fresh row reference (data swap) invalidates the cache slot.
       const rowBg = getCachedResolverResult(getRowBackground, row, rowId, rowIdx) ?? null;
       const rowBorder = getCachedResolverResult(getRowBorder, row, rowId, rowIdx) ?? null;
-      const rowIsFullySelected = isRowSelected ? isRowSelected(rowId) : false;
+      const rowBorders = getRowSelectionBorders ? getRowSelectionBorders(rowId) : null;
+      const rowIsFullySelected = rowBorders !== null;
 
       // When sub-grids are expanded use in-flow layout so the expansion row
       // naturally pushes subsequent rows downward. When no sub-grids are
       // expanded use absolute positioning (the original virtualised layout)
       // which is faster and avoids the reflow cost of a spacer element.
       const rowStyle = hasExpandedSubGrids
-        ? styles.dataRow({ height: rowHeight, totalWidth, isEven: rowIdx % 2 === 0, background: rowBg, border: rowBorder, rowSelected: rowIsFullySelected })
+        ? styles.dataRow({ height: rowHeight, totalWidth, isEven: rowIdx % 2 === 0, background: rowBg, border: rowBorder, borders: rowBorders })
         : styles.virtualizedRow({
             height: rowHeight,
             totalWidth,
@@ -952,7 +955,7 @@ export function DataGridBody<TData extends Record<string, unknown>>(
             isEven: rowIdx % 2 === 0,
             background: rowBg,
             border: rowBorder,
-            rowSelected: rowIsFullySelected,
+            borders: rowBorders,
           });
 
       return (

--- a/packages/react/src/use-keyboard.ts
+++ b/packages/react/src/use-keyboard.ts
@@ -339,10 +339,19 @@ export function useKeyboard<TData extends Record<string, unknown>>(
             scrollViewportHalfScreen(scrollRef?.current ?? null, dir);
           }
         } else {
-          // Plain arrow key moves selection by one cell.
+          // Plain arrow key: in row mode, ArrowUp/Down moves the whole-row
+          // selection to the adjacent row rather than stepping cell-by-cell.
           if (!current) return;
-          const next = getNextCell(current, dir, columns, rowIds);
-          if (next) model.select(next);
+          const isRowMode = state.selection.mode === 'row';
+          if (isRowMode && (dir === 'down' || dir === 'up')) {
+            const currentRowIdx = rowIds.indexOf(current.rowId);
+            const nextRowIdx = dir === 'down' ? currentRowIdx + 1 : currentRowIdx - 1;
+            const nextRowId = rowIds[nextRowIdx];
+            if (nextRowId) model.selectRowByKey(nextRowId);
+          } else {
+            const next = getNextCell(current, dir, columns, rowIds);
+            if (next) model.select(next);
+          }
         }
         break;
       }

--- a/packages/react/src/use-keyboard.ts
+++ b/packages/react/src/use-keyboard.ts
@@ -292,14 +292,17 @@ export function useKeyboard<TData extends Record<string, unknown>>(
 
         e.preventDefault();
 
-        // Row-mode horizontal arrows are no-ops. There is no cell-level
+        // Row-intent horizontal arrows are no-ops. There is no cell-level
         // focus while a whole row is selected, so stepping left/right
         // would collapse the row range onto a single cell. Applies to
         // plain and Shift-modified horizontal arrows alike; Ctrl/Cmd+Arrow
         // keeps its Excel "End" semantics because a user explicitly
         // asking for End-jump should still land on a cell.
+        const isRowIntent =
+          state.selection.mode === 'row' ||
+          state.selection.range?.kind === 'row';
         if (
-          state.selection.mode === 'row' &&
+          isRowIntent &&
           (dir === 'left' || dir === 'right') &&
           !(e.ctrlKey || e.metaKey)
         ) {
@@ -353,11 +356,15 @@ export function useKeyboard<TData extends Record<string, unknown>>(
             scrollViewportHalfScreen(scrollRef?.current ?? null, dir);
           }
         } else {
-          // Plain arrow key: in row mode, ArrowUp/Down moves the whole-row
-          // selection to the adjacent row rather than stepping cell-by-cell.
+          // Plain arrow key: with a row-intent selection (row mode or a
+          // range tagged `kind: 'row'` from a gutter click), ArrowUp/Down
+          // moves the whole-row selection to the adjacent row rather than
+          // stepping cell-by-cell.
           if (!current) return;
-          const isRowMode = state.selection.mode === 'row';
-          if (isRowMode && (dir === 'down' || dir === 'up')) {
+          const plainArrowRowIntent =
+            state.selection.mode === 'row' ||
+            state.selection.range?.kind === 'row';
+          if (plainArrowRowIntent && (dir === 'down' || dir === 'up')) {
             const currentRowIdx = rowIds.indexOf(current.rowId);
             const nextRowIdx = dir === 'down' ? currentRowIdx + 1 : currentRowIdx - 1;
             const nextRowId = rowIds[nextRowIdx];

--- a/packages/react/src/use-keyboard.ts
+++ b/packages/react/src/use-keyboard.ts
@@ -292,6 +292,20 @@ export function useKeyboard<TData extends Record<string, unknown>>(
 
         e.preventDefault();
 
+        // Row-mode horizontal arrows are no-ops. There is no cell-level
+        // focus while a whole row is selected, so stepping left/right
+        // would collapse the row range onto a single cell. Applies to
+        // plain and Shift-modified horizontal arrows alike; Ctrl/Cmd+Arrow
+        // keeps its Excel "End" semantics because a user explicitly
+        // asking for End-jump should still land on a cell.
+        if (
+          state.selection.mode === 'row' &&
+          (dir === 'left' || dir === 'right') &&
+          !(e.ctrlKey || e.metaKey)
+        ) {
+          break;
+        }
+
         if (e.ctrlKey || e.metaKey) {
           // Ctrl/Cmd+Arrow jumps Excel "End" style: walk along the row/column
           // and stop at the edge of the nearest populated block. Ctrl+Shift

--- a/stories/Selection.stories.tsx
+++ b/stories/Selection.stories.tsx
@@ -61,25 +61,21 @@ export const RowSelection: StoryObj = {
 };
 
 /**
- * Range selection with the Excel-style row-number gutter enabled. The
- * contract demonstrated here:
+ * Row-header-driven row selection with Excel-style UX. The contract:
  *
- *   - Clicking a `role="rowheader"` cell (the left gutter) selects every
- *     cell in that row and paints a single 2px outline on the `role="row"`
- *     element. Per-cell outlines are suppressed while the row is fully
- *     selected, so the border reads as one rectangle around the whole row.
- *   - Clicking any `role="gridcell"` switches back to per-cell selection —
- *     the row outline disappears and the clicked cell paints its own
- *     outline. Sibling cells deselect.
+ *   - Plain click on a `role="rowheader"` cell selects the whole row; the
+ *     outline is painted once on the `role="row"` element.
+ *   - Clicking any `role="gridcell"` collapses back to per-cell selection.
  *
- * This is the behaviour covered by `e2e/grid-row-selection.spec.ts`.
+ * See `RowRangeContiguous` and `RowRangeDisjoint` for the Shift/Cmd-click
+ * and keyboard-driven extensions built on top of this primitive.
  */
 export const RowHeaderSelection: StoryObj = {
   parameters: {
     docs: {
       description: {
         story:
-          'Row-header-driven row selection with Excel-style UX. Click the left row-number gutter to select the whole row (single outline on the row element). Click any data cell to collapse back to per-cell selection.',
+          'Plain-click row selection via the row-number gutter. Clicking the gutter selects the whole row; clicking any data cell collapses back to per-cell selection.',
       },
     },
   },
@@ -105,12 +101,100 @@ export const RowHeaderSelection: StoryObj = {
   ),
 };
 
+/**
+ * Contiguous row-range selection. Click a row-number gutter cell, then
+ * Shift+click another row-number cell further down: every row in between
+ * (and the anchor + focus rows themselves) is selected as a single range,
+ * and the outline is painted around the outer edges of the whole block —
+ * top border on the first row, bottom border on the last row, left/right
+ * borders on every row, no internal horizontals.
+ *
+ * Keyboard: with a row selected, Shift+ArrowDown / Shift+ArrowUp extends
+ * the range one row at a time. Plain ArrowDown / ArrowUp moves the
+ * single-row selection. Shift+ArrowLeft / Shift+ArrowRight and plain
+ * ArrowLeft / ArrowRight are no-ops while a full-row selection is active.
+ * ESC clears.
+ */
+export const RowRangeContiguous: StoryObj = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Shift+click a row-number cell after a plain click selects every row between the anchor and focus as a single range, outlined as one rectangle. Shift+ArrowDown / Shift+ArrowUp extends the range by one row; plain ArrowDown / ArrowUp moves the selection; left/right arrows are no-ops while a row range is active; ESC clears.',
+      },
+    },
+  },
+  render: () => (
+    <div style={storyContainer}>
+      <h2 style={styles.heading}>Contiguous Row-Range Selection</h2>
+      <p style={styles.subtitle}>
+        Click row 2's gutter cell, then <kbd>Shift</kbd>+click row 6's
+        gutter cell — rows 2–6 are one range with a single outer outline.
+        Try <kbd>Shift</kbd>+<kbd>↓</kbd> / <kbd>Shift</kbd>+<kbd>↑</kbd> to
+        grow or shrink the range.
+      </p>
+      <div style={gridContainer}>
+        <MuiDataGrid
+          data={makeEmployees(20)}
+          columns={defaultColumns as any}
+          rowKey="id"
+          selectionMode="row"
+          keyboardNavigation
+          shiftArrowBehavior="rangeSelect"
+          chrome={{ rowNumbers: true }}
+        />
+      </div>
+    </div>
+  ),
+};
+
+/**
+ * Disjoint multi-row selection. Cmd/Ctrl+click row-number gutter cells to
+ * toggle rows into or out of the selection without clearing existing
+ * selections. Each disjoint row paints its own four-sided outline so the
+ * visual grouping reads as "several independent rows", not "one range".
+ *
+ * On macOS use Cmd+click; on Windows/Linux use Ctrl+click (the rowheader
+ * handler reads both via `metaKey || ctrlKey`).
+ */
+export const RowRangeDisjoint: StoryObj = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Cmd/Ctrl+click row-number cells to build a disjoint row selection — non-adjacent rows highlighted independently, each with its own outline. Cmd/Ctrl+click a selected row again to toggle it off.',
+      },
+    },
+  },
+  render: () => (
+    <div style={storyContainer}>
+      <h2 style={styles.heading}>Disjoint Row-Range Selection</h2>
+      <p style={styles.subtitle}>
+        Click row 2's gutter cell, then <kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+click
+        row 5 and row 8. Three separate rows are highlighted, each with its
+        own outline. <kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+click any selected row
+        again to toggle it off.
+      </p>
+      <div style={gridContainer}>
+        <MuiDataGrid
+          data={makeEmployees(20)}
+          columns={defaultColumns as any}
+          rowKey="id"
+          selectionMode="row"
+          keyboardNavigation
+          chrome={{ rowNumbers: true }}
+        />
+      </div>
+    </div>
+  ),
+};
+
 export const RangeSelection: StoryObj = {
   parameters: {
     docs: {
       description: {
         story:
-          'Range selection with Shift + click drag. With the default `shiftArrowBehavior: "scroll"`, Shift + arrow keys pan the viewport instead of extending the range — see the `RangeSelectionKeyboard` story for opt-in keyboard-driven range extension.',
+          'Range selection with Shift+click drag across cells. With the default `shiftArrowBehavior: "scroll"`, Shift+arrow keys pan the viewport instead of extending the range — see `RangeSelectionKeyboard` for opt-in keyboard range extension. The row-number gutter is enabled here so you can also demonstrate row-level range features: plain-click a gutter cell selects one row, Shift+click a second gutter cell extends into a contiguous row range outlined as a single block, and Cmd/Ctrl+click toggles disjoint rows. See `RowRangeContiguous` and `RowRangeDisjoint` for standalone demos.',
       },
     },
   },
@@ -118,7 +202,10 @@ export const RangeSelection: StoryObj = {
     <div style={storyContainer}>
       <h2 style={styles.heading}>Range Selection</h2>
       <p style={styles.subtitle}>
-        Click a cell, then Shift + click another cell to select a rectangular range. <kbd>Ctrl+A</kbd> selects all.
+        Click a cell, then <kbd>Shift</kbd>+click another cell to select a
+        rectangular range. <kbd>Ctrl+A</kbd> selects all. Clicking the
+        left-gutter row-number cells selects whole rows — Shift+click for
+        a contiguous row range, Cmd/Ctrl+click for disjoint rows.
       </p>
       <div style={gridContainer}>
         <MuiDataGrid
@@ -127,6 +214,7 @@ export const RangeSelection: StoryObj = {
           rowKey="id"
           selectionMode="range"
           keyboardNavigation
+          chrome={{ rowNumbers: true }}
         />
       </div>
     </div>

--- a/stories/Selection.stories.tsx
+++ b/stories/Selection.stories.tsx
@@ -138,7 +138,7 @@ export const RowRangeContiguous: StoryObj = {
           data={makeEmployees(20)}
           columns={defaultColumns as any}
           rowKey="id"
-          selectionMode="row"
+          selectionMode="range"
           keyboardNavigation
           shiftArrowBehavior="rangeSelect"
           chrome={{ rowNumbers: true }}
@@ -180,7 +180,7 @@ export const RowRangeDisjoint: StoryObj = {
           data={makeEmployees(20)}
           columns={defaultColumns as any}
           rowKey="id"
-          selectionMode="row"
+          selectionMode="range"
           keyboardNavigation
           chrome={{ rowNumbers: true }}
         />


### PR DESCRIPTION
## Summary
- Shift+click a row-number gutter cell after a plain click selects every row between as a single contiguous range, outlined as one block (top on first row, bottom on last, sides on every row, no internal horizontals).
- Cmd/Ctrl+click toggles disjoint rows into or out of the selection; each disjoint row carries its own four-sided outline.
- Keyboard (row mode): plain ArrowUp/Down moves the full-row selection one row; Shift+ArrowUp/Down with `shiftArrowBehavior="rangeSelect"` grows/shrinks the range one row at a time; plain and Shift-modified ArrowLeft/ArrowRight are no-ops (Ctrl/Cmd+Arrow retains Excel End-jump); Escape clears.
- Outline is rendered via four stacked `box-shadow: inset` parts on the `role="row"` element, gated by per-side flags from the new `getRowSelectionBorders` core helper, which walks `state.ranges` so Cmd+click disjoint rows all render independently.

## Implementation
- `packages/core`: add `RowOutlineSides` and `getRowSelectionBorders(state, rowId, columns, rowIds)`; extend `isRowFullySelected` with an optional `rowIds` arg so multi-range selections are respected. Multi-row covering is gated on `mode === 'row'` to prevent Ctrl+A in cell/range mode from suppressing per-cell outlines.
- `packages/react`: `DataGrid` passes a memoised `getRowSelectionBorders` callback through to `DataGridBody`, which renders the inset box-shadow on both the grouped and virtualised row paths and suppresses per-cell outlines while a row is fully covered.
- `packages/react/use-keyboard`: horizontal arrows short-circuit in row mode so they don't collapse the selection; Shift+Arrow in `rangeSelect` mode reuses the existing `extendTo` path, which naturally produces full-row covering ranges when the focus stays on the last column.
- Stories: `RowRangeContiguous` and `RowRangeDisjoint` under `Examples/Selection` drive the new behaviour. Both use `selectionMode="row"`.

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 91 files, 1756 tests pass (25 new, incl. 7 `row-range-selection` + 8 `row-range-keyboard` + 10 core multi-range `selection` cases)
- [x] `pnpm exec playwright test e2e/grid-row-selection.spec.ts --project=chromium` — 14 tests pass
  - `Shift+click extends to a contiguous row range outlined as one block (#66)`
  - `Cmd/Ctrl+click toggles a disjoint row with its own four-sided outline (#66)`
  - `Cmd/Ctrl+click a selected row again removes it from the disjoint selection (#66)`
  - `Shift+ArrowDown once extends the row selection down by one row (#66)`
  - `Shift+ArrowDown twice extends the row selection down by two rows (#66)`
  - `Shift+ArrowUp shrinks an extended range back (#66)`
  - `Shift+ArrowLeft and Shift+ArrowRight are no-ops while a row is selected (#66)`
  - `plain ArrowDown moves the row selection to the next row (#66)`
  - `plain ArrowLeft and ArrowRight are no-ops while a row is selected (#66)`
  - `Escape clears the row selection (#66)`
- [x] Manual in Storybook: `Examples/Selection → Row Range Contiguous` and `Row Range Disjoint` render the expected outlines with Shift+click, Cmd+click, Shift+Arrow, and Arrow key paths.

Closes: #66