### PR TITLE
fix(clipboard): append trailing LF to every TSV row for Excel/Sheets parity

### DIFF
--- a/packages/core/src/__tests__/clipboard.test.ts
+++ b/packages/core/src/__tests__/clipboard.test.ts
@@ -118,7 +118,9 @@ describe('serializeRangeToText', () => {
       anchor: { rowId: 'r1', field: 'name' },
       focus: { rowId: 'r1', field: 'age' },
     };
-    expect(serializeRangeToText(data, range, cols, rowIds)).toBe('Alice\t30');
+    // Multi-cell ranges terminate with LF so spreadsheet apps treat the
+    // payload as a row-oriented block on paste (issue #65).
+    expect(serializeRangeToText(data, range, cols, rowIds)).toBe('Alice\t30\n');
   });
 
   it('serializes a multi-row single-column range', () => {
@@ -127,8 +129,9 @@ describe('serializeRangeToText', () => {
       focus: { rowId: 'r3', field: 'name' },
     };
     // Explicit `false` isolates the body rows from the Feature 6 default
-    // that prepends a header for multi-row ranges.
-    expect(serializeRangeToText(data, range, cols, rowIds, false)).toBe('Alice\nBob\nCarol');
+    // that prepends a header for multi-row ranges. Every row — including
+    // the last — is terminated with LF so the payload parses as a block.
+    expect(serializeRangeToText(data, range, cols, rowIds, false)).toBe('Alice\nBob\nCarol\n');
   });
 
   it('serializes a full multi-row multi-column range', () => {
@@ -137,7 +140,7 @@ describe('serializeRangeToText', () => {
       focus: { rowId: 'r2', field: 'age' },
     };
     const result = serializeRangeToText(data, range, cols, rowIds, false);
-    expect(result).toBe('Alice\t30\nBob\t25');
+    expect(result).toBe('Alice\t30\nBob\t25\n');
   });
 
   it('includes headers when requested', () => {
@@ -146,7 +149,7 @@ describe('serializeRangeToText', () => {
       focus: { rowId: 'r1', field: 'age' },
     };
     const result = serializeRangeToText(data, range, cols, rowIds, true);
-    expect(result).toBe('Name\tAge\nAlice\t30');
+    expect(result).toBe('Name\tAge\nAlice\t30\n');
   });
 
   it('excludes headers by default', () => {
@@ -164,7 +167,7 @@ describe('serializeRangeToText', () => {
       focus: { rowId: 'r1', field: 'name' },
     };
     const result = serializeRangeToText(data, range, cols, rowIds, false);
-    expect(result).toBe('Alice\t30\nBob\t25');
+    expect(result).toBe('Alice\t30\nBob\t25\n');
   });
 
   it('formats null cell values as empty string', () => {
@@ -176,7 +179,7 @@ describe('serializeRangeToText', () => {
       focus: { rowId: 'r1', field: 'age' },
     };
     const rowIds2 = ['r1'];
-    expect(serializeRangeToText(dataWithNull, range, cols, rowIds2)).toBe('\t30');
+    expect(serializeRangeToText(dataWithNull, range, cols, rowIds2)).toBe('\t30\n');
   });
 
   it('serializes the entire grid via selectAll-style range', () => {
@@ -184,7 +187,11 @@ describe('serializeRangeToText', () => {
       anchor: { rowId: 'r1', field: 'name' },
       focus: { rowId: 'r3', field: 'city' },
     };
-    const lines = serializeRangeToText(data, range, cols, rowIds, false).split('\n');
+    // Trailing LF produces an empty trailing element when split — drop it
+    // before asserting on the body rows.
+    const lines = serializeRangeToText(data, range, cols, rowIds, false)
+      .split('\n')
+      .filter(l => l.length > 0);
     expect(lines).toHaveLength(3);
     expect(lines[0]).toBe('Alice\t30\tLondon');
     expect(lines[1]).toBe('Bob\t25\tParis');

--- a/packages/core/src/clipboard.ts
+++ b/packages/core/src/clipboard.ts
@@ -120,12 +120,20 @@ function escapeHtml(raw: string): string {
 /**
  * Serialises a rectangular cell range into tab-separated plain text.
  *
- * Columns are delimited by tabs and rows by newlines, matching the format
- * expected by spreadsheet applications. Values containing tab, newline,
+ * Columns are delimited by tabs and every multi-cell row — including the
+ * last — is terminated by a trailing LF, matching the format Excel and
+ * Google Sheets emit when copying cells. The trailing newline ensures
+ * spreadsheet applications parse the payload as a row-oriented block
+ * rather than a bare cell value on paste. Values containing tab, newline,
  * carriage-return, or double-quote characters are RFC-4180-quoted so the
  * payload round-trips through Excel without losing row/column structure.
  * Chrome columns (row-number gutter, controls column) are filtered out
  * before serialisation.
+ *
+ * Single-cell selections are the one exception: they represent a scalar
+ * value the user typically pastes into another cell, a search box, or a
+ * cell editor. Appending an LF there would convert the paste into a
+ * two-row operation (value + blank), so we emit the bare value instead.
  *
  * The `includeHeaders` parameter supports three calling conventions:
  *
@@ -171,7 +179,18 @@ export function serializeRangeToText(
     );
   }
 
-  return lines.join('\n');
+  // Terminate every row with LF (including the last) so spreadsheet
+  // applications parse the payload as a row-oriented block. A bare cell
+  // value with no newline is treated as a plain string by Excel/Sheets and
+  // loses the row boundary on paste — see issue #65.
+  //
+  // Single-cell selections (1×1, no header row) keep the historical
+  // bare-value contract so pastes into scalar targets (another cell, a
+  // search box, a cell editor) still work.
+  if (lines.length === 0) return '';
+  const isSingleCell = !useHeaders && rows.length === 1 && cols.length === 1;
+  if (isSingleCell) return lines[0]!;
+  return lines.join('\n') + '\n';
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/react/src/__tests__/clipboard-integration.test.tsx
+++ b/packages/react/src/__tests__/clipboard-integration.test.tsx
@@ -149,7 +149,7 @@ describe('Clipboard integration — copy', () => {
     model.select({ rowId: '1', field: 'name' });
     model.extendTo({ rowId: '2', field: 'age' });
     const range = model.getState().selection.range!;
-    // Pass explicit `false` so the assertion on `lines.length === 2` is
+    // Pass explicit `false` so the body-row count assertion below is
     // unaffected by the Feature 6 header-by-default rule for multi-row
     // ranges.
     const text = serializeRangeToText(
@@ -159,7 +159,9 @@ describe('Clipboard integration — copy', () => {
       model.getRowIds(),
       false,
     );
-    const lines = text.split('\n');
+    // Trailing LF (issue #65) introduces an empty terminal segment when
+    // split — drop it before counting body rows.
+    const lines = text.split('\n').filter(l => l.length > 0);
     expect(lines).toHaveLength(2);
     expect(lines[0]!.split('\t')).toHaveLength(2);
   });
@@ -178,7 +180,7 @@ describe('Clipboard integration — copy', () => {
       model.getRowIds(),
       false,
     );
-    expect(text).toBe('Alice\t30\nBob\t25\nCharlie\t35');
+    expect(text).toBe('Alice\t30\nBob\t25\nCharlie\t35\n');
   });
 
   it('copy includes header row when configured', () => {
@@ -210,7 +212,9 @@ describe('Clipboard integration — copy', () => {
       model.getRowIds(),
       false,
     );
-    const lines = text.split('\n');
+    // Trailing LF (issue #65) introduces an empty terminal segment when
+    // split — drop it before counting body rows.
+    const lines = text.split('\n').filter(l => l.length > 0);
     expect(lines).toHaveLength(1);
     expect(lines[0]).toBe('Alice\t30');
   });


### PR DESCRIPTION
## Summary

- Multi-cell `Ctrl+C` now terminates every TSV row (including the last) with a trailing `\n`, matching the format Excel and Google Sheets emit when copying cells.
- Single-cell selections retain the historical bare-value contract so scalar pastes (cell editors, search boxes) still work.
- Updated unit and React integration tests that pinned the old no-trailing-LF format.

Fixes the failing e2e assertion at `e2e/clipboard-copy.spec.ts:91` (`expect(clip.text).toContain('\n')`) reported against issue #65.

## Test plan

- [x] `pnpm exec vitest run packages/core` (595 tests green)
- [x] `pnpm exec vitest run packages/react/src/__tests__/clipboard-integration.test.tsx` (34 tests green)
- [x] Full `pnpm test` via pre-commit hook (1877 tests green)
- [x] `pnpm typecheck`
- [x] `npx playwright test e2e/clipboard-copy.spec.ts --reporter=line` — both tests pass (including `:61` which was failing on `main`)