### PR TITLE
fix(editor): inline-input padding/font/height parity with display cell (#65)

### DIFF
--- a/packages/mui/src/components/EditableTextField.tsx
+++ b/packages/mui/src/components/EditableTextField.tsx
@@ -39,9 +39,47 @@ export const EditableTextField = React.memo(function EditableTextField({
   htmlInputSlotProps,
   sx,
 }: EditableTextFieldProps) {
+  // Excel-365 padding parity (issue #65): the inline editor's first glyph
+  // must sit on the same X/Y as the display cell. The host `[role=gridcell]`
+  // still carries its `--dg-cell-padding` during edit mode so display and
+  // edit share one box model; here we absolutely-position the TextField to
+  // fill the cell's *border-box* (escaping the cell's padding-box) and
+  // transfer the same `--dg-cell-padding` onto the native input. Because
+  // `input.rect.left === cell.rect.left` and `input.padding-left ===
+  // cell.padding-left`, the first glyph lands on the same pixel whether the
+  // cell is displaying or editing — Excel's "only the caret changes" feel.
+  // Font is inherited so font-family / size / weight / line-height match
+  // the cell pixel-for-pixel.
   const mergedSx = {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    width: '100%',
     height: '100%',
-    '& input': { height: '100%', padding: '0 4px' },
+    margin: 0,
+    padding: 0,
+    // MUI's Input root normally carries its own vertical padding for the
+    // floating-label / underline affordances; with `disableUnderline` and no
+    // label neither applies, so zero it out and let the native input own
+    // the padding box.
+    '& .MuiInputBase-root': {
+      width: '100%',
+      height: '100%',
+      margin: 0,
+      padding: 0,
+      font: 'inherit',
+      lineHeight: 'inherit',
+    },
+    '& input': {
+      width: '100%',
+      height: '100%',
+      boxSizing: 'border-box',
+      padding: 'var(--dg-cell-padding, 0 12px)',
+      margin: 0,
+      border: 0,
+      font: 'inherit',
+      lineHeight: 'inherit',
+    },
     ...sx,
   };
 

--- a/packages/react/src/body/DataGridBody.styles.ts
+++ b/packages/react/src/body/DataGridBody.styles.ts
@@ -111,8 +111,19 @@ export const cell = (opts: {
 
 /** Style for the fallback `<input>` editor used when no custom cell renderer
  *  is configured. Strips the native input chrome so it visually matches the
- *  surrounding cell. */
+ *  surrounding cell.
+ *
+ *  Excel-365 padding parity (issue #65): the input is positioned absolutely
+ *  to fill the cell's *border-box* (not the padding-box) so that
+ *  `input.getBoundingClientRect().left === cell.getBoundingClientRect().left`.
+ *  It then re-applies the same `--dg-cell-padding` token the cell uses, so
+ *  the first glyph lands on the exact pixel it occupied in display mode —
+ *  the only visible change when edit mode begins is a blinking caret. Font
+ *  is inherited so family / size / weight / line-height match the cell. */
 export const cellInput: CSSProperties = {
+  position: 'absolute',
+  top: 0,
+  left: 0,
   width: '100%',
   height: '100%',
   margin: 0,
@@ -120,6 +131,7 @@ export const cellInput: CSSProperties = {
   outline: 'none',
   padding: 'var(--dg-cell-padding, 0 12px)',
   font: 'inherit',
+  lineHeight: 'inherit',
   background: 'transparent',
   boxSizing: 'border-box',
 };

--- a/packages/react/src/cells/TextCell/TextCell.styles.ts
+++ b/packages/react/src/cells/TextCell/TextCell.styles.ts
@@ -11,19 +11,43 @@ export const placeholder: CSSProperties = {
   color: '#9ca3af',
 };
 
+// Excel-365 padding parity (issue #65): the inline editor is positioned
+// absolutely to fill the cell's *border-box* (escaping the cell's
+// padding-box) and then re-applies the same `--dg-cell-padding` token the
+// cell uses, so `input.rect.left === cell.rect.left` and
+// `input.padding-left === cell.padding-left` — the first glyph lands on
+// the same pixel it occupied in display mode and the only visible change
+// on enter-edit is a blinking caret. Font is inherited so family / size /
+// weight / line-height match the cell pixel-for-pixel.
 export const editTextarea: CSSProperties = {
+  position: 'absolute',
+  top: 0,
+  left: 0,
   width: '100%',
   height: '100%',
+  margin: 0,
   border: 0,
   outline: 'none',
   resize: 'vertical',
   boxSizing: 'border-box',
+  padding: 'var(--dg-cell-padding, 0 12px)',
+  font: 'inherit',
+  lineHeight: 'inherit',
+  background: 'transparent',
 };
 
 export const editInput: CSSProperties = {
+  position: 'absolute',
+  top: 0,
+  left: 0,
   width: '100%',
   height: '100%',
+  margin: 0,
   border: 0,
   outline: 'none',
   boxSizing: 'border-box',
+  padding: 'var(--dg-cell-padding, 0 12px)',
+  font: 'inherit',
+  lineHeight: 'inherit',
+  background: 'transparent',
 };


### PR DESCRIPTION
## Summary

- Absolutely-position the inline `<input>` / `<textarea>` / MUI `TextField` to fill the host cell's *border-box* and re-apply the same `--dg-cell-padding` token the cell uses, so `input.rect.left === cell.rect.left` and `input.padding-left === cell.padding-left`. The first glyph stays pinned on its exact pixel across the display -> edit transition (Excel-365 "only the caret changes" feel).
- Inherit `font` and `line-height` on the editor so font-family / size / weight / line-height are identical to the cell — no 14px system-ui -> 16px Roboto jump on enter-edit.
- Fix applies to three renderers: the non-MUI fallback `cellInput` / `editInput` / `editTextarea` style factories, and the MUI `EditableTextField` wrapper (covers `MuiTextCell` on the `Examples/Editing` stories).

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm -F @istracked/datagrid-core build` — clean
- [x] `pnpm exec vitest run packages/react` — 1186/1186 pass (including the 7 existing `editor-padding.test.tsx` contract assertions, snapshot intact)
- [x] `pnpm exec vitest run packages/mui` — 27/27 pass
- [x] `npx playwright test e2e/editor-padding.spec.ts` — all 3 green (glyph-X delta, padding/font/line-height parity, height parity)
- [x] `npx playwright test e2e/edit-commit-nav.spec.ts` — no regression from this change (remaining failures are pre-existing truncation-display issues unrelated to editor padding)