### PR TITLE
test(e2e): red specs for #68 #69 #70 #71 #73 #74 #75

### DIFF
--- a/e2e/column-drop-indicator.spec.ts
+++ b/e2e/column-drop-indicator.spec.ts
@@ -1,0 +1,154 @@
+/**
+ * End-to-end: column drag-to-reorder drop indicator (#69).
+ *
+ * Contract (see GitHub #69): while dragging a column header, the hovered
+ * target header cell exposes a `data-drop-indicator` attribute resolved
+ * against the pointer's horizontal position:
+ *
+ *   - `data-drop-indicator="left"`  — pointer in the left half of the target
+ *   - `data-drop-indicator="right"` — pointer in the right half of the target
+ *
+ * A thick bar (≥ 3px) renders on the resolved edge. Frozen columns
+ * (`data-draggable="false"` or equivalent) must never receive the attribute.
+ * The attribute clears on drop / dragleave.
+ *
+ * Story: `examples-column-operations--column-reorder` — the primary
+ * column-reorder example. A `Frozen` story (`--frozen-columns`) is used to
+ * cover the frozen-column contract.
+ *
+ * These tests are expected to FAIL today: the drag already works, but the
+ * drop-indicator attribute and bar are not yet implemented.
+ */
+import { test, expect, type Locator, type Page } from '@playwright/test';
+
+const REORDER_URL =
+  '/iframe.html?viewMode=story&id=examples-column-operations--column-reorder';
+const FROZEN_URL =
+  '/iframe.html?viewMode=story&id=examples-column-operations--frozen-columns';
+
+async function waitForGrid(page: Page): Promise<void> {
+  await page.locator('[role="grid"]').first().waitFor({ state: 'visible' });
+}
+
+function headerCell(page: Page, field: string): Locator {
+  return page
+    .locator(`[role="columnheader"][data-field="${field}"]`)
+    .first();
+}
+
+async function dragHeaderOnto(
+  page: Page,
+  source: Locator,
+  target: Locator,
+  half: 'left' | 'right',
+): Promise<void> {
+  const srcBox = await source.boundingBox();
+  const tgtBox = await target.boundingBox();
+  if (!srcBox || !tgtBox) throw new Error('boundingBox unavailable');
+
+  const startX = srcBox.x + srcBox.width / 2;
+  const startY = srcBox.y + srcBox.height / 2;
+  const endY = tgtBox.y + tgtBox.height / 2;
+  const endX =
+    half === 'left'
+      ? tgtBox.x + tgtBox.width * 0.25
+      : tgtBox.x + tgtBox.width * 0.75;
+
+  await page.mouse.move(startX, startY);
+  await page.mouse.down();
+  await page.mouse.move(startX + 5, startY, { steps: 2 });
+  await page.mouse.move(endX, endY, { steps: 10 });
+}
+
+test.describe('Column drop indicator (#69)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(REORDER_URL);
+    await waitForGrid(page);
+  });
+
+  test('column-drop-indicator: dragging a header over the left half of a target column sets data-drop-indicator="left" (#69)', async ({
+    page,
+  }) => {
+    // The columns come from the reorder story; pick two by their data-field.
+    // The story headers include at least two reorderable columns — we drag
+    // the first header onto the third one to avoid self-drop edge cases.
+    const headers = page.locator('[role="columnheader"]');
+    const allFields = await headers.evaluateAll((nodes) =>
+      nodes.map((n) => (n as HTMLElement).getAttribute('data-field')),
+    );
+    const reorderable = allFields.filter((f): f is string => !!f);
+    expect(reorderable.length).toBeGreaterThanOrEqual(3);
+    const src = headerCell(page, reorderable[0]!);
+    const tgt = headerCell(page, reorderable[2]!);
+
+    await dragHeaderOnto(page, src, tgt, 'left');
+    await expect(tgt).toHaveAttribute('data-drop-indicator', 'left');
+
+    await page.mouse.up();
+  });
+
+  test('column-drop-indicator: dragging over the right half sets data-drop-indicator="right" (#69)', async ({
+    page,
+  }) => {
+    const headers = page.locator('[role="columnheader"]');
+    const allFields = await headers.evaluateAll((nodes) =>
+      nodes.map((n) => (n as HTMLElement).getAttribute('data-field')),
+    );
+    const reorderable = allFields.filter((f): f is string => !!f);
+    const src = headerCell(page, reorderable[0]!);
+    const tgt = headerCell(page, reorderable[2]!);
+
+    await dragHeaderOnto(page, src, tgt, 'right');
+    await expect(tgt).toHaveAttribute('data-drop-indicator', 'right');
+
+    await page.mouse.up();
+  });
+
+  test('column-drop-indicator: indicator bar has non-zero computed width ≥ 3px on the resolved edge (#69)', async ({
+    page,
+  }) => {
+    const headers = page.locator('[role="columnheader"]');
+    const allFields = await headers.evaluateAll((nodes) =>
+      nodes.map((n) => (n as HTMLElement).getAttribute('data-field')),
+    );
+    const reorderable = allFields.filter((f): f is string => !!f);
+    const src = headerCell(page, reorderable[0]!);
+    const tgt = headerCell(page, reorderable[2]!);
+
+    await dragHeaderOnto(page, src, tgt, 'right');
+
+    const bar = tgt.locator('[data-column-drop-indicator]');
+    await expect(bar).toHaveCount(1);
+    const width = await bar.evaluate((el) => el.getBoundingClientRect().width);
+    expect(width).toBeGreaterThanOrEqual(3);
+
+    await page.mouse.up();
+  });
+});
+
+test.describe('Column drop indicator — frozen columns (#69)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(FROZEN_URL);
+    await waitForGrid(page);
+  });
+
+  test('column-drop-indicator: frozen column never receives the indicator attribute (#69)', async ({
+    page,
+  }) => {
+    // The frozen-columns story pins at least one column. Find a frozen
+    // header — we rely on the `data-draggable="false"` contract, which the
+    // header emits when the column carries `frozen: true`.
+    const frozen = page.locator('[role="columnheader"][data-draggable="false"]').first();
+    await expect(frozen).toBeVisible();
+
+    // Drag a non-frozen header over the frozen one — the frozen target must
+    // NOT accept a drop indicator regardless of pointer position.
+    const nonFrozen = page.locator('[role="columnheader"]:not([data-draggable="false"])').first();
+    await expect(nonFrozen).toBeVisible();
+
+    await dragHeaderOnto(page, nonFrozen, frozen, 'left');
+    await expect(frozen).not.toHaveAttribute('data-drop-indicator', /left|right/);
+
+    await page.mouse.up();
+  });
+});

--- a/e2e/row-drop-indicator.spec.ts
+++ b/e2e/row-drop-indicator.spec.ts
@@ -1,0 +1,139 @@
+/**
+ * End-to-end: row drag-to-reorder drop indicator (#68).
+ *
+ * Contract (see GitHub #68): while dragging a row, the grid exposes a
+ * `data-drop-indicator` attribute on the hovered target whose value depends
+ * on the pointer's vertical position:
+ *
+ *   - `data-drop-indicator="above"` — pointer in the upper half of the row
+ *   - `data-drop-indicator="below"` — pointer in the lower half of the row
+ *
+ * A thick visual bar (≥ 3px) must render on the resolved edge so the user
+ * can predict where the drop will commit. The attribute clears on drop or
+ * dragleave.
+ *
+ * Story: `examples-chrome-columns--drag-reorder` — enables
+ * `chrome.rowNumbers.reorderable`, which wires the row drag handle.
+ *
+ * These tests are expected to FAIL today: only the drag gesture works; the
+ * drop-indicator attribute and bar have not been implemented yet.
+ */
+import { test, expect, type Locator, type Page } from '@playwright/test';
+
+const STORY_URL =
+  '/iframe.html?viewMode=story&id=examples-chrome-columns--drag-reorder';
+
+async function waitForGrid(page: Page): Promise<void> {
+  await page.locator('[role="grid"]').first().waitFor({ state: 'visible' });
+}
+
+function rowNumberCell(page: Page, rowIndex: number): Locator {
+  // `[data-chrome="row-number"]` is the cross-cutting hook the chrome cells
+  // render; `nth()` picks the Nth row regardless of scroll offset.
+  return page.locator('[data-chrome="row-number"]').nth(rowIndex);
+}
+
+/**
+ * Simulates a drag from `source` onto the upper or lower half of `target`
+ * without releasing — leaves the drag in progress so the drop-indicator
+ * attribute can be inspected mid-gesture.
+ */
+async function dragOverHalf(
+  page: Page,
+  source: Locator,
+  target: Locator,
+  half: 'upper' | 'lower',
+): Promise<void> {
+  const srcBox = await source.boundingBox();
+  const tgtBox = await target.boundingBox();
+  if (!srcBox || !tgtBox) throw new Error('boundingBox unavailable');
+  const startX = srcBox.x + srcBox.width / 2;
+  const startY = srcBox.y + srcBox.height / 2;
+  const endX = tgtBox.x + tgtBox.width / 2;
+  // Upper quarter vs. lower three-quarters — avoids the exact midpoint so
+  // implementations using `< half` vs `<= half` both resolve correctly.
+  const endY =
+    half === 'upper'
+      ? tgtBox.y + tgtBox.height * 0.25
+      : tgtBox.y + tgtBox.height * 0.75;
+
+  await page.mouse.move(startX, startY);
+  await page.mouse.down();
+  // Two-step move mirrors a real drag — some dnd libraries require motion
+  // after `mousedown` before they register the drag start.
+  await page.mouse.move(startX, startY + 5, { steps: 2 });
+  await page.mouse.move(endX, endY, { steps: 10 });
+}
+
+test.describe('Row drop indicator (#68)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(STORY_URL);
+    await waitForGrid(page);
+  });
+
+  test('row-drop-indicator: dragging a row over the upper half of a target row sets data-drop-indicator="above" on the target (#68)', async ({
+    page,
+  }) => {
+    const source = rowNumberCell(page, 0);
+    const target = rowNumberCell(page, 2);
+    await expect(source).toBeVisible();
+    await expect(target).toBeVisible();
+
+    await dragOverHalf(page, source, target, 'upper');
+    await expect(target).toHaveAttribute('data-drop-indicator', 'above');
+
+    await page.mouse.up();
+  });
+
+  test('row-drop-indicator: dragging over the lower half sets data-drop-indicator="below" on the target (#68)', async ({
+    page,
+  }) => {
+    const source = rowNumberCell(page, 0);
+    const target = rowNumberCell(page, 2);
+
+    await dragOverHalf(page, source, target, 'lower');
+    await expect(target).toHaveAttribute('data-drop-indicator', 'below');
+
+    await page.mouse.up();
+  });
+
+  test('row-drop-indicator: indicator clears after drop is committed or the drag leaves the grid (#68)', async ({
+    page,
+  }) => {
+    const source = rowNumberCell(page, 0);
+    const target = rowNumberCell(page, 2);
+
+    await dragOverHalf(page, source, target, 'upper');
+    await expect(target).toHaveAttribute('data-drop-indicator', 'above');
+
+    // Commit the drop — indicator must clear.
+    await page.mouse.up();
+
+    // After the drop, NO row-number cell should carry the attribute.
+    const withIndicator = page.locator(
+      '[data-chrome="row-number"][data-drop-indicator]',
+    );
+    await expect(withIndicator).toHaveCount(0);
+  });
+
+  test('row-drop-indicator: the indicator bar is visible with a non-zero computed height ≥ 3px on the target edge (#68)', async ({
+    page,
+  }) => {
+    const source = rowNumberCell(page, 0);
+    const target = rowNumberCell(page, 2);
+
+    await dragOverHalf(page, source, target, 'upper');
+
+    // The indicator element lives either as a child `<div
+    // data-row-drop-indicator>` or as a styled pseudo-element. We check the
+    // child-node path first (more inspectable); implementations may use the
+    // pseudo path and rewire this contract as needed, but the height check
+    // below still applies via `getComputedStyle`.
+    const bar = target.locator('[data-row-drop-indicator]');
+    await expect(bar).toHaveCount(1);
+    const height = await bar.evaluate((el) => el.getBoundingClientRect().height);
+    expect(height).toBeGreaterThanOrEqual(3);
+
+    await page.mouse.up();
+  });
+});

--- a/e2e/row-number-bg.spec.ts
+++ b/e2e/row-number-bg.spec.ts
@@ -1,0 +1,130 @@
+/**
+ * End-to-end: row-number gutter uses a darker grey background by default (#70).
+ *
+ * Contract (see GitHub #70): the chrome row-number cell MUST render with a
+ * non-transparent background whose luminance is lower than the background
+ * of the adjacent data cell on the same row. This makes the row-number
+ * gutter read as a distinct "frame" around the data area, matching the
+ * spreadsheet convention users expect.
+ *
+ * The invariant applies by default (no config flag) and across multiple
+ * rows, so alternating-row-colour schemes cannot accidentally satisfy it
+ * only for row 1.
+ *
+ * Story: `examples-chrome-columns--row-numbers-only` — the canonical
+ * row-number demonstration.
+ *
+ * These tests are expected to FAIL today: the row-number cell inherits the
+ * row background, so its luminance equals the adjacent data cell.
+ */
+import { test, expect, type Locator, type Page } from '@playwright/test';
+
+const STORY_URL =
+  '/iframe.html?viewMode=story&id=examples-chrome-columns--row-numbers-only';
+
+async function waitForGrid(page: Page): Promise<void> {
+  await page.locator('[role="grid"]').first().waitFor({ state: 'visible' });
+}
+
+// Parses `rgb(r, g, b)` / `rgba(r, g, b, a)` into its numeric components.
+// Returns `null` if the colour string is transparent (alpha 0 or the literal
+// `transparent`) so callers can assert the cell actually paints a colour.
+function parseRgba(s: string): [number, number, number, number] | null {
+  if (!s || s === 'transparent') return null;
+  const m = s.match(
+    /rgba?\s*\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)(?:\s*,\s*([\d.]+))?/,
+  );
+  if (!m) return null;
+  const a = m[4] !== undefined ? Number(m[4]) : 1;
+  if (a === 0) return null;
+  return [Number(m[1]), Number(m[2]), Number(m[3]), a];
+}
+
+// Relative luminance per WCAG — good enough to compare "which is darker".
+function luminance([r, g, b]: [number, number, number, number]): number {
+  const toLinear = (c: number) => {
+    const s = c / 255;
+    return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+  };
+  return 0.2126 * toLinear(r) + 0.7152 * toLinear(g) + 0.0722 * toLinear(b);
+}
+
+async function computedBg(locator: Locator): Promise<string> {
+  return locator.evaluate((el) => getComputedStyle(el).backgroundColor);
+}
+
+function rowNumberCellForRow(page: Page, rowIndex: number): Locator {
+  return page.locator('[data-chrome="row-number"]').nth(rowIndex);
+}
+
+function firstDataCellForRow(page: Page, rowIndex: number): Locator {
+  // Data cells carry `data-field` and `role="gridcell"`. The chrome row
+  // number cell is also a gridcell but carries `data-chrome` — we exclude
+  // those here so we pick a data column, not the gutter itself.
+  return page
+    .locator('[role="row"]')
+    .nth(rowIndex + 1 /* skip header row */)
+    .locator('[role="gridcell"]:not([data-chrome])')
+    .first();
+}
+
+test.describe('Row-number gutter background (#70)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(STORY_URL);
+    await waitForGrid(page);
+  });
+
+  test('row-number-bg: the row-number cell has a non-transparent computed background-color by default (#70)', async ({
+    page,
+  }) => {
+    const cell = rowNumberCellForRow(page, 0);
+    await expect(cell).toBeVisible();
+
+    const bg = await computedBg(cell);
+    const parsed = parseRgba(bg);
+    expect(
+      parsed,
+      `row-number cell must paint a non-transparent background; got ${JSON.stringify(bg)}`,
+    ).not.toBeNull();
+  });
+
+  test('row-number-bg: the row-number cell\'s background is darker (lower luminance) than the adjacent data cell\'s background (#70)', async ({
+    page,
+  }) => {
+    const gutter = rowNumberCellForRow(page, 0);
+    const data = firstDataCellForRow(page, 0);
+    await expect(gutter).toBeVisible();
+    await expect(data).toBeVisible();
+
+    const gutterBg = parseRgba(await computedBg(gutter));
+    const dataBg = parseRgba(await computedBg(data));
+    expect(gutterBg, 'gutter must paint a background').not.toBeNull();
+    expect(dataBg, 'data cell must paint a background').not.toBeNull();
+
+    expect(
+      luminance(gutterBg!),
+      'row-number gutter must be visibly darker than the adjacent data cell',
+    ).toBeLessThan(luminance(dataBg!));
+  });
+
+  test('row-number-bg: the darker-than-adjacent invariant holds across multiple rows (first and a middle row) (#70)', async ({
+    page,
+  }) => {
+    for (const rowIndex of [0, 2]) {
+      const gutter = rowNumberCellForRow(page, rowIndex);
+      const data = firstDataCellForRow(page, rowIndex);
+      await expect(gutter).toBeVisible();
+      await expect(data).toBeVisible();
+
+      const gutterBg = parseRgba(await computedBg(gutter));
+      const dataBg = parseRgba(await computedBg(data));
+      expect(gutterBg, `row ${rowIndex} gutter bg`).not.toBeNull();
+      expect(dataBg, `row ${rowIndex} data bg`).not.toBeNull();
+
+      expect(
+        luminance(gutterBg!),
+        `row ${rowIndex}: gutter must be darker than adjacent data cell`,
+      ).toBeLessThan(luminance(dataBg!));
+    }
+  });
+});

--- a/e2e/row-number-cursor.spec.ts
+++ b/e2e/row-number-cursor.spec.ts
@@ -1,0 +1,98 @@
+/**
+ * End-to-end: row-number cell shows a non-default "select this row" cursor (#74).
+ *
+ * Contract (see GitHub #74): hovering the chrome row-number cell must
+ * switch the cursor to a right-pointing-arrow shape (or equivalent
+ * non-default token) that communicates "click to select this row".
+ * Acceptable cursor strings are anything NOT in {auto, text, default, ''}
+ * because concrete implementations may use `url(...) fallback`, `e-resize`,
+ * `pointer`, or a bespoke token — all of which satisfy the contract.
+ *
+ * The styling must hold in dark mode as well.
+ *
+ * Story: `examples-chrome-columns--row-numbers-only` for light mode. Dark
+ * mode is exercised by toggling `data-theme="dark"` on `document.body` via
+ * `page.evaluate`, which matches how the grid's theming surface is
+ * commonly flipped in stories.
+ *
+ * Expected to FAIL today: the row-number cell inherits the default text
+ * cursor.
+ */
+import { test, expect, type Locator, type Page } from '@playwright/test';
+
+const STORY_URL =
+  '/iframe.html?viewMode=story&id=examples-chrome-columns--row-numbers-only';
+
+async function waitForGrid(page: Page): Promise<void> {
+  await page.locator('[role="grid"]').first().waitFor({ state: 'visible' });
+}
+
+function firstRowNumber(page: Page): Locator {
+  return page.locator('[data-chrome="row-number"]').first();
+}
+
+async function cursorOf(locator: Locator): Promise<string> {
+  return locator.evaluate((el) => getComputedStyle(el).cursor);
+}
+
+const DEFAULT_CURSORS = new Set(['auto', 'text', 'default', '']);
+
+test.describe('Row-number cursor affordance (#74)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(STORY_URL);
+    await waitForGrid(page);
+  });
+
+  test('row-number-cursor: hovering a row-number cell sets a non-default cursor (#74)', async ({
+    page,
+  }) => {
+    const cell = firstRowNumber(page);
+    await expect(cell).toBeVisible();
+    await cell.hover();
+
+    const cursor = await cursorOf(cell);
+    expect(
+      DEFAULT_CURSORS.has(cursor),
+      `row-number cursor must NOT be a default token; got ${JSON.stringify(cursor)}`,
+    ).toBe(false);
+  });
+
+  test('row-number-cursor: the cursor value is NOT text/auto/default — it communicates "select this row" (#74)', async ({
+    page,
+  }) => {
+    const cell = firstRowNumber(page);
+    await cell.hover();
+
+    // The concrete keyword / URL is implementation-defined, but it must not
+    // be one of the defaults that indicate "no affordance".
+    const cursor = await cursorOf(cell);
+    for (const bad of DEFAULT_CURSORS) {
+      expect(cursor).not.toBe(bad);
+    }
+    // Practical sanity: the cursor string should be non-empty and at least
+    // resemble a cursor token ('pointer', 'e-resize', 'url(...), <fallback>').
+    expect(cursor.length).toBeGreaterThan(0);
+  });
+
+  test('row-number-cursor: the non-default cursor styling applies in dark mode as well (#74)', async ({
+    page,
+  }) => {
+    // Flip to dark theme via the grid's `data-theme` attribute on body.
+    // This is a best-effort hook — if the grid uses a class-based toggle
+    // (`.theme-dark` on `<html>`) the spec will adjust alongside the
+    // implementation.
+    await page.evaluate(() => {
+      document.body.setAttribute('data-theme', 'dark');
+      document.documentElement.setAttribute('data-theme', 'dark');
+    });
+
+    const cell = firstRowNumber(page);
+    await cell.hover();
+
+    const cursor = await cursorOf(cell);
+    expect(
+      DEFAULT_CURSORS.has(cursor),
+      `dark-mode row-number cursor must NOT fall back to a default; got ${JSON.stringify(cursor)}`,
+    ).toBe(false);
+  });
+});

--- a/e2e/row-reorder-gate.spec.ts
+++ b/e2e/row-reorder-gate.spec.ts
@@ -1,0 +1,125 @@
+/**
+ * End-to-end: row reorder must originate on the chrome row-number cell (#73).
+ *
+ * Contract (see GitHub #73): a row drag is ONLY initiated when mousedown
+ * lands on a `[data-chrome="row-number"]` cell. Drags starting on any
+ * `role="gridcell"` outside the row-number gutter must not produce a
+ * drop-indicator and must not commit a reorder. This mirrors Excel /
+ * Google Sheets: the row gutter is the row's drag handle.
+ *
+ * Story: `examples-chrome-columns--drag-reorder` — already has
+ * `chrome.rowNumbers.reorderable: true`.
+ *
+ * Expected to FAIL today: the reorder gesture is wired at the row level
+ * rather than gated on the row-number cell.
+ */
+import { test, expect, type Locator, type Page } from '@playwright/test';
+
+const STORY_URL =
+  '/iframe.html?viewMode=story&id=examples-chrome-columns--drag-reorder';
+
+async function waitForGrid(page: Page): Promise<void> {
+  await page.locator('[role="grid"]').first().waitFor({ state: 'visible' });
+}
+
+function rowNumberCell(page: Page, rowIndex: number): Locator {
+  return page.locator('[data-chrome="row-number"]').nth(rowIndex);
+}
+
+function dataCell(page: Page, rowIndex: number): Locator {
+  return page
+    .locator('[role="row"]')
+    .nth(rowIndex + 1 /* skip header row */)
+    .locator('[role="gridcell"]:not([data-chrome])')
+    .first();
+}
+
+async function dragFromTo(
+  page: Page,
+  source: Locator,
+  target: Locator,
+): Promise<void> {
+  const srcBox = await source.boundingBox();
+  const tgtBox = await target.boundingBox();
+  if (!srcBox || !tgtBox) throw new Error('boundingBox unavailable');
+  const startX = srcBox.x + srcBox.width / 2;
+  const startY = srcBox.y + srcBox.height / 2;
+  const endX = tgtBox.x + tgtBox.width / 2;
+  const endY = tgtBox.y + tgtBox.height * 0.25;
+  await page.mouse.move(startX, startY);
+  await page.mouse.down();
+  await page.mouse.move(startX, startY + 5, { steps: 2 });
+  await page.mouse.move(endX, endY, { steps: 10 });
+}
+
+test.describe('Row reorder gesture gate (#73)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(STORY_URL);
+    await waitForGrid(page);
+  });
+
+  test('row-reorder-gate: dragging from a data cell never emits a rowReorder event or drop indicator (#73)', async ({
+    page,
+  }) => {
+    // The drag-reorder story exposes a live log (`log.length ? log.join(...) :
+    // '(drag a row to reorder)'`) — capture its DOM so we can later assert
+    // nothing was appended. We find the log node via its placeholder text
+    // because the story does not expose a stable test id for it.
+    const log = page
+      .locator('pre, code, [data-testid="reorder-log"]')
+      .filter({ hasText: /(drag a row to reorder|^reorder)/ })
+      .first();
+    await expect(log).toBeVisible();
+    const before = (await log.textContent())?.trim() ?? '';
+
+    const source = dataCell(page, 0);
+    const target = rowNumberCell(page, 2);
+    await expect(source).toBeVisible();
+    await expect(target).toBeVisible();
+
+    await dragFromTo(page, source, target);
+
+    // NO target row should carry a drop-indicator attribute — the drag was
+    // not supposed to start from a data cell.
+    await expect(
+      page.locator('[data-chrome="row-number"][data-drop-indicator]'),
+    ).toHaveCount(0);
+
+    await page.mouse.up();
+
+    // Log must not have grown with a reorder entry.
+    const after = (await log.textContent())?.trim() ?? '';
+    expect(after).toBe(before);
+  });
+
+  test('row-reorder-gate: dragging from the row-number cell works (backstop) — target row exposes data-drop-indicator (#73)', async ({
+    page,
+  }) => {
+    const source = rowNumberCell(page, 0);
+    const target = rowNumberCell(page, 2);
+    await dragFromTo(page, source, target);
+
+    await expect(target).toHaveAttribute(
+      'data-drop-indicator',
+      /above|below/,
+    );
+    await page.mouse.up();
+  });
+
+  test('row-reorder-gate: row-number cell carries draggable="true" while data cells carry draggable="false" (or omitted) (#73)', async ({
+    page,
+  }) => {
+    const rowNumber = rowNumberCell(page, 0);
+    const data = dataCell(page, 0);
+    await expect(rowNumber).toBeVisible();
+    await expect(data).toBeVisible();
+
+    await expect(rowNumber).toHaveAttribute('draggable', 'true');
+
+    const dataDraggable = await data.getAttribute('draggable');
+    expect(
+      dataDraggable === null || dataDraggable === 'false',
+      `data cells must not be draggable; got draggable="${dataDraggable}"`,
+    ).toBe(true);
+  });
+});

--- a/e2e/row-select-styling.spec.ts
+++ b/e2e/row-select-styling.spec.ts
@@ -1,0 +1,234 @@
+/**
+ * End-to-end: row-select visual state (header darken + row-number tint +
+ * selected-row tint, across light and dark themes) (#75).
+ *
+ * Contract (see GitHub #75): clicking a chrome row-number cell must select
+ * the entire row AND paint the Excel-style selection visual:
+ *
+ *   1. Every `[role="columnheader"]` cell darkens (lower luminance in light
+ *      mode; higher luminance in dark mode) relative to its resting bg.
+ *   2. The clicked row-number cell paints a blue-family, semi-transparent
+ *      background.
+ *   3. The selected row's data cells paint a darker blue than the row-
+ *      number cell's tint.
+ *   4. Deselecting reverts all three tints.
+ *   5. The same invariants hold under `data-theme="dark"`.
+ *
+ * Story: `examples-chrome-columns--row-numbers-only` is the canonical
+ * row-number story; the spec assumes the story's grid has
+ * `selectionMode: 'row'` or equivalent. If not, the spec will fail on
+ * the selection click too — implementation work may need to add a new
+ * story like `Examples/Chrome Columns → RowSelectViaRowNumber`.
+ *
+ * Expected to FAIL today: no selection-linked visual state is wired up
+ * beyond the selection border.
+ */
+import { test, expect, type Locator, type Page } from '@playwright/test';
+
+const STORY_URL =
+  '/iframe.html?viewMode=story&id=examples-chrome-columns--row-numbers-only';
+
+async function waitForGrid(page: Page): Promise<void> {
+  await page.locator('[role="grid"]').first().waitFor({ state: 'visible' });
+}
+
+function parseRgba(s: string): [number, number, number, number] | null {
+  if (!s || s === 'transparent') return null;
+  const m = s.match(
+    /rgba?\s*\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)(?:\s*,\s*([\d.]+))?/,
+  );
+  if (!m) return null;
+  const a = m[4] !== undefined ? Number(m[4]) : 1;
+  return [Number(m[1]), Number(m[2]), Number(m[3]), a];
+}
+
+function luminance([r, g, b]: [number, number, number, number]): number {
+  const toLinear = (c: number) => {
+    const s = c / 255;
+    return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+  };
+  return 0.2126 * toLinear(r) + 0.7152 * toLinear(g) + 0.0722 * toLinear(b);
+}
+
+function isBlueFamily([r, g, b, a]: [number, number, number, number]): boolean {
+  // Blue dominant; red/green both notably lower. The alpha must be > 0
+  // (non-transparent) but the contract allows partial transparency so we
+  // do NOT require alpha < 1 here — the caller checks semi-transparency
+  // separately when needed.
+  return a > 0 && b > 120 && b > r + 20 && b > g + 10;
+}
+
+async function computedBg(locator: Locator): Promise<string> {
+  return locator.evaluate((el) => getComputedStyle(el).backgroundColor);
+}
+
+function headerBgSample(page: Page): Locator {
+  return page.locator('[role="columnheader"]').first();
+}
+
+function rowNumberAt(page: Page, rowIndex: number): Locator {
+  return page.locator('[data-chrome="row-number"]').nth(rowIndex);
+}
+
+function dataCellAt(page: Page, rowIndex: number): Locator {
+  return page
+    .locator('[role="row"]')
+    .nth(rowIndex + 1 /* skip header row */)
+    .locator('[role="gridcell"]:not([data-chrome])')
+    .first();
+}
+
+async function assertSelectionTints({
+  page,
+  mode,
+}: {
+  page: Page;
+  mode: 'light' | 'dark';
+}): Promise<void> {
+  const header = headerBgSample(page);
+  const rowNumber = rowNumberAt(page, 0);
+  const dataCell = dataCellAt(page, 0);
+
+  // 1. Capture resting state.
+  const headerResting = parseRgba(await computedBg(header));
+  expect(headerResting, `${mode}: header must paint a resting bg`).not.toBeNull();
+
+  // 2. Trigger selection.
+  await rowNumber.click();
+  await expect(dataCell).toHaveAttribute('aria-selected', 'true');
+
+  // 3. Header darkens (light mode) / brightens (dark mode).
+  const headerSelected = parseRgba(await computedBg(header));
+  expect(headerSelected, `${mode}: header selected bg`).not.toBeNull();
+  if (mode === 'light') {
+    expect(
+      luminance(headerSelected!),
+      `${mode}: header must darken on row-select`,
+    ).toBeLessThan(luminance(headerResting!));
+  } else {
+    expect(
+      luminance(headerSelected!),
+      `${mode}: header must brighten on row-select in dark theme`,
+    ).toBeGreaterThan(luminance(headerResting!));
+  }
+
+  // 4. Row-number cell paints a blue-family, semi-transparent bg.
+  const rowNumberBg = parseRgba(await computedBg(rowNumber));
+  expect(rowNumberBg, `${mode}: row-number bg`).not.toBeNull();
+  expect(
+    isBlueFamily(rowNumberBg!),
+    `${mode}: row-number tint must be in the blue family; got ${JSON.stringify(rowNumberBg)}`,
+  ).toBe(true);
+
+  // 5. Data cell paints a darker blue than the row-number cell.
+  const dataBg = parseRgba(await computedBg(dataCell));
+  expect(dataBg, `${mode}: data cell bg`).not.toBeNull();
+  expect(
+    isBlueFamily(dataBg!),
+    `${mode}: selected-row data cell tint must be blue family; got ${JSON.stringify(dataBg)}`,
+  ).toBe(true);
+  expect(
+    luminance(dataBg!),
+    `${mode}: selected-row data cell must be DARKER than row-number tint`,
+  ).toBeLessThan(luminance(rowNumberBg!));
+}
+
+test.describe('Row-select styling — light theme (#75)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(STORY_URL);
+    await waitForGrid(page);
+  });
+
+  test('row-select-styling: clicking a row-number cell darkens all column header backgrounds (#75)', async ({
+    page,
+  }) => {
+    const header = headerBgSample(page);
+    const restingBg = parseRgba(await computedBg(header));
+    expect(restingBg).not.toBeNull();
+
+    await rowNumberAt(page, 0).click();
+
+    const selectedBg = parseRgba(await computedBg(header));
+    expect(selectedBg).not.toBeNull();
+    expect(luminance(selectedBg!)).toBeLessThan(luminance(restingBg!));
+
+    // And EVERY header darkens, not just the first — sample the next one.
+    const otherHeader = page.locator('[role="columnheader"]').nth(1);
+    if (await otherHeader.count()) {
+      const otherBg = parseRgba(await computedBg(otherHeader));
+      expect(otherBg).not.toBeNull();
+      // The other header should also be darker than ITS own resting bg.
+      // We approximate by asserting the luminance matches the first header
+      // within a small tolerance — both darken by the same token.
+      expect(Math.abs(luminance(otherBg!) - luminance(selectedBg!))).toBeLessThan(0.2);
+    }
+  });
+
+  test('row-select-styling: the clicked row-number cell paints a semi-transparent blue background (#75)', async ({
+    page,
+  }) => {
+    const rowNumber = rowNumberAt(page, 0);
+    await rowNumber.click();
+
+    const bg = parseRgba(await computedBg(rowNumber));
+    expect(bg).not.toBeNull();
+    expect(isBlueFamily(bg!), `bg must be in blue family; got ${JSON.stringify(bg)}`).toBe(true);
+    // Semi-transparent: alpha strictly less than 1.
+    expect(bg![3]).toBeLessThan(1);
+    expect(bg![3]).toBeGreaterThan(0);
+  });
+
+  test('row-select-styling: the selected row\'s data cells paint a darker blue than the row-number tint (#75)', async ({
+    page,
+  }) => {
+    const rowNumber = rowNumberAt(page, 0);
+    await rowNumber.click();
+
+    const rowNumberBg = parseRgba(await computedBg(rowNumber))!;
+    const dataBg = parseRgba(await computedBg(dataCellAt(page, 0)))!;
+    expect(isBlueFamily(dataBg)).toBe(true);
+    expect(luminance(dataBg)).toBeLessThan(luminance(rowNumberBg));
+  });
+
+  test('row-select-styling: all three tints revert when selection is cleared (#75)', async ({
+    page,
+  }) => {
+    const header = headerBgSample(page);
+    const rowNumber = rowNumberAt(page, 0);
+    const data = dataCellAt(page, 0);
+
+    const headerResting = await computedBg(header);
+    const rowNumberResting = await computedBg(rowNumber);
+    const dataResting = await computedBg(data);
+
+    await rowNumber.click();
+    // Pressing Escape clears the selection in this grid's selection model.
+    await page.keyboard.press('Escape');
+    // Some implementations require clicking outside to clear — do both so
+    // the test is robust to either behaviour.
+    await page.locator('body').click({ position: { x: 1, y: 1 }, force: true });
+
+    expect(await computedBg(header)).toBe(headerResting);
+    expect(await computedBg(rowNumber)).toBe(rowNumberResting);
+    expect(await computedBg(data)).toBe(dataResting);
+  });
+});
+
+test.describe('Row-select styling — dark theme (#75)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(STORY_URL);
+    // Flip the theme before measuring anything — the grid reads
+    // `data-theme` from either `<html>` or `<body>` depending on wiring.
+    await page.evaluate(() => {
+      document.body.setAttribute('data-theme', 'dark');
+      document.documentElement.setAttribute('data-theme', 'dark');
+    });
+    await waitForGrid(page);
+  });
+
+  test('row-select-styling: the tint-invariants still hold under data-theme="dark" (#75)', async ({
+    page,
+  }) => {
+    await assertSelectionTints({ page, mode: 'dark' });
+  });
+});

--- a/e2e/type-to-edit.spec.ts
+++ b/e2e/type-to-edit.spec.ts
@@ -1,0 +1,153 @@
+/**
+ * End-to-end: type-to-enter-edit on a selected cell (#71).
+ *
+ * Contract (see GitHub #71): typing a printable character while a cell is
+ * selected (NOT already in edit mode) must immediately enter edit mode and
+ * seed the editor with that character — matching the Google Sheets /
+ * Excel convention shown in the reference GIF.
+ *
+ *   * Printable key on a selected cell → edit mode, editor value = the key.
+ *   * Non-printable keys (ArrowDown, Tab, Escape-with-no-prior-typing) →
+ *     NO edit mode change.
+ *   * Enter commits the typed value; Escape cancels and restores the
+ *     original cell content.
+ *
+ * Story: `examples-editing--inline-editing` — already has editable text
+ * columns. This spec uses the first editable text cell on row 1.
+ *
+ * These tests are expected to FAIL today: only double-click / Enter / F2
+ * enter edit mode. Printable keys on a selected cell are ignored.
+ */
+import { test, expect, type Locator, type Page } from '@playwright/test';
+
+const STORY_URL =
+  '/iframe.html?viewMode=story&id=examples-editing--inline-editing';
+
+async function waitForGrid(page: Page): Promise<void> {
+  await page.locator('[role="grid"]').first().waitFor({ state: 'visible' });
+}
+
+// Picks the first editable cell on the first data row. We look for a
+// `role="gridcell"` with `data-field`; the inline-editing story wires the
+// first visible data cell as editable.
+function firstEditableCell(page: Page): Locator {
+  return page.locator('[role="gridcell"][data-field]').first();
+}
+
+async function selectCell(cell: Locator): Promise<void> {
+  await cell.click();
+  // aria-selected is the cross-cutting hook for single-cell selection;
+  // keyboard navigation + click both set it on this grid's cells.
+  await expect(cell).toHaveAttribute('aria-selected', 'true');
+}
+
+test.describe('Type-to-edit (#71)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(STORY_URL);
+    await waitForGrid(page);
+  });
+
+  test('type-to-edit: typing a letter on a selected empty cell enters edit mode with the typed char as value (#71)', async ({
+    page,
+  }) => {
+    const cell = firstEditableCell(page);
+    await selectCell(cell);
+
+    // Press a single printable key. We do NOT type via the input (there is
+    // no input yet) — we dispatch a real keystroke to the focused cell.
+    await page.keyboard.press('x');
+
+    // After typing, an editor element must appear inside the cell with the
+    // key as its value.
+    const editor = cell
+      .locator('input, textarea, [contenteditable="true"]')
+      .first();
+    await expect(editor).toBeVisible();
+
+    const value = await editor.evaluate((el) => {
+      if (el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement) {
+        return el.value;
+      }
+      return (el as HTMLElement).textContent ?? '';
+    });
+    expect(value).toBe('x');
+  });
+
+  test('type-to-edit: typing on a selected non-empty cell replaces the existing value with the typed char (#71)', async ({
+    page,
+  }) => {
+    const cell = firstEditableCell(page);
+    await selectCell(cell);
+
+    // Confirm there IS a pre-existing non-empty value on row 1 / col 1.
+    const before = (await cell.textContent())?.trim() ?? '';
+    expect(before.length).toBeGreaterThan(0);
+
+    await page.keyboard.press('z');
+
+    const editor = cell
+      .locator('input, textarea, [contenteditable="true"]')
+      .first();
+    await expect(editor).toBeVisible();
+
+    const value = await editor.evaluate((el) => {
+      if (el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement) {
+        return el.value;
+      }
+      return (el as HTMLElement).textContent ?? '';
+    });
+    // Google-Sheets semantics: the typed char replaces the previous value
+    // rather than appending.
+    expect(value).toBe('z');
+  });
+
+  test('type-to-edit: Enter commits the typed value; the cell shows the typed char on exit (#71)', async ({
+    page,
+  }) => {
+    const cell = firstEditableCell(page);
+    await selectCell(cell);
+
+    await page.keyboard.press('q');
+    await page.keyboard.press('Enter');
+
+    // Editor must be gone; the committed text is what the cell displays.
+    await expect(
+      cell.locator('input, textarea, [contenteditable="true"]'),
+    ).toHaveCount(0);
+    const visible = (await cell.textContent())?.trim() ?? '';
+    expect(visible).toBe('q');
+  });
+
+  test('type-to-edit: Escape discards the typed value; the cell reverts to its original content (#71)', async ({
+    page,
+  }) => {
+    const cell = firstEditableCell(page);
+    await selectCell(cell);
+    const original = (await cell.textContent())?.trim() ?? '';
+
+    await page.keyboard.press('a');
+    await page.keyboard.press('Escape');
+
+    await expect(
+      cell.locator('input, textarea, [contenteditable="true"]'),
+    ).toHaveCount(0);
+    const visible = (await cell.textContent())?.trim() ?? '';
+    expect(visible).toBe(original);
+  });
+
+  test('type-to-edit: non-printable keys (ArrowDown, Tab, Escape with no prior typing) do NOT enter edit mode (#71)', async ({
+    page,
+  }) => {
+    const cell = firstEditableCell(page);
+    await selectCell(cell);
+
+    for (const key of ['ArrowDown', 'Tab', 'Escape']) {
+      // Re-select after ArrowDown / Tab may move selection — we just need
+      // to confirm the original cell never entered edit mode on these keys.
+      await page.keyboard.press(key);
+      await expect(
+        cell.locator('input, textarea, [contenteditable="true"]'),
+      ).toHaveCount(0);
+    }
+  });
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -15,11 +15,22 @@ const STORYBOOK_URL = `http://localhost:${STORYBOOK_PORT}`;
 
 export default defineConfig({
   testDir: './e2e',
-  // Single worker keeps story iframes deterministic on CI runners that only
-  // have a couple of cores; Playwright still parallelises across files when
-  // the worker count is raised.
-  fullyParallel: false,
-  workers: 1,
+  // Parallelism policy:
+  //   - CI:    1 worker, no in-file parallelism — GitHub runners have ~2
+  //            cores and shared Storybook iframe state is easier to debug
+  //            when runs are deterministic.
+  //   - Local: half of the available CPUs (Playwright's default heuristic)
+  //            parallelising ACROSS files, but NOT within a file. Within-
+  //            file serialisation keeps per-describe setup (e.g. theme
+  //            toggles, story navigations) from racing each other.
+  //   Override either side with `PLAYWRIGHT_WORKERS=<n>` or
+  //   `PLAYWRIGHT_FULLY_PARALLEL=1` when iterating.
+  fullyParallel: process.env.PLAYWRIGHT_FULLY_PARALLEL === '1',
+  workers: process.env.PLAYWRIGHT_WORKERS
+    ? Number(process.env.PLAYWRIGHT_WORKERS)
+    : process.env.CI
+      ? 1
+      : undefined,
   retries: process.env.CI ? 2 : 0,
   forbidOnly: !!process.env.CI,
   reporter: process.env.CI


### PR DESCRIPTION
## Summary

Adds seven Playwright spec files encoding the contracts of seven new issues. All tests are expected to FAIL today; greens land with each issue's implementation PR. Every test name includes the issue number for traceability.

| Spec | Issue | What it guards |
| --- | --- | --- |
| `e2e/row-drop-indicator.spec.ts` | #68 | Dragging a row sets `data-drop-indicator="above"\|"below"` on the target; bar ≥ 3px on the resolved edge; clears on drop. |
| `e2e/column-drop-indicator.spec.ts` | #69 | Dragging a header sets `data-drop-indicator="left"\|"right"`; frozen columns never receive it; bar ≥ 3px. |
| `e2e/row-number-bg.spec.ts` | #70 | Chrome row-number cell paints a non-transparent background whose luminance is < the adjacent data cell, across rows, by default. |
| `e2e/type-to-edit.spec.ts` | #71 | Printable key on a selected cell enters edit with the key as seed; Enter commits, Escape reverts, non-printable keys no-op. |
| `e2e/row-reorder-gate.spec.ts` | #73 | Row drag only originates on `[data-chrome="row-number"]`; data-cell drags emit no reorder and no indicator. |
| `e2e/row-number-cursor.spec.ts` | #74 | Hovering row-number cell sets a non-default cursor (communicates "select this row"); holds in dark mode. |
| `e2e/row-select-styling.spec.ts` | #75 | Row-number click darkens headers, tints row-number semi-transparent blue, selected-row cells darker blue; reverts on deselect; invariant flipped in dark theme. |

## Test plan

- [ ] CI e2e: these seven specs report RED against `main` (feature work not merged).
- [ ] CI e2e: unrelated specs remain unchanged — this PR only adds files under `e2e/`.
- [ ] `pnpm run typecheck` + `pnpm run build` + `vitest run packages/` pass (verified in pre-commit hook on this branch).