### PR TITLE
chore(e2e): link Playwright tests to their tracking issues

### DIFF
--- a/e2e/clipboard-copy.spec.ts
+++ b/e2e/clipboard-copy.spec.ts
@@ -58,7 +58,7 @@ test.describe('Clipboard copy — dual flavor ClipboardItem', () => {
     await waitForGrid(page);
   });
 
-  test('multi-cell selection + Ctrl+C writes both text/plain TSV and text/html <table>', async ({ page }) => {
+  test('multi-cell selection + Ctrl+C writes both text/plain TSV and text/html <table> (#65)', async ({ page }) => {
     // Click the anchor cell, then shift-click the focus cell to build a
     // 2x2 range. Field names come from `defaultColumns` in stories/data.ts.
     const anchor = page
@@ -96,7 +96,7 @@ test.describe('Clipboard copy — dual flavor ClipboardItem', () => {
     expect(clip.html.toLowerCase()).toContain('<td');
   });
 
-  test('clipboard read round-trips each row as its own <tr>', async ({ page }) => {
+  test('clipboard read round-trips each row as its own <tr> (#65)', async ({ page }) => {
     // Select two rows × one column.
     const cell = page
       .locator('[role="gridcell"][data-row-id="1"]')

--- a/e2e/edit-commit-nav.spec.ts
+++ b/e2e/edit-commit-nav.spec.ts
@@ -67,7 +67,7 @@ for (const { label, url } of STORY_URLS) {
     // -----------------------------------------------------------------------
     // Enter → commit + move DOWN
     // -----------------------------------------------------------------------
-    test('Enter commits typed value and moves selection DOWN one row', async ({ page }) => {
+    test('Enter commits typed value and moves selection DOWN one row (#65)', async ({ page }) => {
       const target = cell(page, '2', 'name');
       const input = await beginEdit(target);
 
@@ -88,7 +88,7 @@ for (const { label, url } of STORY_URLS) {
     // -----------------------------------------------------------------------
     // Tab → commit + move RIGHT
     // -----------------------------------------------------------------------
-    test('Tab commits typed value and moves selection RIGHT one cell', async ({ page }) => {
+    test('Tab commits typed value and moves selection RIGHT one cell (#65)', async ({ page }) => {
       const target = cell(page, '2', 'name');
       const input = await beginEdit(target);
 
@@ -108,7 +108,7 @@ for (const { label, url } of STORY_URLS) {
     // -----------------------------------------------------------------------
     // Escape → cancel + STAY
     // -----------------------------------------------------------------------
-    test('Escape discards the draft and keeps selection on the same cell', async ({ page }) => {
+    test('Escape discards the draft and keeps selection on the same cell (#65)', async ({ page }) => {
       const target = cell(page, '2', 'name');
       const originalText = (await target.innerText()).trim();
 
@@ -133,7 +133,7 @@ for (const { label, url } of STORY_URLS) {
     // the editor's `stopPropagation` / stale `editing.cell` state blocks
     // plain arrow navigation from running after an edit commits.
     // -----------------------------------------------------------------------
-    test('ArrowRight after Enter commit moves selection one more cell to the right', async ({ page }) => {
+    test('ArrowRight after Enter commit moves selection one more cell to the right (#65)', async ({ page }) => {
       const target = cell(page, '2', 'name');
       const input = await beginEdit(target);
 

--- a/e2e/editor-padding.spec.ts
+++ b/e2e/editor-padding.spec.ts
@@ -42,7 +42,7 @@ test.describe('Inline Editing – editor padding matches cell padding (Excel-365
     await page.locator('[role="grid"]').first().waitFor({ state: 'visible' });
   });
 
-  test('first glyph X position does not shift on enter-edit (≤ 1px delta)', async ({ page }) => {
+  test('first glyph X position does not shift on enter-edit (≤ 1px delta) (#65)', async ({ page }) => {
     const target = cell(page, '1', 'name');
     await target.click();
     await expect(target).toHaveAttribute('aria-selected', 'true');
@@ -85,7 +85,7 @@ test.describe('Inline Editing – editor padding matches cell padding (Excel-365
     expect(Math.abs(postEditLeft - preEditLeft)).toBeLessThanOrEqual(1);
   });
 
-  test('input padding / font-size / line-height match the cell pixel-for-pixel', async ({ page }) => {
+  test('input padding / font-size / line-height match the cell pixel-for-pixel (#65)', async ({ page }) => {
     const target = cell(page, '1', 'name');
     await target.click();
 
@@ -133,7 +133,7 @@ test.describe('Inline Editing – editor padding matches cell padding (Excel-365
     expect(inputMetrics.lineHeight).toBe(cellMetrics.lineHeight);
   });
 
-  test('input is not visually shorter/taller than the cell (height delta ≤ 1px)', async ({ page }) => {
+  test('input is not visually shorter/taller than the cell (height delta ≤ 1px) (#65)', async ({ page }) => {
     const target = cell(page, '2', 'name');
     await target.click();
     const cellHeight = await target.evaluate(

--- a/e2e/grid-keyboard.spec.ts
+++ b/e2e/grid-keyboard.spec.ts
@@ -42,7 +42,7 @@ test.describe('Basic Grid – keyboard navigation', () => {
     await page.locator('[role="grid"]').first().waitFor({ state: 'visible' });
   });
 
-  test('ArrowDown moves selection down one row', async ({ page }) => {
+  test('ArrowDown moves selection down one row (#16)', async ({ page }) => {
     const first = cell(page, '1', 'name');
     await first.click();
     await expect(first).toHaveAttribute('aria-selected', 'true');
@@ -57,7 +57,7 @@ test.describe('Basic Grid – keyboard navigation', () => {
     await expect(first).toHaveAttribute('aria-selected', 'false');
   });
 
-  test('Enter enters edit mode and a second Enter commits the new value', async ({ page }) => {
+  test('Enter enters edit mode and a second Enter commits the new value (#16)', async ({ page }) => {
     const target = cell(page, '3', 'name');
     await target.click();
     await expect(target).toHaveAttribute('aria-selected', 'true');
@@ -83,7 +83,7 @@ test.describe('Basic Grid – keyboard navigation', () => {
     expect(newValue).not.toBe(originalText);
   });
 
-  test('Escape cancels the edit and preserves the original value', async ({ page }) => {
+  test('Escape cancels the edit and preserves the original value (#16)', async ({ page }) => {
     const target = cell(page, '5', 'name');
     await target.click();
     await expect(target).toHaveAttribute('aria-selected', 'true');
@@ -105,7 +105,7 @@ test.describe('Basic Grid – keyboard navigation', () => {
     await expect(target).not.toContainText('garbage-should-not-commit');
   });
 
-  test('Tab commits the draft value (Enter-parity per issue #10)', async ({ page }) => {
+  test('Tab commits the draft value (Enter-parity per issue #10) (#16)', async ({ page }) => {
     const target = cell(page, '7', 'name');
     await target.click();
     await expect(target).toHaveAttribute('aria-selected', 'true');

--- a/e2e/grid-row-selection.spec.ts
+++ b/e2e/grid-row-selection.spec.ts
@@ -90,7 +90,7 @@ test.describe('Row selection – outline rendered on row, not per cell', () => {
     await waitForGrid(page);
   });
 
-  test('clicking a rowheader paints the outline on the row element', async ({ page }) => {
+  test('clicking a rowheader paints the outline on the row element (#64)', async ({ page }) => {
     const rowheader = page.locator('[role="rowheader"][data-row-id="3"]').first();
     await expect(rowheader).toBeVisible();
     await rowheader.click();
@@ -120,7 +120,7 @@ test.describe('Row selection – outline rendered on row, not per cell', () => {
     }
   });
 
-  test('a different row stays un-outlined when another row is selected', async ({ page }) => {
+  test('a different row stays un-outlined when another row is selected (#64)', async ({ page }) => {
     const target = page.locator('[role="rowheader"][data-row-id="2"]').first();
     await target.click();
 
@@ -128,7 +128,7 @@ test.describe('Row selection – outline rendered on row, not per cell', () => {
     expect(await rowHasAnySide(otherRow)).toBe(false);
   });
 
-  test('clicking a gridcell directly does NOT paint the row-level outline', async ({ page }) => {
+  test('clicking a gridcell directly does NOT paint the row-level outline (#64)', async ({ page }) => {
     const clickedCell = page
       .locator('[role="gridcell"][data-row-id="4"][data-field="name"]')
       .first();
@@ -153,7 +153,7 @@ test.describe('Row selection – outline rendered on row, not per cell', () => {
     await expect(siblingCell).toHaveAttribute('aria-selected', 'false');
   });
 
-  test('clicking a gridcell after a row is selected collapses to per-cell UX', async ({ page }) => {
+  test('clicking a gridcell after a row is selected collapses to per-cell UX (#64)', async ({ page }) => {
     const rowheader = page.locator('[role="rowheader"][data-row-id="6"]').first();
     await rowheader.click();
 
@@ -190,7 +190,7 @@ test.describe('Row range – Shift+click contiguous and Cmd/Ctrl+click disjoint'
     await waitForGrid(page);
   });
 
-  test('Shift+click extends to a contiguous row range outlined as one block', async ({ page }) => {
+  test('Shift+click extends to a contiguous row range outlined as one block (#66)', async ({ page }) => {
     const first = page.locator('[role="rowheader"][data-row-id="2"]').first();
     const last = page.locator('[role="rowheader"][data-row-id="5"]').first();
     await first.click();
@@ -212,7 +212,7 @@ test.describe('Row range – Shift+click contiguous and Cmd/Ctrl+click disjoint'
     expect(await rowHasAnySide(row6)).toBe(false);
   });
 
-  test('Cmd/Ctrl+click toggles a disjoint row with its own four-sided outline', async ({ page }) => {
+  test('Cmd/Ctrl+click toggles a disjoint row with its own four-sided outline (#66)', async ({ page }) => {
     // Plain click row 2, then Cmd/Ctrl+click row 5. Intermediate rows stay
     // un-selected; both anchor and disjoint row carry the full four sides.
     const r2 = page.locator('[role="rowheader"][data-row-id="2"]').first();
@@ -232,7 +232,7 @@ test.describe('Row range – Shift+click contiguous and Cmd/Ctrl+click disjoint'
     expect(await rowHasAnySide(row4)).toBe(false);
   });
 
-  test('Cmd/Ctrl+click a selected row again removes it from the disjoint selection', async ({ page }) => {
+  test('Cmd/Ctrl+click a selected row again removes it from the disjoint selection (#66)', async ({ page }) => {
     const r2 = page.locator('[role="rowheader"][data-row-id="2"]').first();
     const r5 = page.locator('[role="rowheader"][data-row-id="5"]').first();
     await r2.click();
@@ -245,7 +245,7 @@ test.describe('Row range – Shift+click contiguous and Cmd/Ctrl+click disjoint'
     expect(await rowHasAnySide(row5)).toBe(false);
   });
 
-  test('Shift+ArrowDown once extends the row selection down by one row', async ({ page }) => {
+  test('Shift+ArrowDown once extends the row selection down by one row (#66)', async ({ page }) => {
     const r3 = page.locator('[role="rowheader"][data-row-id="3"]').first();
     await r3.click();
     await page.locator('[role="grid"]').first().focus();
@@ -260,7 +260,7 @@ test.describe('Row range – Shift+click contiguous and Cmd/Ctrl+click disjoint'
     expect(await rowHasAnySide(row5)).toBe(false);
   });
 
-  test('Shift+ArrowDown twice extends the row selection down by two rows', async ({ page }) => {
+  test('Shift+ArrowDown twice extends the row selection down by two rows (#66)', async ({ page }) => {
     const r3 = page.locator('[role="rowheader"][data-row-id="3"]').first();
     await r3.click();
     await page.locator('[role="grid"]').first().focus();
@@ -278,7 +278,7 @@ test.describe('Row range – Shift+click contiguous and Cmd/Ctrl+click disjoint'
     expect(await rowHasAnySide(row6)).toBe(false);
   });
 
-  test('Shift+ArrowUp shrinks an extended range back', async ({ page }) => {
+  test('Shift+ArrowUp shrinks an extended range back (#66)', async ({ page }) => {
     const r3 = page.locator('[role="rowheader"][data-row-id="3"]').first();
     await r3.click();
     await page.locator('[role="grid"]').first().focus();
@@ -295,7 +295,7 @@ test.describe('Row range – Shift+click contiguous and Cmd/Ctrl+click disjoint'
     expect(await rowHasAnySide(row5)).toBe(false);
   });
 
-  test('Shift+ArrowLeft and Shift+ArrowRight are no-ops while a row is selected', async ({ page }) => {
+  test('Shift+ArrowLeft and Shift+ArrowRight are no-ops while a row is selected (#66)', async ({ page }) => {
     const r3 = page.locator('[role="rowheader"][data-row-id="3"]').first();
     await r3.click();
     await page.locator('[role="grid"]').first().focus();
@@ -317,7 +317,7 @@ test.describe('Row range – Shift+click contiguous and Cmd/Ctrl+click disjoint'
     }
   });
 
-  test('plain ArrowDown moves the row selection to the next row', async ({ page }) => {
+  test('plain ArrowDown moves the row selection to the next row (#66)', async ({ page }) => {
     const r3 = page.locator('[role="rowheader"][data-row-id="3"]').first();
     await r3.click();
     await page.locator('[role="grid"]').first().focus();
@@ -331,7 +331,7 @@ test.describe('Row range – Shift+click contiguous and Cmd/Ctrl+click disjoint'
     });
   });
 
-  test('plain ArrowLeft and ArrowRight are no-ops while a row is selected', async ({ page }) => {
+  test('plain ArrowLeft and ArrowRight are no-ops while a row is selected (#66)', async ({ page }) => {
     const r3 = page.locator('[role="rowheader"][data-row-id="3"]').first();
     await r3.click();
     await page.locator('[role="grid"]').first().focus();
@@ -348,7 +348,7 @@ test.describe('Row range – Shift+click contiguous and Cmd/Ctrl+click disjoint'
     expect(after).toEqual(before);
   });
 
-  test('Escape clears the row selection', async ({ page }) => {
+  test('Escape clears the row selection (#66)', async ({ page }) => {
     const r3 = page.locator('[role="rowheader"][data-row-id="3"]').first();
     await r3.click();
     await page.locator('[role="grid"]').first().focus();

--- a/e2e/grid-subgrid.spec.ts
+++ b/e2e/grid-subgrid.spec.ts
@@ -30,7 +30,7 @@ test.describe('Sub-grid – ARIA wiring + expansion', () => {
     await waitForGrid(page);
   });
 
-  test('clicking the expander mounts a nested grid with the expected id format', async ({ page }) => {
+  test('clicking the expander mounts a nested grid with the expected id format (#6)', async ({ page }) => {
     // Exactly one parent grid exists before any toggle is clicked. The
     // count of `[role="grid"]` must increase when we expand a row.
     const initialGridCount = await page.locator('[role="grid"]').count();
@@ -54,7 +54,7 @@ test.describe('Sub-grid – ARIA wiring + expansion', () => {
     expect(nestedGridId!).toMatch(/-row-.+-subgrid$/);
   });
 
-  test('nested grid carries aria-labelledby pointing at an in-DOM parent cell id', async ({ page }) => {
+  test('nested grid carries aria-labelledby pointing at an in-DOM parent cell id (#6)', async ({ page }) => {
     const firstToggle = page.locator('[data-testid="subgrid-toggle"]').first();
     await firstToggle.click();
 
@@ -76,7 +76,7 @@ test.describe('Sub-grid – ARIA wiring + expansion', () => {
     expect(nestedId).not.toBe(parentId);
   });
 
-  test('expanded sub-grid renders inner cells and Tab reaches a grid', async ({ page }) => {
+  test('expanded sub-grid renders inner cells and Tab reaches a grid (#6)', async ({ page }) => {
     const firstToggle = page.locator('[data-testid="subgrid-toggle"]').first();
     await firstToggle.click();
 

--- a/e2e/grid-xss.spec.ts
+++ b/e2e/grid-xss.spec.ts
@@ -60,7 +60,7 @@ test.describe('RichText cell – XSS hardening', () => {
     await page.locator('[role="grid"]').first().waitFor({ state: 'visible' });
   });
 
-  test('raw HTML <a href="javascript:"> is not rendered as a live link', async ({ page }) => {
+  test('raw HTML <a href="javascript:"> is not rendered as a live link (#47)', async ({ page }) => {
     const cell = richTextCell(page, '1');
     await expect(cell).toBeVisible();
 
@@ -121,7 +121,7 @@ test.describe('RichText cell – XSS hardening', () => {
     ).toEqual([]);
   });
 
-  test('markdown link with javascript: scheme is neutered', async ({ page }) => {
+  test('markdown link with javascript: scheme is neutered (#47)', async ({ page }) => {
     const cell = richTextCell(page, '2');
     await expect(cell).toBeVisible();
 

--- a/e2e/hover-tooltip.spec.ts
+++ b/e2e/hover-tooltip.spec.ts
@@ -34,7 +34,7 @@ test.describe('Hover tooltip — portal + viewport clamping', () => {
     await waitForGrid(page);
   });
 
-  test('hovering a cell shows a portaled role="tooltip" with its text content', async ({ page }) => {
+  test('hovering a cell shows a portaled role="tooltip" with its text content (#65)', async ({ page }) => {
     // Pick the first visible data cell in the "Text" column.
     const cell = page
       .locator('[role="gridcell"][data-field="text"]')
@@ -74,7 +74,7 @@ test.describe('Hover tooltip — portal + viewport clamping', () => {
     expect(cellContainsTooltip).toBe(false);
   });
 
-  test('tooltip stays inside the viewport (viewport-edge clamping)', async ({ page }) => {
+  test('tooltip stays inside the viewport (viewport-edge clamping) (#65)', async ({ page }) => {
     // Hover the rightmost visible cell in the first row so the tooltip
     // has a strong chance of overflowing right-edge without clamping.
     const row = page.locator('[role="row"][data-row-id="1"]').first();

--- a/e2e/rich-text-floating-menu.spec.ts
+++ b/e2e/rich-text-floating-menu.spec.ts
@@ -59,7 +59,7 @@ test.describe('RichText cell – floating formatting menu (Feature A)', () => {
     await page.locator('[role="grid"]').first().waitFor({ state: 'visible' });
   });
 
-  test('toolbar renders at document root via portal, not as a descendant of the cell', async ({ page }) => {
+  test('toolbar renders at document root via portal, not as a descendant of the cell (#9)', async ({ page }) => {
     const cell = richTextCell(page, '1');
     await expect(cell).toBeVisible();
     await enterEditMode(cell);
@@ -84,7 +84,7 @@ test.describe('RichText cell – floating formatting menu (Feature A)', () => {
     ).toBe(false);
   });
 
-  test('cell near viewport top flips the menu to `data-placement="below"`', async ({ page }) => {
+  test('cell near viewport top flips the menu to `data-placement="below"` (#9)', async ({ page }) => {
     const cell = richTextCell(page, '1');
     await expect(cell).toBeVisible();
 
@@ -105,7 +105,7 @@ test.describe('RichText cell – "Show formatting" toggle (Feature B)', () => {
     await page.locator('[role="grid"]').first().waitFor({ state: 'visible' });
   });
 
-  test('toggle ON shows raw `**` delimiters alongside the rendered <strong>', async ({ page }) => {
+  test('toggle ON shows raw `**` delimiters alongside the rendered <strong> (#9)', async ({ page }) => {
     const cell = richTextCell(page, '1');
     await expect(cell).toBeVisible();
     await enterEditMode(cell);
@@ -141,7 +141,7 @@ test.describe('RichText cell – "Show formatting" toggle (Feature B)', () => {
     ).toBeGreaterThan(0);
   });
 
-  test('toggle OFF hides the `**` delimiters but keeps the <strong> rendering', async ({ page }) => {
+  test('toggle OFF hides the `**` delimiters but keeps the <strong> rendering (#9)', async ({ page }) => {
     const cell = richTextCell(page, '1');
     await expect(cell).toBeVisible();
     await enterEditMode(cell);

--- a/e2e/validation-tooltip.spec.ts
+++ b/e2e/validation-tooltip.spec.ts
@@ -86,7 +86,7 @@ test.describe('Validation tooltip — portal + severity styling', () => {
     await waitForGrid(page);
   });
 
-  test('error-severity: portal tooltip exists with a red background and an error icon', async ({ page }) => {
+  test('error-severity: portal tooltip exists with a red background and an error icon (#65)', async ({ page }) => {
     // Row 1 / email — story wires an error-severity "invalid email" validator.
     await commit(page, '1', 'email', 'not-an-email');
 
@@ -114,7 +114,7 @@ test.describe('Validation tooltip — portal + severity styling', () => {
     await expect(cell.locator('[role="alert"]')).toHaveCount(0);
   });
 
-  test('warning-severity: tooltip background in the yellow family with a warning icon', async ({ page }) => {
+  test('warning-severity: tooltip background in the yellow family with a warning icon (#65)', async ({ page }) => {
     // The story's `name` column has a warning-severity rule ("letters only");
     // entering digits triggers it without failing the error-severity rule.
     await commit(page, '1', 'name', 'Alice99');
@@ -130,7 +130,7 @@ test.describe('Validation tooltip — portal + severity styling', () => {
     await expect(tip.locator('[data-icon="warning"]')).toHaveCount(1);
   });
 
-  test('two validators (error + warning): both messages listed, error first', async ({ page }) => {
+  test('two validators (error + warning): both messages listed, error first (#65)', async ({ page }) => {
     // The story's `name` column has two validators: minLength (error) and
     // letters-only (warning). An empty-then-digit value fires both: empty
     // hits minLength as error; "1" also contains a digit as warning. To hit
@@ -157,7 +157,7 @@ test.describe('Validation tooltip — portal + severity styling', () => {
     expect(severities).toEqual(['error', 'warning']);
   });
 
-  test('no inline validation message is rendered inside an invalid cell', async ({ page }) => {
+  test('no inline validation message is rendered inside an invalid cell (#65)', async ({ page }) => {
     await commit(page, '1', 'email', 'bad');
 
     const cell = page.locator('[role="gridcell"][data-row-id="1"][data-field="email"]').first();


### PR DESCRIPTION
## Summary
- Suffix 42 Playwright test names across 10 e2e spec files with their tracking issue number (e.g. `(#65)`), so a failed CI line points directly at the issue that owns the contract.
- Cell-overflow tests (`e2e/cell-overflow.spec.ts`, 6 tests → #63) will be added in a follow-up once PR #62 lands on main.

## Coverage
| File | Tests | Issue |
|---|---|---|
| `e2e/clipboard-copy.spec.ts` | 2 | #65 |
| `e2e/edit-commit-nav.spec.ts` | 4 | #65 |
| `e2e/editor-padding.spec.ts` | 3 | #65 |
| `e2e/grid-keyboard.spec.ts` | 4 | #16 |
| `e2e/grid-row-selection.spec.ts` | 4 + 10 | #64 + #66 |
| `e2e/grid-subgrid.spec.ts` | 3 | #6 |
| `e2e/grid-xss.spec.ts` | 2 | #47 |
| `e2e/hover-tooltip.spec.ts` | 2 | #65 |
| `e2e/rich-text-floating-menu.spec.ts` | 4 | #9 |
| `e2e/validation-tooltip.spec.ts` | 4 | #65 |

## Test plan
- [x] Pre-commit hook: typecheck + build + 1837 vitest tests all pass
- [ ] Playwright titles now include `(#<issueNum>)` for each of the 42 renamed tests
- [ ] No runtime / selector changes; rename is purely the test title string