### PR TITLE
fix(editing): Excel-365 commit-and-advance for text cell renderers + Ctrl+A editor guard

### DIFF
--- a/e2e/edit-commit-nav.spec.ts
+++ b/e2e/edit-commit-nav.spec.ts
@@ -72,8 +72,12 @@ for (const { label, url } of STORY_URLS) {
       const input = await beginEdit(target);
 
       const newValue = `enter-${label}-${Date.now()}`;
-      await input.press('Control+a');
-      await input.pressSequentially(newValue, { delay: 2 });
+      // `fill` atomically clears + sets the value via the DOM property and
+      // dispatches an `input` event, which React's controlled-input
+      // `onChange` picks up. More robust than keystroke-level Ctrl+A +
+      // pressSequentially, where selection state can be dropped across the
+      // focus/re-render cycle in chromium.
+      await input.fill(newValue);
       await input.press('Enter');
 
       // Editor is gone.
@@ -93,8 +97,7 @@ for (const { label, url } of STORY_URLS) {
       const input = await beginEdit(target);
 
       const newValue = `tab-${label}-${Date.now()}`;
-      await input.press('Control+a');
-      await input.pressSequentially(newValue, { delay: 2 });
+      await input.fill(newValue);
       await input.press('Tab');
 
       await expect(target.locator('input')).toHaveCount(0);
@@ -113,8 +116,7 @@ for (const { label, url } of STORY_URLS) {
       const originalText = (await target.innerText()).trim();
 
       const input = await beginEdit(target);
-      await input.press('Control+a');
-      await input.pressSequentially('should-not-persist', { delay: 2 });
+      await input.fill('should-not-persist');
       await input.press('Escape');
 
       await expect(target.locator('input')).toHaveCount(0);
@@ -138,8 +140,7 @@ for (const { label, url } of STORY_URLS) {
       const input = await beginEdit(target);
 
       const newValue = `post-commit-arrow-${Date.now()}`;
-      await input.press('Control+a');
-      await input.pressSequentially(newValue, { delay: 2 });
+      await input.fill(newValue);
       await input.press('Enter');
 
       // Enter-commit landed us on (3, name).

--- a/packages/react/src/DataGrid.tsx
+++ b/packages/react/src/DataGrid.tsx
@@ -159,7 +159,18 @@ export interface CellRendererProps<TData = Record<string, unknown>> {
   column: ColumnDef<TData>;
   rowIndex: number;
   isEditing: boolean;
-  onCommit: (value: CellValue) => void;
+  /**
+   * Commit the edited value and exit edit mode.
+   *
+   * Optional second argument encodes the Excel-365 commit-and-move intent:
+   *   `'down'`  → Enter  : commit and move selection DOWN one row.
+   *   `'right'` → Tab    : commit and move selection RIGHT one column.
+   *   `undefined`        → no advance (e.g. blur commit).
+   *
+   * The grid clamps at edges (last row for `'down'`, last column for `'right'`)
+   * and leaves selection on the current cell rather than wrapping.
+   */
+  onCommit: (value: CellValue, advance?: 'down' | 'right') => void;
   onCancel: () => void;
   /**
    * Stable identifier of the owning grid, forwarded so cell renderers that

--- a/packages/react/src/__tests__/edit-commit-nav.test.tsx
+++ b/packages/react/src/__tests__/edit-commit-nav.test.tsx
@@ -300,3 +300,28 @@ describe('edit-commit-nav — arrow keys work AFTER a commit / cancel', () => {
     expect(isSelected('2', 'age')).toBe(true);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Editor focus vs grid shortcuts: Ctrl+A in edit mode must stay local to
+// the input (native "select all text") and NOT be hijacked by the grid's
+// "select all cells" handler. Pairs with the `Ctrl+A selects all cells`
+// test in keyboard-nav — the gate is in use-keyboard.ts.
+// ---------------------------------------------------------------------------
+
+describe('edit-commit-nav — Ctrl+A stays local to the editor input', () => {
+  it('Ctrl+A does NOT trigger selectAllCells while a cell is in edit mode', () => {
+    renderGrid();
+    const input = enterEditAndType('1', 'name', 'Alice-draft');
+
+    // Fire Ctrl+A on the grid root — simulates the real event bubble path.
+    // fireEvent returns `false` if defaultPrevented was called.
+    const notPrevented = fireEvent.keyDown(getGrid(), {
+      key: 'a',
+      ctrlKey: true,
+    });
+
+    expect(notPrevented).toBe(true);
+    // Editor is still mounted — the grid-level handler didn't yank focus.
+    expect(input).toBeInTheDocument();
+  });
+});

--- a/packages/react/src/body/DataGridBody.tsx
+++ b/packages/react/src/body/DataGridBody.tsx
@@ -822,7 +822,7 @@ export function DataGridBody<TData extends Record<string, unknown>>(
             isEditing={editing}
             gridId={gridId}
             rowId={rowId}
-            onCommit={v => {
+            onCommit={(v, advance) => {
               const vResults = validateCell(col, v, rowId, row);
               const severe = mostSevere(vResults);
               if (severe && severe.severity === 'error') {
@@ -834,6 +834,21 @@ export function DataGridBody<TData extends Record<string, unknown>>(
               model.setCellValue(cellAddr, v);
               model.cancelEdit();
               onCellEdit?.(rowId, col.field, v, value);
+              // Excel-365 commit-and-advance: Enter → DOWN, Tab → RIGHT.
+              // Stay at edges rather than wrap. Matches the default inline
+              // <input> path below and the unit test contract in
+              // `edit-commit-nav.test.tsx`.
+              if (advance === 'down') {
+                const nextRowId = rowIds[rowIdx + 1];
+                if (nextRowId != null) {
+                  model.select({ rowId: nextRowId, field: col.field });
+                }
+              } else if (advance === 'right') {
+                const nextCol = orderedVisibleColumns[colIdx + 1];
+                if (nextCol) {
+                  model.select({ rowId, field: nextCol.field });
+                }
+              }
             }}
             onCancel={() => model.cancelEdit()}
           />

--- a/packages/react/src/cells/TextCell/TextCell.tsx
+++ b/packages/react/src/cells/TextCell/TextCell.tsx
@@ -28,8 +28,12 @@ interface TextCellProps<TData = Record<string, unknown>> {
   rowIndex: number;
   /** Whether the cell is currently in inline-edit mode. */
   isEditing: boolean;
-  /** Callback to persist the edited value back to the data source. */
-  onCommit: (value: CellValue) => void;
+  /**
+   * Callback to persist the edited value back to the data source. Optional
+   * `advance` encodes Excel-365 commit-and-move intent: `'down'` for Enter,
+   * `'right'` for Tab, `undefined` for blur commits.
+   */
+  onCommit: (value: CellValue, advance?: 'down' | 'right') => void;
   /** Callback to discard the current edit and exit edit mode. */
   onCancel: () => void;
 }
@@ -116,11 +120,12 @@ export const TextCell = React.memo(function TextCell<TData = Record<string, unkn
   /**
    * Commits on Enter (single-line only), commits on Tab, cancels on Escape.
    *
-   * Issue #10: Enter and Tab both commit-and-stay — the cell exits edit mode
-   * but selection remains on the same cell. `preventDefault` suppresses the
-   * browser's Tab-focus-advance, and `stopPropagation` prevents the
-   * grid-level keyboard handler from re-entering edit mode (Enter) or moving
-   * selection to the adjacent cell (Tab).
+   * Excel-365 commit-and-advance: Enter commits the draft and advances
+   * selection DOWN one row; Tab commits and advances RIGHT one column. At
+   * the grid edge the selection stays put. `preventDefault` suppresses the
+   * browser's Tab-focus-advance, and `stopPropagation` keeps the grid-level
+   * keyboard handler from observing the same Enter/Tab twice (the advance
+   * is already applied by the `onCommit` consumer).
    */
   const handleKeyDown = (e: React.KeyboardEvent) => {
     // Guard: ignore Enter/Tab while an IME candidate window is open.
@@ -129,11 +134,11 @@ export const TextCell = React.memo(function TextCell<TData = Record<string, unkn
     if (e.key === 'Enter' && !column.format?.includes('multiline')) {
       e.preventDefault();
       e.stopPropagation();
-      onCommit(draft);
+      onCommit(draft, 'down');
     } else if (e.key === 'Tab') {
       e.preventDefault();
       e.stopPropagation();
-      onCommit(draft);
+      onCommit(draft, 'right');
     } else if (e.key === 'Escape') {
       handleCancel();
     }
@@ -157,11 +162,12 @@ export const TextCell = React.memo(function TextCell<TData = Record<string, unkn
         onChange={(e) => setDraft(e.target.value)}
         onKeyDown={(e) => {
           // In multiline mode Enter inserts a newline rather than committing,
-          // but Tab still commits-and-stays per issue #10. Escape cancels.
+          // but Tab commits and advances RIGHT one column per the Excel-365
+          // contract. Escape cancels.
           if (e.key === 'Tab') {
             e.preventDefault();
             e.stopPropagation();
-            onCommit(draft);
+            onCommit(draft, 'right');
           } else if (e.key === 'Escape') {
             handleCancel();
           }

--- a/packages/react/src/cells/TextCell/__tests__/TextCell.test.tsx
+++ b/packages/react/src/cells/TextCell/__tests__/TextCell.test.tsx
@@ -53,7 +53,9 @@ describe('TextCell', () => {
     expect(input?.value).toBe('hello');
   });
 
-  it('calls onCommit with updated value on Enter', () => {
+  // Excel-365 commit-and-advance: Enter commits the draft and hints the
+  // grid to move selection DOWN one row (second arg = 'down').
+  it('calls onCommit with updated value + DOWN advance on Enter', () => {
     const onCommit = vi.fn();
     const { container } = render(
       <TextCell value="hello" row={{}} column={baseColumn} rowIndex={0} isEditing={true} onCommit={onCommit} onCancel={noop} />
@@ -61,12 +63,13 @@ describe('TextCell', () => {
     const input = container.querySelector('input')!;
     fireEvent.change(input, { target: { value: 'world' } });
     fireEvent.keyDown(input, { key: 'Enter' });
-    expect(onCommit).toHaveBeenCalledWith('world');
+    expect(onCommit).toHaveBeenCalledWith('world', 'down');
   });
 
-  // Issue #10: Enter must commit the draft AND stop propagation/defaults so
-  // the grid-level handler does not re-open edit mode afterwards.
-  it('stops propagation and prevents default on Enter (issue #10)', () => {
+  // Enter must preventDefault (no form submit) and stopPropagation so the
+  // grid-level handler does not observe a second commit/advance for the
+  // same event — the advance is already encoded in the onCommit call.
+  it('stops propagation and prevents default on Enter', () => {
     const onCommit = vi.fn();
     const { container } = render(
       <TextCell value="hello" row={{}} column={baseColumn} rowIndex={0} isEditing={true} onCommit={onCommit} onCancel={noop} />
@@ -77,14 +80,14 @@ describe('TextCell', () => {
     const stopProp = vi.spyOn(evt, 'stopPropagation');
     const prevDef = vi.spyOn(evt, 'preventDefault');
     input.dispatchEvent(evt);
-    expect(onCommit).toHaveBeenCalledWith('world');
+    expect(onCommit).toHaveBeenCalledWith('world', 'down');
     expect(stopProp).toHaveBeenCalled();
     expect(prevDef).toHaveBeenCalled();
   });
 
-  // Issue #10: Tab commits exactly like Enter (commit-and-stay) instead of
-  // the browser's default focus-advance.
-  it('commits on Tab and does not advance focus (issue #10)', () => {
+  // Excel-365 commit-and-advance: Tab commits and hints the grid to move
+  // RIGHT one column (second arg = 'right').
+  it('commits on Tab and hints RIGHT advance', () => {
     const onCommit = vi.fn();
     const onCancel = vi.fn();
     const { container } = render(
@@ -96,16 +99,16 @@ describe('TextCell', () => {
     const stopProp = vi.spyOn(evt, 'stopPropagation');
     const prevDef = vi.spyOn(evt, 'preventDefault');
     input.dispatchEvent(evt);
-    expect(onCommit).toHaveBeenCalledWith('world');
+    expect(onCommit).toHaveBeenCalledWith('world', 'right');
     expect(onCancel).not.toHaveBeenCalled();
     // Default Tab behaviour (focus move) is suppressed.
     expect(prevDef).toHaveBeenCalled();
     expect(stopProp).toHaveBeenCalled();
   });
 
-  // Issue #10: Shift+Tab must behave the same as Tab — commit-and-stay, no
-  // reverse focus advance to the cell on the left.
-  it('commits on Shift+Tab (issue #10)', () => {
+  // Shift+Tab commits with the same RIGHT hint — reverse-advance is not
+  // modelled yet; the grid clamps at edges either way.
+  it('commits on Shift+Tab with RIGHT advance', () => {
     const onCommit = vi.fn();
     const { container } = render(
       <TextCell value="hello" row={{}} column={baseColumn} rowIndex={0} isEditing={true} onCommit={onCommit} onCancel={noop} />
@@ -115,7 +118,7 @@ describe('TextCell', () => {
     const evt = new KeyboardEvent('keydown', { key: 'Tab', shiftKey: true, bubbles: true, cancelable: true });
     const prevDef = vi.spyOn(evt, 'preventDefault');
     input.dispatchEvent(evt);
-    expect(onCommit).toHaveBeenCalledWith('world');
+    expect(onCommit).toHaveBeenCalledWith('world', 'right');
     expect(prevDef).toHaveBeenCalled();
   });
 
@@ -200,7 +203,7 @@ describe('TextCell', () => {
     const input = container.querySelector('input')!;
     fireEvent.change(input, { target: { value: '' } });
     fireEvent.keyDown(input, { key: 'Enter' });
-    expect(onCommit).toHaveBeenCalledWith('');
+    expect(onCommit).toHaveBeenCalledWith('', 'down');
   });
 
   it('passes placeholder to input in edit mode', () => {

--- a/packages/react/src/cells/hooks/__tests__/hooks.test.tsx
+++ b/packages/react/src/cells/hooks/__tests__/hooks.test.tsx
@@ -32,19 +32,28 @@ describe('useDraftState', () => {
     expect(result.current.draft).toBe('initial');
   });
 
-  it('commit() calls onCommit with current draft', () => {
+  it('commit() calls onCommit with current draft and no advance', () => {
     const onCommit = vi.fn();
     const { result } = renderHook(() => useDraftState({ ...defaultOpts, onCommit, isEditing: true }));
     act(() => result.current.setDraft('world'));
     act(() => result.current.commit());
-    expect(onCommit).toHaveBeenCalledWith('world');
+    expect(onCommit).toHaveBeenCalledWith('world', undefined);
   });
 
-  it('commit(raw) calls onCommit with provided value', () => {
+  it('commit(raw) calls onCommit with provided value and no advance', () => {
     const onCommit = vi.fn();
     const { result } = renderHook(() => useDraftState({ ...defaultOpts, onCommit }));
     act(() => result.current.commit('override'));
-    expect(onCommit).toHaveBeenCalledWith('override');
+    expect(onCommit).toHaveBeenCalledWith('override', undefined);
+  });
+
+  it('commit(raw, advance) forwards the Excel-365 advance hint', () => {
+    const onCommit = vi.fn();
+    const { result } = renderHook(() => useDraftState({ ...defaultOpts, onCommit }));
+    act(() => result.current.commit('x', 'down'));
+    act(() => result.current.commit('y', 'right'));
+    expect(onCommit).toHaveBeenNthCalledWith(1, 'x', 'down');
+    expect(onCommit).toHaveBeenNthCalledWith(2, 'y', 'right');
   });
 
   it('transformCommit is applied before onCommit', () => {
@@ -54,25 +63,25 @@ describe('useDraftState', () => {
     );
     act(() => result.current.setDraft('42'));
     act(() => result.current.commit());
-    expect(onCommit).toHaveBeenCalledWith(42);
+    expect(onCommit).toHaveBeenCalledWith(42, undefined);
   });
 
-  it('handleKeyDown Enter commits', () => {
+  it('handleKeyDown Enter commits with DOWN advance hint', () => {
     const onCommit = vi.fn();
     const { result } = renderHook(() => useDraftState({ ...defaultOpts, onCommit, isEditing: true }));
     act(() => {
       result.current.handleKeyDown({ key: 'Enter', preventDefault: vi.fn(), stopPropagation: vi.fn() } as any);
     });
-    expect(onCommit).toHaveBeenCalled();
+    expect(onCommit).toHaveBeenCalledWith('hello', 'down');
   });
 
-  it('handleKeyDown Tab commits', () => {
+  it('handleKeyDown Tab commits with RIGHT advance hint', () => {
     const onCommit = vi.fn();
     const { result } = renderHook(() => useDraftState({ ...defaultOpts, onCommit, isEditing: true }));
     act(() => {
       result.current.handleKeyDown({ key: 'Tab', preventDefault: vi.fn(), stopPropagation: vi.fn() } as any);
     });
-    expect(onCommit).toHaveBeenCalled();
+    expect(onCommit).toHaveBeenCalledWith('hello', 'right');
   });
 
   it('handleKeyDown Escape cancels', () => {

--- a/packages/react/src/cells/hooks/useDraftState.ts
+++ b/packages/react/src/cells/hooks/useDraftState.ts
@@ -14,8 +14,12 @@ export interface UseDraftStateOptions {
   initialValue: string;
   /** Whether the cell is currently editing. */
   isEditing: boolean;
-  /** Callback fired with the transformed value when the edit is confirmed. */
-  onCommit: (value: unknown) => void;
+  /**
+   * Callback fired with the transformed value when the edit is confirmed.
+   * Optional `advance` hints the grid to move selection DOWN (Enter) or
+   * RIGHT (Tab) after committing — blur commits pass `undefined`.
+   */
+  onCommit: (value: unknown, advance?: 'down' | 'right') => void;
   /** Callback fired when the edit is discarded (Escape). */
   onCancel: () => void;
   /** Optional transform applied to the draft string before committing (e.g. `parseFloat`). */
@@ -38,8 +42,12 @@ export interface UseDraftStateReturn {
   handleKeyDown: (e: React.KeyboardEvent) => void;
   /** Blur handler: commits the current draft. */
   handleBlur: () => void;
-  /** Imperative commit: pass a raw string override or falls back to current draft. */
-  commit: (raw?: string) => void;
+  /**
+   * Imperative commit: pass a raw string override or falls back to current
+   * draft. Optional `advance` forwards the Excel-365 commit-and-move intent
+   * to the grid (Enter → 'down', Tab → 'right').
+   */
+  commit: (raw?: string, advance?: 'down' | 'right') => void;
 }
 
 /**
@@ -89,11 +97,11 @@ export function useDraftState({
 
   /** Transforms and commits a value, defaulting to the current draft. */
   const commit = useCallback(
-    (raw?: string) => {
+    (raw?: string, advance?: 'down' | 'right') => {
       if (cancelledRef.current) return;
       const source = raw !== undefined ? raw : draft;
       const committed = transformCommit ? transformCommit(source) : source;
-      onCommit(committed);
+      onCommit(committed, advance);
     },
     [draft, transformCommit, onCommit],
   );
@@ -101,18 +109,23 @@ export function useDraftState({
   /**
    * Commits on Enter or Tab, cancels on Escape.
    *
-   * Issue #10: Enter and Tab both commit-and-stay. `preventDefault` prevents
-   * the browser's native Tab-focus-advance and any form submission, while
-   * `stopPropagation` stops the grid-level keyboard handler from re-opening
-   * edit mode (Enter) or advancing the selection (Tab) after the cell editor
-   * has already committed.
+   * Excel-365 commit-and-advance: Enter commits and moves selection DOWN
+   * one row; Tab commits and moves RIGHT one column. `preventDefault`
+   * suppresses the browser's native Tab-focus-advance and any form
+   * submission, and `stopPropagation` keeps the grid-level keyboard
+   * handler from observing a second Enter/Tab for the same event (the
+   * advance has already been applied via `onCommit`).
    */
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
-      if (e.key === 'Enter' || e.key === 'Tab') {
+      if (e.key === 'Enter') {
         e.preventDefault();
         e.stopPropagation();
-        commit();
+        commit(undefined, 'down');
+      } else if (e.key === 'Tab') {
+        e.preventDefault();
+        e.stopPropagation();
+        commit(undefined, 'right');
       } else if (e.key === 'Escape') {
         cancelledRef.current = true;
         onCancel();

--- a/packages/react/src/use-keyboard.ts
+++ b/packages/react/src/use-keyboard.ts
@@ -438,8 +438,12 @@ export function useKeyboard<TData extends Record<string, unknown>>(
         break;
       }
       // --- Ctrl+A: select all cells ---
+      // Must NOT fire while an editor input has focus — otherwise
+      // Ctrl+A in the inline editor is swallowed by the grid and the
+      // user can't select-all-text to replace it. Matches the Ctrl+C /
+      // Ctrl+V / Ctrl+X gating below.
       case 'a': {
-        if (e.ctrlKey || e.metaKey) {
+        if ((e.ctrlKey || e.metaKey) && !editing.cell) {
           e.preventDefault();
           model.selectAllCells();
         }

--- a/stories/Editing.stories.tsx
+++ b/stories/Editing.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { MuiDataGrid } from '@istracked/datagrid-mui';
 import type { ColumnDef, CellValue } from '@istracked/datagrid-core';
@@ -14,6 +14,7 @@ export default meta;
 export const InlineEditing: StoryObj = {
   render: () => {
     const [log, setLog] = useState<string[]>([]);
+    const data = useMemo(() => makeEmployees(15), []);
     return (
       <div style={storyContainer}>
         <h2 style={styles.heading}>Inline Cell Editing</h2>
@@ -22,7 +23,7 @@ export const InlineEditing: StoryObj = {
         </p>
         <div style={gridContainer}>
           <MuiDataGrid
-            data={makeEmployees(15)}
+            data={data}
             columns={defaultColumns as any}
             rowKey="id"
             selectionMode="cell"
@@ -48,6 +49,7 @@ export const EnterTabCommitAndAdvance: StoryObj = {
   name: 'Enter/Tab commit-and-advance (Excel-365)',
   render: () => {
     const [log, setLog] = useState<string[]>([]);
+    const data = useMemo(() => makeEmployees(10), []);
     return (
       <div style={storyContainer}>
         <h2 style={styles.heading}>Enter / Tab: commit-and-advance</h2>
@@ -62,7 +64,7 @@ export const EnterTabCommitAndAdvance: StoryObj = {
         </p>
         <div style={gridContainer}>
           <MuiDataGrid
-            data={makeEmployees(10)}
+            data={data}
             columns={defaultColumns as any}
             rowKey="id"
             selectionMode="cell"
@@ -106,6 +108,7 @@ export const WithValidation: StoryObj = {
       }
       return c;
     });
+    const data = useMemo(() => makeEmployees(10), []);
     return (
       <div style={storyContainer}>
         <h2 style={styles.heading}>Validation</h2>
@@ -114,7 +117,7 @@ export const WithValidation: StoryObj = {
         </p>
         <div style={gridContainer}>
           <MuiDataGrid
-            data={makeEmployees(10)}
+            data={data}
             columns={cols as any}
             rowKey="id"
             selectionMode="cell"
@@ -129,6 +132,7 @@ export const WithValidation: StoryObj = {
 export const EscapeCancelsAndKeepsSelection: StoryObj = {
   render: () => {
     const [log, setLog] = useState<string[]>([]);
+    const data = useMemo(() => makeEmployees(8), []);
     return (
       <div style={storyContainer}>
         <h2 style={styles.heading}>Escape Cancels Edit and Keeps Selection</h2>
@@ -140,7 +144,7 @@ export const EscapeCancelsAndKeepsSelection: StoryObj = {
         </p>
         <div style={gridContainer}>
           <MuiDataGrid
-            data={makeEmployees(8)}
+            data={data}
             columns={defaultColumns as any}
             rowKey="id"
             selectionMode="cell"
@@ -159,21 +163,24 @@ export const EscapeCancelsAndKeepsSelection: StoryObj = {
 };
 
 export const UndoRedo: StoryObj = {
-  render: () => (
-    <div style={storyContainer}>
-      <h2 style={styles.heading}>Undo / Redo</h2>
-      <p style={styles.subtitle}>
-        Edit cells then press <kbd>Ctrl+Z</kbd> to undo and <kbd>Ctrl+Y</kbd> or <kbd>Ctrl+Shift+Z</kbd> to redo.
-      </p>
-      <div style={gridContainer}>
-        <MuiDataGrid
-          data={makeEmployees(10)}
-          columns={defaultColumns as any}
-          rowKey="id"
-          selectionMode="cell"
-          keyboardNavigation
-        />
+  render: () => {
+    const data = useMemo(() => makeEmployees(10), []);
+    return (
+      <div style={storyContainer}>
+        <h2 style={styles.heading}>Undo / Redo</h2>
+        <p style={styles.subtitle}>
+          Edit cells then press <kbd>Ctrl+Z</kbd> to undo and <kbd>Ctrl+Y</kbd> or <kbd>Ctrl+Shift+Z</kbd> to redo.
+        </p>
+        <div style={gridContainer}>
+          <MuiDataGrid
+            data={data}
+            columns={defaultColumns as any}
+            rowKey="id"
+            selectionMode="cell"
+            keyboardNavigation
+          />
+        </div>
       </div>
-    </div>
-  ),
+    );
+  },
 };


### PR DESCRIPTION
## Summary

- **Excel-365 commit-and-advance now fires on every editable text cell, not only the default `<input>`.** Extends `CellRendererProps.onCommit` with an optional `advance?: 'down' | 'right'` so `TextCell`, `MuiTextCell`, and anything built on `useDraftState` can hint the grid to move selection DOWN (Enter) or RIGHT (Tab) after a successful commit.
- **Ctrl+A inside an editor is no longer hijacked by the grid.** Grid-level Ctrl+A is now gated on `!editing.cell`, so native select-all-text works while an inline editor is open. Pairs with the existing Ctrl+V / Ctrl+X / Ctrl+C gates.
- **E2E spec hardening.** Replaces the flaky `press('Control+a') + pressSequentially()` idiom with `input.fill()`, which atomically replaces the input value via the DOM property. Memoises the Employee dataset in every `Examples/Editing` story so `setLog` re-renders don't reset the grid's `dataAtom` and revert a just-committed value.

## Impact

- Drops `edit-commit-nav.spec.ts` from 15 red → 20/20 green across 5 editing stories.
- Contract in `packages/react/src/__tests__/edit-commit-nav.test.tsx` (the Excel-365 canonical spec) still passes 20/20.
- Full React vitest suite: 1162/1162 green.
- Overall Playwright delta: 27 → 10 E2E failures on `main` at d8c5b57. Remaining clusters (clipboard-copy, editor-padding, rich-text-floating-menu, validation-tooltip) are distinct feature gaps tracked separately.

## Test plan

- [x] `pnpm exec vitest run packages/react` → 1162 passed
- [x] `pnpm exec playwright test e2e/edit-commit-nav.spec.ts` → 20/20 passed
- [x] `pnpm exec playwright test` → 48 passed, 10 failed (unrelated clusters)