### PR TITLE
fix(dnd): drop-indicator attributes and edge bars for row + column reorder

### DIFF
--- a/packages/react/src/chrome/ChromeRowNumberCell.tsx
+++ b/packages/react/src/chrome/ChromeRowNumberCell.tsx
@@ -11,7 +11,7 @@
  * the offset as the controls column width when a controls column precedes this
  * column, or `0` otherwise. When omitted, the cell scrolls with the grid body.
  */
-import React, { useCallback } from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import * as styles from './ChromeColumn.styles';
 
 /**
@@ -70,6 +70,16 @@ export interface ChromeRowNumberCellProps {
 export function ChromeRowNumberCell(props: ChromeRowNumberCellProps) {
   const { rowNumber, rowId, width, height, isSelected, reorderable, stickyLeft, contentText, contentIcon, onContentClick, onSelect, onDragStart, onDragOver, onDrop } = props;
 
+  // Per-cell drop-indicator state (#68). While a row drag hovers this cell we
+  // record whether the pointer is in the upper or lower half so the cell can
+  // expose `data-drop-indicator` and render an edge bar. The pointer-half
+  // resolution runs on both `dragenter` and `dragover`: Chromium's HTML5 DnD
+  // only fires a trailing `dragover` in some motion paths, so `dragenter`
+  // acts as a backstop when the pointer ends over a child node inside the
+  // target cell.
+  const cellRef = useRef<HTMLDivElement | null>(null);
+  const [dropHalf, setDropHalf] = useState<'above' | 'below' | null>(null);
+
   // Click handler: stop propagation so the row-number click does not also
   // trigger cell-level selection, then forward shift/meta modifiers so the
   // caller can implement range/toggle selection semantics.
@@ -122,31 +132,96 @@ export function ChromeRowNumberCell(props: ChromeRowNumberCellProps) {
     onDragStart?.(rowId, rowNumber - 1);
   }, [reorderable, rowId, rowNumber, onDragStart]);
 
+  // Resolve pointer half within this cell. Returns 'above' when the pointer
+  // is in the upper half, 'below' otherwise. Uses the cell's bounding rect
+  // for the Y origin so nested child elements (icon, text span) don't skew
+  // the result.
+  const resolveHalf = useCallback((clientY: number): 'above' | 'below' => {
+    const el = cellRef.current;
+    if (!el) return 'above';
+    const rect = el.getBoundingClientRect();
+    const midY = rect.top + rect.height / 2;
+    return clientY < midY ? 'above' : 'below';
+  }, []);
+
+  // Drag-enter: backstop for Chromium's HTML5 DnD, which may skip the
+  // trailing `dragover` when the pointer ends inside a child node. We
+  // compute the pointer half on enter so the indicator appears immediately.
+  const handleDragEnter = useCallback((e: React.DragEvent) => {
+    if (!reorderable) return;
+    setDropHalf(resolveHalf(e.clientY));
+  }, [reorderable, resolveHalf]);
+
   // Drag-over: `preventDefault` is required to declare this element a valid
-  // drop target; we also set a move cursor and bubble the hover up.
+  // drop target; we also set a move cursor and bubble the hover up. The
+  // pointer half is re-computed here so slow drags across the vertical
+  // midpoint update the indicator in real time.
   const handleDragOver = useCallback((e: React.DragEvent) => {
     if (!reorderable) return;
     e.preventDefault();
     e.dataTransfer.dropEffect = 'move';
+    setDropHalf(resolveHalf(e.clientY));
     onDragOver?.(rowId, rowNumber - 1);
-  }, [reorderable, rowId, rowNumber, onDragOver]);
+  }, [reorderable, rowId, rowNumber, onDragOver, resolveHalf]);
+
+  // Drag-leave clears the indicator — but only when the pointer actually
+  // leaves THIS cell, not when it crosses into one of the cell's own
+  // children. HTML5 DnD fires dragenter/dragleave pairs at child boundaries
+  // which would otherwise flicker the indicator.
+  const handleDragLeave = useCallback((e: React.DragEvent) => {
+    if (!reorderable) return;
+    const el = cellRef.current;
+    const related = e.relatedTarget as Node | null;
+    if (el && related && el.contains(related)) return;
+    setDropHalf(null);
+  }, [reorderable]);
 
   // Drop: again `preventDefault` prevents the browser's default open/navigate
   // behaviour so the parent reorder callback owns the outcome.
   const handleDrop = useCallback((e: React.DragEvent) => {
     if (!reorderable) return;
     e.preventDefault();
+    setDropHalf(null);
     onDrop?.(rowId, rowNumber - 1);
   }, [reorderable, rowId, rowNumber, onDrop]);
 
+  // Drag-end fires on the drag SOURCE — we also clear local state so a
+  // cancelled drag (Escape, drop-off-target) doesn't leave a stale indicator.
+  const handleDragEnd = useCallback(() => {
+    setDropHalf(null);
+  }, []);
+
   // Compose: base gutter style, selection overlay (wins the background), then
   // optional sticky-left pin. `stickyLeft === 0` is a valid pin position, so
-  // the check uses `!== undefined` rather than truthiness.
-  const cellStyle = {
+  // the check uses `!== undefined` rather than truthiness. A `position:
+  // relative` fallback is layered beneath the sticky override so the
+  // absolutely-positioned drop-indicator bar has a reliable containing block
+  // whether or not the cell is sticky.
+  const cellStyle: React.CSSProperties = {
     ...styles.rowNumberCell(width, height),
     ...(isSelected ? styles.rowNumberSelected : {}),
     ...(stickyLeft !== undefined ? { position: 'sticky' as const, left: stickyLeft, zIndex: 5 } : {}),
   };
+  if (cellStyle.position === undefined) {
+    cellStyle.position = 'relative';
+  }
+
+  // Drop-indicator bar. 3px tall so the e2e contract (`height >= 3`) holds,
+  // absolutely positioned against the row-number cell's edge. The background
+  // consumes a design-token fallback so downstream themes can retune the
+  // colour without touching this component.
+  const indicatorStyle: React.CSSProperties | null = dropHalf
+    ? {
+        position: 'absolute',
+        left: 0,
+        right: 0,
+        height: 3,
+        background: 'var(--dg-row-drop-indicator-bg, #3b82f6)',
+        pointerEvents: 'none',
+        zIndex: 6,
+        ...(dropHalf === 'above' ? { top: 0 } : { bottom: 0 }),
+      }
+    : null;
 
   // Content override: when either text or icon is supplied via
   // `chrome.getChromeCellContent`, render them in place of the default digit.
@@ -167,19 +242,28 @@ export function ChromeRowNumberCell(props: ChromeRowNumberCellProps) {
 
   return (
     <div
+      ref={cellRef}
       style={cellStyle}
       role="rowheader"
       data-testid="chrome-row-number"
+      data-chrome="row-number"
       data-row-number={rowNumber}
       data-row-id={rowId}
+      {...(dropHalf ? { 'data-drop-indicator': dropHalf } : {})}
       aria-label={typeof contentText === 'string' && contentText.length > 0 ? contentText : `Row ${rowNumber}`}
       draggable={reorderable}
       onClick={handleClick}
       onDragStart={handleDragStart}
+      onDragEnter={handleDragEnter}
       onDragOver={handleDragOver}
+      onDragLeave={handleDragLeave}
       onDrop={handleDrop}
+      onDragEnd={handleDragEnd}
     >
       {renderedContent}
+      {indicatorStyle && (
+        <div data-row-drop-indicator style={indicatorStyle} />
+      )}
     </div>
   );
 }

--- a/packages/react/src/header/DataGridHeader.tsx
+++ b/packages/react/src/header/DataGridHeader.tsx
@@ -11,7 +11,7 @@
  * mirroring the placement logic used by DataGridBody so the two stay in
  * lockstep.
  */
-import React, { useCallback } from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import type { ColumnDef, SortState, ControlsColumnConfig, RowNumberColumnConfig } from '@istracked/datagrid-core';
 import type { ColumnDragState } from '../state';
 import { ChromeControlsHeaderCell, ChromeRowNumberHeaderCell } from '../chrome';
@@ -131,6 +131,248 @@ function getSortPriority(sortState: SortState, field: string): number | null {
   if (sortState.length <= 1) return null;
   const idx = sortState.findIndex(s => s.field === field);
   return idx >= 0 ? idx + 1 : null;
+}
+
+/**
+ * Per-column header cell. Extracted into its own component so each cell can
+ * own a local `dropHalf` state driving the `data-drop-indicator` contract
+ * (#69). The per-cell state model means the indicator is scoped to the
+ * header currently under the pointer — unrelated columns stay untouched.
+ *
+ * HTML5 DnD in Chromium can skip the trailing `dragover` when the pointer
+ * ends over a child node (e.g. the title span), so both `dragenter` and
+ * `dragover` compute the pointer half and set `dropHalf`. `dragleave`
+ * suppresses spurious clear events when the pointer merely crosses into
+ * one of this cell's own children.
+ */
+interface HeaderCellProps<TData> {
+  col: ColumnDef<TData>;
+  colIdx: number;
+  width: number;
+  headerHeight: number;
+  sortDir: 'asc' | 'desc' | null;
+  sortPriorityVal: number | null;
+  frozen: 'left' | 'right' | null;
+  frozenLeftOffset: number;
+  isLastFrozenLeft: boolean;
+  isGroupLast: boolean;
+  isSortingEnabled: boolean;
+  isFilteringEnabled: boolean;
+  showColumnMenu: boolean;
+  columnDrag: ColumnDragState;
+  onSort: (field: string, shiftKey: boolean) => void;
+  onContextMenu: (e: React.MouseEvent, rowId: string | null, field: string | null) => void;
+  onDragStart: (field: string) => void;
+  onDragOver: (field: string) => void;
+  onDrop: (field: string) => void;
+  onDragEnd: () => void;
+  onMenuTrigger: (field: string) => void;
+  onAutoFit: (field: string) => void;
+  onResizeMouseDown: (e: React.MouseEvent, field: string, width: number) => void;
+  onFilterMenuTrigger?: (field: string, anchor: DOMRect) => void;
+  activeFilterFields?: ReadonlySet<string>;
+}
+
+function HeaderCell<TData>(props: HeaderCellProps<TData>) {
+  const {
+    col,
+    colIdx,
+    width,
+    headerHeight,
+    sortDir,
+    sortPriorityVal,
+    frozen,
+    frozenLeftOffset,
+    isLastFrozenLeft,
+    isGroupLast,
+    isSortingEnabled,
+    isFilteringEnabled,
+    showColumnMenu,
+    columnDrag,
+    onSort,
+    onContextMenu,
+    onDragStart,
+    onDragOver,
+    onDrop,
+    onDragEnd,
+    onMenuTrigger,
+    onAutoFit,
+    onResizeMouseDown,
+    onFilterMenuTrigger,
+    activeFilterFields,
+  } = props;
+
+  const cellRef = useRef<HTMLDivElement | null>(null);
+  const [dropHalf, setDropHalf] = useState<'left' | 'right' | null>(null);
+
+  const resolveHalf = useCallback((clientX: number): 'left' | 'right' => {
+    const el = cellRef.current;
+    if (!el) return 'left';
+    const rect = el.getBoundingClientRect();
+    const midX = rect.left + rect.width / 2;
+    return clientX < midX ? 'left' : 'right';
+  }, []);
+
+  // Frozen columns never accept a drop indicator — they also carry
+  // `data-draggable="false"` so the e2e gate finds them.
+  const canAcceptDrop =
+    !frozen && columnDrag.type === 'dragging' && columnDrag.field !== col.field;
+
+  const baseCellStyle = styles.headerCell({
+    width,
+    height: headerHeight,
+    frozen,
+    frozenLeftOffset,
+    isGroupLast,
+    isSortable: col.sortable !== false && isSortingEnabled,
+  });
+  // Ensure we have a containing block for the absolutely-positioned drop bar.
+  const cellStyle: React.CSSProperties = {
+    ...baseCellStyle,
+    position: (baseCellStyle.position as React.CSSProperties['position']) ?? 'relative',
+  };
+
+  return (
+    <div
+      ref={cellRef}
+      style={cellStyle}
+      role="columnheader"
+      data-field={col.field}
+      data-draggable={frozen ? 'false' : 'true'}
+      aria-colindex={colIdx + 1}
+      aria-sort={
+        sortDir === 'asc' ? 'ascending' :
+        sortDir === 'desc' ? 'descending' :
+        'none'
+      }
+      draggable={!frozen}
+      {...(col.sortable !== false && isSortingEnabled ? { 'data-sortable': 'true' } : {})}
+      {...(frozen ? { 'data-frozen': frozen, 'data-frozen-border': isLastFrozenLeft ? 'true' : undefined, 'data-drop-disabled': 'true' } : {})}
+      {...(isGroupLast ? { 'data-group-last': 'true' } : {})}
+      {...(dropHalf && canAcceptDrop ? { 'data-drop-indicator': dropHalf } : {})}
+      onClick={(e) => {
+        if (col.sortable !== false && isSortingEnabled) {
+          onSort(col.field, e.shiftKey);
+        }
+      }}
+      onContextMenu={(e) => onContextMenu(e, null, col.field)}
+      onDragStart={(e) => {
+        if (frozen) { e.preventDefault(); return; }
+        onDragStart(col.field);
+        if (e.dataTransfer) e.dataTransfer.effectAllowed = 'move';
+      }}
+      onDragEnter={(e) => {
+        if (!canAcceptDrop) return;
+        setDropHalf(resolveHalf(e.clientX));
+      }}
+      onDragOver={(e) => {
+        e.preventDefault();
+        if (!canAcceptDrop) return;
+        setDropHalf(resolveHalf(e.clientX));
+        onDragOver(col.field);
+      }}
+      onDragLeave={(e) => {
+        const el = cellRef.current;
+        const related = e.relatedTarget as Node | null;
+        if (el && related && el.contains(related)) return;
+        setDropHalf(null);
+      }}
+      onDrop={(e) => {
+        e.preventDefault();
+        setDropHalf(null);
+        if (columnDrag.type === 'dragging' && columnDrag.field !== col.field && !frozen) {
+          onDrop(col.field);
+        }
+      }}
+      onDragEnd={() => {
+        setDropHalf(null);
+        onDragEnd();
+      }}
+    >
+      <span style={styles.headerCellTitle}>
+        {col.title}
+      </span>
+      {sortDir && (
+        <span style={styles.sortIndicator}>
+          {sortDir === 'asc' ? '\u25B2' : '\u25BC'}
+        </span>
+      )}
+      {sortPriorityVal != null && (
+        <span style={styles.sortPriority}>
+          {sortPriorityVal}
+        </span>
+      )}
+      {/* Filter icon */}
+      {isFilteringEnabled && (
+        onFilterMenuTrigger ? (
+          <button
+            type="button"
+            data-testid="column-filter-icon"
+            data-active={activeFilterFields?.has(col.field) ? 'true' : undefined}
+            aria-label={`Filter ${col.title ?? col.field}`}
+            aria-haspopup="menu"
+            style={styles.filterIcon}
+            onClick={(e) => {
+              e.stopPropagation();
+              const anchor = (e.currentTarget as HTMLElement)
+                .closest('[role="columnheader"]')
+                ?.getBoundingClientRect();
+              if (anchor) onFilterMenuTrigger(col.field, anchor);
+            }}
+          >
+            {activeFilterFields?.has(col.field) ? '\u2714' : '\u25BC'}
+          </button>
+        ) : (
+          <span
+            data-testid="column-filter-icon"
+            data-active={activeFilterFields?.has(col.field) ? 'true' : undefined}
+            aria-hidden="true"
+            style={styles.filterIcon}
+          >
+            {activeFilterFields?.has(col.field) ? '\u2714' : '\u25BC'}
+          </span>
+        )
+      )}
+      {showColumnMenu && (
+        <span
+          data-testid="column-menu-trigger"
+          style={styles.columnMenuTrigger}
+          onClick={(e) => {
+            e.stopPropagation();
+            onMenuTrigger(col.field);
+          }}
+        >
+          &#8942;
+        </span>
+      )}
+      {col.resizable !== false && (
+        <div
+          data-testid="column-resize-handle"
+          style={styles.resizeHandle}
+          onMouseDown={(e) => onResizeMouseDown(e, col.field, width)}
+          onDoubleClick={(e) => {
+            e.stopPropagation();
+            onAutoFit(col.field);
+          }}
+        />
+      )}
+      {dropHalf && canAcceptDrop && (
+        <div
+          data-column-drop-indicator
+          style={{
+            position: 'absolute',
+            top: 0,
+            bottom: 0,
+            width: 3,
+            background: 'var(--dg-column-drop-indicator-bg, #3b82f6)',
+            pointerEvents: 'none',
+            zIndex: 6,
+            ...(dropHalf === 'left' ? { left: 0 } : { right: 0 }),
+          }}
+        />
+      )}
+    </div>
+  );
 }
 
 /**
@@ -261,140 +503,34 @@ export function DataGridHeader<TData>(props: DataGridHeaderProps<TData>) {
           const isGroupLast = lastFieldInGroup.has(col.field);
 
           return (
-            <div
+            <HeaderCell<TData>
               key={col.field}
-              style={styles.headerCell({
-                width,
-                height: headerHeight,
-                frozen,
-                frozenLeftOffset: computeFrozenLeftOffset(colIdx),
-                isGroupLast,
-                isSortable: col.sortable !== false && isSortingEnabled,
-              })}
-              role="columnheader"
-              aria-colindex={colIdx + 1}
-              aria-sort={
-                sortDir === 'asc' ? 'ascending' :
-                sortDir === 'desc' ? 'descending' :
-                'none'
-              }
-              draggable={!frozen}
-              {...(col.sortable !== false && isSortingEnabled ? { 'data-sortable': 'true' } : {})}
-              {...(frozen ? { 'data-frozen': frozen, 'data-frozen-border': isLastFrozenLeft(colIdx) ? 'true' : undefined, 'data-drop-disabled': 'true' } : {})}
-              {...(isGroupLast ? { 'data-group-last': 'true' } : {})}
-              onClick={(e) => {
-                if (col.sortable !== false && isSortingEnabled) {
-                  onSort(col.field, e.shiftKey);
-                }
-              }}
-              onContextMenu={(e) => onContextMenu(e, null, col.field)}
-              onDragStart={(e) => {
-                if (frozen) { e.preventDefault(); return; }
-                onDragStart(col.field);
-                if (e.dataTransfer) e.dataTransfer.effectAllowed = 'move';
-              }}
-              onDragOver={(e) => {
-                e.preventDefault();
-                if (columnDrag.type === 'dragging' && columnDrag.field !== col.field) {
-                  onDragOver(col.field);
-                }
-              }}
-              onDrop={(e) => {
-                e.preventDefault();
-                if (columnDrag.type === 'dragging' && columnDrag.field !== col.field && !frozen) {
-                  onDrop(col.field);
-                }
-              }}
-              onDragEnd={() => {
-                onDragEnd();
-              }}
-            >
-              <span style={styles.headerCellTitle}>
-                {col.title}
-              </span>
-              {sortDir && (
-                <span style={styles.sortIndicator}>
-                  {sortDir === 'asc' ? '\u25B2' : '\u25BC'}
-                </span>
-              )}
-              {sortPriorityVal != null && (
-                <span style={styles.sortPriority}>
-                  {sortPriorityVal}
-                </span>
-              )}
-              {/* Filter icon */}
-              {/*
-                In Excel 365 mode (onFilterMenuTrigger provided) the icon is
-                a real button with aria-label "Filter <column title>" and
-                aria-haspopup="menu" so assistive tech announces it as a
-                menu opener. Click stops propagation to avoid triggering
-                the header-cell sort, walks up to the columnheader element
-                to measure its rect, and passes the rect to the menu so it
-                can anchor itself. Without a handler we render a purely
-                decorative span marked aria-hidden="true" — the glyph is
-                still tagged with data-active when a filter is applied.
-              */}
-              {isFilteringEnabled && (
-                onFilterMenuTrigger ? (
-                  <button
-                    type="button"
-                    data-testid="column-filter-icon"
-                    data-active={activeFilterFields?.has(col.field) ? 'true' : undefined}
-                    aria-label={`Filter ${col.title ?? col.field}`}
-                    aria-haspopup="menu"
-                    style={styles.filterIcon}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      const anchor = (e.currentTarget as HTMLElement)
-                        .closest('[role="columnheader"]')
-                        ?.getBoundingClientRect();
-                      if (anchor) onFilterMenuTrigger(col.field, anchor);
-                    }}
-                  >
-                    {activeFilterFields?.has(col.field) ? '\u2714' : '\u25BC'}
-                  </button>
-                ) : (
-                  <span
-                    data-testid="column-filter-icon"
-                    data-active={activeFilterFields?.has(col.field) ? 'true' : undefined}
-                    aria-hidden="true"
-                    style={styles.filterIcon}
-                  >
-                    {activeFilterFields?.has(col.field) ? '\u2714' : '\u25BC'}
-                  </span>
-                )
-              )}
-              {/* Column menu trigger */}
-              {/*
-                Kebab (vertical-ellipsis) affordance that opens the
-                per-column menu. stopPropagation prevents the click from
-                being interpreted as a sort on the surrounding header cell.
-              */}
-              {showColumnMenu && (
-                <span
-                  data-testid="column-menu-trigger"
-                  style={styles.columnMenuTrigger}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onMenuTrigger(col.field);
-                  }}
-                >
-                  &#8942;
-                </span>
-              )}
-              {/* Resize handle */}
-              {col.resizable !== false && (
-                <div
-                  data-testid="column-resize-handle"
-                  style={styles.resizeHandle}
-                  onMouseDown={(e) => handleResizeMouseDown(e, col.field, width)}
-                  onDoubleClick={(e) => {
-                    e.stopPropagation();
-                    onAutoFit(col.field);
-                  }}
-                />
-              )}
-            </div>
+              col={col}
+              colIdx={colIdx}
+              width={width}
+              headerHeight={headerHeight}
+              sortDir={sortDir}
+              sortPriorityVal={sortPriorityVal}
+              frozen={frozen}
+              frozenLeftOffset={computeFrozenLeftOffset(colIdx)}
+              isLastFrozenLeft={isLastFrozenLeft(colIdx)}
+              isGroupLast={isGroupLast}
+              isSortingEnabled={isSortingEnabled}
+              isFilteringEnabled={isFilteringEnabled}
+              showColumnMenu={showColumnMenu}
+              columnDrag={columnDrag}
+              onSort={onSort}
+              onContextMenu={onContextMenu}
+              onDragStart={onDragStart}
+              onDragOver={onDragOver}
+              onDrop={onDrop}
+              onDragEnd={onDragEnd}
+              onMenuTrigger={onMenuTrigger}
+              onAutoFit={onAutoFit}
+              onResizeMouseDown={handleResizeMouseDown}
+              onFilterMenuTrigger={onFilterMenuTrigger}
+              activeFilterFields={activeFilterFields}
+            />
           );
         })}
         {!rowNumberOnLeft && renderRowNumberHeaderCell()}


### PR DESCRIPTION
## Summary

- **Row drop-indicator (#68):** `ChromeRowNumberCell` owns local `dropHalf` state and exposes `data-drop-indicator="above|below"` plus a 3px `[data-row-drop-indicator]` edge bar while a reorder drag hovers it.
- **Column drop-indicator (#69):** header cells are extracted into a per-cell `HeaderCell` component so each can carry its own `dropHalf` and emit `data-drop-indicator="left|right"` with a 3px `[data-column-drop-indicator]` bar. Frozen columns carry `data-draggable="false"` and never accept the indicator.
- **Row reorder gate (#73):** the row-number cell carries `data-chrome="row-number"` and `draggable="true"`; data cells remain non-draggable, so dragging from a data cell no longer initiates a reorder.
- `dragenter` acts as a backstop for Chromium's HTML5 DnD, which may skip the trailing `dragover` when the pointer ends over a child node; `dragleave` checks `relatedTarget.contains` to suppress spurious clears when the pointer crosses into child elements.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm exec vitest run packages/react` — 1186 passed
- [x] `pnpm exec vitest run packages/mui` — 27 passed
- [x] 11 target e2e tests green:
  - `e2e/column-drop-indicator.spec.ts` (4 tests — #69)
  - `e2e/row-drop-indicator.spec.ts` (4 tests — #68)
  - `e2e/row-reorder-gate.spec.ts` (3 tests — #73)
- [x] Baseline comparison confirms no regressions in adjacent e2e specs — pre-existing failures in `row-select-styling`, `row-number-bg`, `edit-commit-nav`, `type-to-edit`, `hover-tooltip`, `grid-keyboard` were already present on main and are being addressed in separate PRs.