### PR TITLE
fix(chrome): row-number gutter bg, cursor, and row-select tints (#70 #74 #75)

### DIFF
--- a/packages/react/src/DataGrid.tsx
+++ b/packages/react/src/DataGrid.tsx
@@ -29,6 +29,11 @@
  * @module DataGrid
  */
 import React, { useRef, useCallback, useState, useEffect, useId, useMemo } from 'react';
+// Side-effect CSS import: the theme layer defines `--dg-*` tokens (scoped to
+// `.istracked-datagrid[data-theme="..."]`) plus the `data-row-selected`
+// header-darken rule. Without this import the CSS lives on disk but never
+// reaches the DOM, and host pages see inline-style fallbacks only.
+import './styles/datagrid-theme.css';
 import {
   GridConfig,
   ColumnDef,
@@ -556,6 +561,27 @@ export function DataGrid<TData extends Record<string, unknown>>(props: DataGridP
     [state.selection, orderedVisibleColumns, rowIds],
   );
 
+  // Grid-level "any row is fully selected?" signal. When true, the root
+  // element is tagged `data-row-selected="true"` so CSS can darken column
+  // headers (#75) and surfaces outside the body can react without threading
+  // selection state through every child. A range counts as row-level when
+  // it is tagged `kind: 'row'` OR when it spans every visible column
+  // (fallback for `selectionMode: 'row'` cell clicks that widen the range).
+  const hasRowSelection = useMemo(() => {
+    if (orderedVisibleColumns.length === 0) return false;
+    for (const r of state.selection.ranges) {
+      if (r.kind === 'row') return true;
+      // Fallback: a range that covers from the first visible column's field
+      // to the last visible column's field, regardless of row span.
+      const firstField = orderedVisibleColumns[0]?.field;
+      const lastField = orderedVisibleColumns[orderedVisibleColumns.length - 1]?.field;
+      if (firstField === undefined || lastField === undefined) continue;
+      const fields = new Set([r.anchor.field, r.focus.field]);
+      if (fields.has(firstField) && fields.has(lastField)) return true;
+    }
+    return false;
+  }, [state.selection.ranges, orderedVisibleColumns]);
+
   const isEditingCell = useCallback((rowId: string, field: string): boolean => {
     const cell = state.editing.cell;
     return cell !== null && cell.rowId === rowId && cell.field === field;
@@ -888,6 +914,12 @@ export function DataGrid<TData extends Record<string, unknown>>(props: DataGridP
     } else {
       model.selectRowByKey(rowId);
     }
+    // Refocus the grid container so the keyboard handler's scope guard
+    // (`container.contains(e.target)`) passes on the next keystroke — without
+    // this, pressing Escape after a row-number click is a no-op because the
+    // click target (the chrome cell) is inside the container but focus never
+    // moves there; keystrokes land on `<body>` and are discarded.
+    containerRef.current?.focus({ preventScroll: true });
   }, [model]);
 
   const [rowDragState, setRowDragState] = useState<{ sourceRowId: string; sourceIndex: number } | null>(null);
@@ -1267,6 +1299,7 @@ export function DataGrid<TData extends Record<string, unknown>>(props: DataGridP
         aria-labelledby={ariaLabelledBy}
         data-density={density}
         {...(themeId ? { 'data-theme': themeId } : {})}
+        {...(hasRowSelection ? { 'data-row-selected': 'true' } : {})}
         {...(isReadOnly ? { 'data-readonly': 'true' } : {})}
         {...(showGhostRow ? { 'data-ghost-row': 'true' } : {})}
         {...(fileDropEnabled ? { 'data-file-drop': 'true' } : {})}

--- a/packages/react/src/__tests__/chrome-composition-scenarios.test.tsx
+++ b/packages/react/src/__tests__/chrome-composition-scenarios.test.tsx
@@ -99,9 +99,14 @@ describe('chrome composition — selected + ranged cell', () => {
     expect(anchor.style.outline).toContain('2px solid');
     expect(anchor.style.outline).toContain('--dg-selection-border');
 
-    // Cells outside the range have neither tint nor selection outline.
+    // Cells outside the range have no range tint and no selection outline.
+    // They still paint the row-resting token (`--dg-row-bg` / `--dg-row-bg-alt`)
+    // so `getComputedStyle` probes resolve to a concrete colour (the #70
+    // row-number vs data luminance check depends on this). Visually identical
+    // to the row container's zebra stripe.
     const outside = getCell('2', 'salary');
-    expect(outside.style.background).toBe('');
+    expect(outside.style.background).not.toContain('--dg-range-bg');
+    expect(outside.style.background).toMatch(/--dg-row-bg/);
     expect(outside.style.outline === '' || outside.style.outline === 'none').toBe(true);
   });
 });
@@ -263,9 +268,13 @@ describe('chrome composition — readonly grid', () => {
     expect(getCell('1', 'dept').style.background).toContain('--dg-range-bg');
     expect(getCell('1', 'name').style.background).toContain('--dg-range-bg');
 
-    // A cell outside the 1x2 range stays transparent — the readOnly flag
-    // must not accidentally paint every cell.
-    expect(getCell('2', 'salary').style.background).toBe('');
+    // A cell outside the 1x2 range carries no range tint — the readOnly
+    // flag must not accidentally paint every cell with the range overlay.
+    // It still paints the row-resting token so computed-style probes resolve
+    // to a concrete colour; visually it matches the row container's zebra.
+    const outside = getCell('2', 'salary').style.background;
+    expect(outside).not.toContain('--dg-range-bg');
+    expect(outside).toMatch(/--dg-row-bg/);
   });
 
   it('chrome resolvers still fire on a readOnly grid', () => {

--- a/packages/react/src/__tests__/range-chrome-composition.test.tsx
+++ b/packages/react/src/__tests__/range-chrome-composition.test.tsx
@@ -86,22 +86,32 @@ describe('range styling routes through the chrome-API plumbing', () => {
     expect(getCell('1', 'b').style.background).toContain('--dg-range-bg');
   });
 
-  it('leaves cells outside the range with no cell-level background override', () => {
+  it('leaves cells outside the range with no range tint (paints the row-resting token as fallback)', () => {
     renderGrid();
     fireEvent.click(getCell('1', 'a'));
     fireEvent.keyDown(getGrid(), { key: 'ArrowRight', shiftKey: true });
 
-    // Out-of-range cell: cell is transparent so the row container's
-    // background (zebra stripe / consumer colour) shows through.
-    expect(getCell('2', 'c').style.background).toBe('');
+    // Out-of-range cell: no range tint is applied. The cell paints the
+    // row-level resting token (`--dg-row-bg` / `--dg-row-bg-alt`) so that
+    // `getComputedStyle(cell).backgroundColor` resolves to a concrete
+    // colour — required by the #70 row-number vs data luminance probe.
+    // The visible colour is identical to the row container's resting
+    // token, so the user still sees a seamless zebra stripe.
+    const bg = getCell('2', 'c').style.background;
+    expect(bg).not.toContain('--dg-range-bg');
+    expect(bg).toMatch(/--dg-row-bg/);
   });
 
   it('single-cell selection does NOT apply the range tint (visual unchanged for default consumers)', () => {
     renderGrid();
     fireEvent.click(getCell('2', 'b'));
-    // No Shift+Arrow — single-cell selection only. Cell should remain
-    // transparent (outline-only visual, matching pre-refactor behaviour).
-    expect(getCell('2', 'b').style.background).toBe('');
+    // No Shift+Arrow — single-cell selection only. No range tint; the cell
+    // falls back to the row-resting token so computed-style probes resolve
+    // to a concrete colour. Visually identical to the row container's
+    // resting zebra stripe.
+    const bg = getCell('2', 'b').style.background;
+    expect(bg).not.toContain('--dg-range-bg');
+    expect(bg).toMatch(/--dg-row-bg/);
   });
 
   it('composes with a consumer getRowBackground: row bg on container, range tint overlays on cells', () => {

--- a/packages/react/src/__tests__/row-number-position.test.tsx
+++ b/packages/react/src/__tests__/row-number-position.test.tsx
@@ -146,9 +146,12 @@ describe('Row number column — position', () => {
 // does not resolve CSS custom properties, so we assert on the inline style
 // string rather than a computed colour value.
 describe('Row number column — background styling', () => {
-  // Body row-number cell must reference the new `--dg-row-number-bg` token
-  // and fall back to `--dg-header-bg` when the token is undefined.
-  it('row-number cell background references --dg-row-number-bg token (Excel-gutter grey default #f3f2f1)', () => {
+  // Body row-number cell must reference the `--dg-row-number-bg` token. The
+  // fallback (#e2e8f0) must be darker than the row-bg-alt so the gutter reads
+  // as a distinct frame per #70 — previously the fallback chained to
+  // `--dg-header-bg`, which matched the alt-row tint and broke the "darker
+  // than adjacent data cell" contract.
+  it('row-number cell background references --dg-row-number-bg token with a darker-than-row fallback (#70)', () => {
     render(
       <DataGrid
         data={data}
@@ -161,17 +164,18 @@ describe('Row number column — background styling', () => {
     const rowNumberCell = screen.getAllByTestId('chrome-row-number')[0]! as HTMLElement;
 
     // jsdom does not resolve CSS custom properties to their fallback value, so
-    // assert on the inline style string that it references our new token and
-    // falls back to the existing header-bg token (Excel-gutter grey is provided
-    // by the `.dg-theme-excel365` stylesheet, not inline).
+    // assert on the inline style string that it references our token and has
+    // an explicit darker-grey fallback (never chain back to the header bg
+    // because that equals the row-alt bg and fails the #70 luminance check).
     const bg = rowNumberCell.style.background || rowNumberCell.style.backgroundColor;
     expect(bg).toContain('--dg-row-number-bg');
-    expect(bg).toContain('--dg-header-bg');
+    expect(bg).not.toContain('--dg-header-bg');
+    expect(bg).toMatch(/#e2e8f0/i);
   });
 
   // Header row-number tile must use the same token chain as the body cell so
   // the gutter reads as a single contiguous band.
-  it('row-number header cell background references --dg-row-number-bg token', () => {
+  it('row-number header cell background references --dg-row-number-bg token with the same darker fallback', () => {
     render(
       <DataGrid
         data={data}
@@ -184,6 +188,7 @@ describe('Row number column — background styling', () => {
     const header = screen.getByTestId('chrome-row-number-header') as HTMLElement;
     const bg = header.style.background || header.style.backgroundColor;
     expect(bg).toContain('--dg-row-number-bg');
-    expect(bg).toContain('--dg-header-bg');
+    expect(bg).not.toContain('--dg-header-bg');
+    expect(bg).toMatch(/#e2e8f0/i);
   });
 });

--- a/packages/react/src/body/DataGridBody.styles.ts
+++ b/packages/react/src/body/DataGridBody.styles.ts
@@ -79,6 +79,14 @@ export const cell = (opts: {
   frozenLeftOffset: number;
   editable: boolean;
   suppressSelectionOutline?: boolean;
+  /**
+   * Row-level resting background (used when no per-cell tint applies). Passed
+   * by the row renderer so every cell paints a concrete colour and
+   * `getComputedStyle().backgroundColor` always resolves — the #70 gutter-
+   * vs-data luminance check reads this on every data cell. Defaults to the
+   * default row token chain when omitted.
+   */
+  rowBackground?: string;
 }): CSSProperties => {
   const frozenBg = opts.frozen ? 'var(--dg-header-bg, #f8fafc)' : undefined;
   const outlineValue = opts.suppressSelectionOutline
@@ -102,10 +110,15 @@ export const cell = (opts: {
     position: opts.frozen ? 'sticky' : 'relative',
     left: opts.frozen === 'left' ? opts.frozenLeftOffset : undefined,
     zIndex: opts.frozen ? 2 : undefined,
-    // Frozen background wins over any per-cell chrome background so pinned
-    // columns stay legible even when a range or consumer hook would otherwise
-    // tint the cell.
-    background: frozenBg ?? opts.background ?? undefined,
+    // Precedence: frozen-column background wins so pinned columns stay
+    // legible against a scrolled range. A per-cell tint from the chrome API
+    // (range highlight, row-selection tint) wins next. The row-level
+    // resting background (passed as `rowBackground`) is used when neither
+    // higher-priority layer applies — this makes computed-style probes
+    // (#70 luminance contract) see a concrete colour. When the caller
+    // omits `rowBackground` the cell stays transparent so consumer row
+    // colours paint through unchanged (see range/chrome-composition tests).
+    background: frozenBg ?? opts.background ?? opts.rowBackground ?? undefined,
   };
 };
 

--- a/packages/react/src/body/DataGridBody.tsx
+++ b/packages/react/src/body/DataGridBody.tsx
@@ -909,7 +909,7 @@ export function DataGridBody<TData extends Record<string, unknown>>(
   // The `key="__row-number__"` is stable across re-renders and distinct from
   // any column `field` value so React can reconcile this child independently
   // of the data-cell list whose keys are `col.field`.
-  const renderRowNumberCell = (row: TData | undefined, rowId: string, rowIdx: number) => {
+  const renderRowNumberCell = (row: TData | undefined, rowId: string, rowIdx: number, isSelectedRow?: boolean) => {
     if (!rowNumberConfig || !onRowNumberClick) return null;
     // Resolve optional per-row chrome-cell content override. Only invoked when
     // the consumer supplied a resolver; the row may be `undefined` during a
@@ -926,6 +926,7 @@ export function DataGridBody<TData extends Record<string, unknown>>(
         rowId={rowId}
         width={rowNumberWidth ?? 50}
         height={rowHeight}
+        isSelected={isSelectedRow}
         reorderable={rowNumberConfig.reorderable !== false}
         stickyLeft={rowNumberStickyLeft}
         contentText={content?.text}
@@ -961,6 +962,16 @@ export function DataGridBody<TData extends Record<string, unknown>>(
     rowId: string,
     rowIdx: number,
     suppressSelectionOutline?: boolean,
+    /**
+     * Consumer-supplied row background (from `chrome.getRowBackground`). When
+     * non-null the row container already paints an explicit colour and cells
+     * must stay transparent so that colour shows through — required by the
+     * range / chrome composition contract (see the tests in
+     * `range-chrome-composition.test.tsx`). When null we fall through to the
+     * row-alternating token inside `styles.cell` so that `getComputedStyle`
+     * resolves to a concrete colour for the #70 luminance contract.
+     */
+    consumerRowBg?: string | null,
   ) => {
     const width = columnWidths[colIdx]?.width ?? 150;
     const value = row[col.field as keyof TData] as CellValue;
@@ -984,8 +995,17 @@ export function DataGridBody<TData extends Record<string, unknown>>(
     // single outline around the row and suppress the per-cell range tint —
     // otherwise every cell in the row repaints the blue tint and the
     // selection reads as "individual cells" rather than "one row block".
-    const cellBackground =
-      !suppressSelectionOutline && isInRange && isInRange(rowId, col.field)
+    //
+    // For row-level selection (#75) we still paint a blue tint on every data
+    // cell — but a darker shade than the row-number gutter so the selected
+    // row reads as "data area is the focus" while the gutter stays the
+    // lighter affordance. The tint is surfaced as a variable so themes can
+    // override; the fallback rgba is opaque enough to register as selected
+    // yet dark enough to satisfy the `luminance(data) < luminance(gutter)`
+    // contract in the spec.
+    const cellBackground = suppressSelectionOutline
+      ? 'var(--dg-row-selected-bg, rgba(59, 130, 246, 0.28))'
+      : isInRange && isInRange(rowId, col.field)
         ? 'var(--dg-range-bg, rgba(59, 130, 246, 0.12))'
         : null;
     const cellType = getCellType(col, rowIdx);
@@ -1067,6 +1087,17 @@ export function DataGridBody<TData extends Record<string, unknown>>(
             frozenLeftOffset: computeFrozenLeftOffset(colIdx),
             editable: col.editable !== false && !isReadOnly,
             suppressSelectionOutline,
+            // Match the row-container's alternating fallback so data cells
+            // paint a concrete colour (required by #70's luminance probe)
+            // without changing the visible stripe pattern. Skip when the
+            // consumer supplied a row colour — the container paints that
+            // explicit colour and cells must stay transparent to let it
+            // show through (see chrome/range composition contract).
+            rowBackground: consumerRowBg
+              ? undefined
+              : rowIdx % 2 === 0
+                ? 'var(--dg-row-bg, #ffffff)'
+                : 'var(--dg-row-bg-alt, #f8fafc)',
           }),
           role: 'gridcell',
           'aria-colindex': colIdx + 1,
@@ -1326,11 +1357,11 @@ export function DataGridBody<TData extends Record<string, unknown>>(
                   height={rowHeight}
                 />
               )}
-              {rowNumberOnLeft && renderRowNumberCell(row, rowId, rowIdx)}
+              {rowNumberOnLeft && renderRowNumberCell(row, rowId, rowIdx, rowIsFullySelected)}
               {orderedVisibleColumns.map((col, colIdx) =>
-                renderCell(col, colIdx, row, rowId, rowIdx, rowIsFullySelected)
+                renderCell(col, colIdx, row, rowId, rowIdx, rowIsFullySelected, rowBg)
               )}
-              {!rowNumberOnLeft && renderRowNumberCell(row, rowId, rowIdx)}
+              {!rowNumberOnLeft && renderRowNumberCell(row, rowId, rowIdx, rowIsFullySelected)}
             </div>
             {isExpanded && renderSubGridExpansionRow && (
               // The expansion row is a spanning row that holds a nested grid.
@@ -1452,11 +1483,11 @@ export function DataGridBody<TData extends Record<string, unknown>>(
                 height={rowHeight}
               />
             )}
-            {rowNumberOnLeft && renderRowNumberCell(row, rowId, rowIdx)}
+            {rowNumberOnLeft && renderRowNumberCell(row, rowId, rowIdx, rowIsFullySelected)}
             {orderedVisibleColumns.map((col, colIdx) =>
-              renderCell(col, colIdx, row, rowId, rowIdx, rowIsFullySelected)
+              renderCell(col, colIdx, row, rowId, rowIdx, rowIsFullySelected, rowBg)
             )}
-            {!rowNumberOnLeft && renderRowNumberCell(row, rowId, rowIdx)}
+            {!rowNumberOnLeft && renderRowNumberCell(row, rowId, rowIdx, rowIsFullySelected)}
           </div>
           {isExpanded && renderSubGridExpansionRow && (
             // See companion branch above for rationale: the nested grid is

--- a/packages/react/src/chrome/ChromeColumn.styles.ts
+++ b/packages/react/src/chrome/ChromeColumn.styles.ts
@@ -119,9 +119,17 @@ export const actionButtonIcon: CSSProperties = {
 
 /**
  * Body-row row-number cell. Centered digit with the Excel-gutter background
- * token `--dg-row-number-bg` that falls back to `--dg-header-bg` when the
- * token is not defined. Does not apply sticky positioning by itself — callers
- * opt into sticky via the `stickyLeft` prop on `ChromeRowNumberCell`.
+ * token `--dg-row-number-bg` that falls back to a grey that is visibly darker
+ * than the default row background (`--dg-row-bg` / `#ffffff`). Without the
+ * darker fallback the gutter would paint the same colour as the adjacent
+ * data cell on un-themed hosts, breaking the "gutter frames the data" visual
+ * contract (#70). Does not apply sticky positioning by itself — callers opt
+ * into sticky via the `stickyLeft` prop on `ChromeRowNumberCell`.
+ *
+ * The `cursor: 'e-resize'` communicates "click to select this row" — a
+ * non-default token the hover cursor spec (#74) requires. `e-resize` is a
+ * right-pointing-arrow shape in most environments, mirroring the Excel
+ * row-header affordance.
  */
 export const rowNumberCell = (width: number, height: number): CSSProperties => ({
   // Locked track width.
@@ -136,12 +144,17 @@ export const rowNumberCell = (width: number, height: number): CSSProperties => (
   borderLeft: '1px solid var(--dg-border-color, #e2e8f0)',
   boxSizing: 'border-box',
   // Clickable for row selection; disable text selection so drag works cleanly.
-  cursor: 'pointer',
+  // `e-resize` is a right-pointing-arrow in most cursor themes and communicates
+  // "select this row" per #74.
+  cursor: 'e-resize',
   userSelect: 'none',
   fontSize: 12,
   color: 'var(--dg-text-color, #64748b)',
-  // Excel-gutter tint via token with fallback to the header background.
-  background: 'var(--dg-row-number-bg, var(--dg-header-bg))',
+  // Excel-gutter tint via token. The fallback must be darker than the default
+  // row background (white / `--dg-row-bg-alt`) so the gutter reads as a
+  // distinct frame. `#e2e8f0` is one step darker than the header bg and
+  // noticeably darker than the row-alt shade.
+  background: 'var(--dg-row-number-bg, #e2e8f0)',
 });
 
 /**
@@ -162,7 +175,7 @@ export const rowNumberHeaderCell = (width: number, height: number): CSSPropertie
   borderLeft: '1px solid var(--dg-border-color, #e2e8f0)',
   boxSizing: 'border-box',
   // Same token chain as the body cell for a seamless gutter.
-  background: 'var(--dg-row-number-bg, var(--dg-header-bg))',
+  background: 'var(--dg-row-number-bg, #e2e8f0)',
   fontSize: 12,
   fontWeight: 600,
   color: 'var(--dg-text-color, #64748b)',
@@ -201,9 +214,17 @@ export const rowNumberDragging: CSSProperties = {
 /**
  * Visual overlay applied to a row-number cell whose row is selected. Merged on
  * top of `rowNumberCell` so it wins the background cascade.
+ *
+ * The fallback is a semi-transparent blue (alpha 0.5) so the gutter reads as
+ * "selected" without fully hiding the underlying grey — and so that data-cell
+ * selection tint in the adjacent row can be painted darker (see #75). The
+ * `--dg-row-number-selected-bg` token lets themes override independently of
+ * `--dg-selection-color`, which is used for non-row-selection highlights.
  */
 export const rowNumberSelected: CSSProperties = {
-  // Selection-tinted fill and bolder digit for the selected row.
-  background: 'var(--dg-selection-color, #dbeafe)',
+  // Selection-tinted fill and bolder digit for the selected row. The default
+  // is an explicit `rgba(...)` so the alpha satisfies the "semi-transparent"
+  // contract in #75 even when no theme token is defined.
+  background: 'var(--dg-row-number-selected-bg, rgba(96, 165, 250, 0.5))',
   fontWeight: 600,
 };

--- a/packages/react/src/chrome/ChromeRowNumberCell.tsx
+++ b/packages/react/src/chrome/ChromeRowNumberCell.tsx
@@ -250,6 +250,7 @@ export function ChromeRowNumberCell(props: ChromeRowNumberCellProps) {
       data-row-number={rowNumber}
       data-row-id={rowId}
       {...(dropHalf ? { 'data-drop-indicator': dropHalf } : {})}
+      data-selected={isSelected ? 'true' : undefined}
       aria-label={typeof contentText === 'string' && contentText.length > 0 ? contentText : `Row ${rowNumber}`}
       draggable={reorderable}
       onClick={handleClick}

--- a/packages/react/src/styles/datagrid-theme.css
+++ b/packages/react/src/styles/datagrid-theme.css
@@ -36,6 +36,10 @@
   --dg-selection-border: #3B82F6;
   --dg-selection-color: #DBEAFE;
   --dg-hover-bg: #F1F5F9;
+  --dg-row-number-bg: #E2E8F0;
+  --dg-row-number-selected-bg: rgba(96, 165, 250, 0.5);
+  --dg-row-selected-bg: rgba(59, 130, 246, 0.28);
+  --dg-header-selected-bg: #CBD5E1;
   --dg-error-color: #EF4444;
   --dg-cell-padding: 0 12px;
   --dg-font-family: system-ui, sans-serif;
@@ -57,7 +61,11 @@
  * root cause of issue #17's "row bg unchanged" bug.
  */
 .istracked-datagrid[data-theme="dark"],
-.istracked-datagrid.dg-theme-dark {
+.istracked-datagrid.dg-theme-dark,
+/* Allow an ancestor (html/body) `data-theme="dark"` to cascade into an
+ * otherwise-unthemed grid instance. This lets a host app toggle dark mode at
+ * the document level without threading `theme="dark"` through every grid. */
+[data-theme="dark"] .istracked-datagrid:not([data-theme="light"]):not(.dg-theme-light) {
   --dg-primary-color: #62A0EA;
   --dg-bg-color: #0F172A;
   --dg-text-color: #F1F5F9;
@@ -76,6 +84,9 @@
   --dg-selection-color: #1E3A8A;
   --dg-hover-bg: #1E293B;
   --dg-row-number-bg: #1E293B;
+  --dg-row-number-selected-bg: rgba(96, 165, 250, 0.45);
+  --dg-row-selected-bg: rgba(59, 130, 246, 0.38);
+  --dg-header-selected-bg: #475569;
   --dg-error-color: #EF4444;
   --dg-cell-padding: 0 12px;
   --dg-font-family: system-ui, sans-serif;
@@ -83,3 +94,16 @@
   --dg-row-height: 36px;
   color-scheme: dark;
 }
+
+/* Row-select visual state (#75).
+ *
+ * When any row is fully selected the grid root carries `data-row-selected="true"`.
+ * In that state every column header is repainted with the "selected"
+ * header background token — in light mode that's one step darker than the
+ * resting header, in dark mode one step brighter. `!important` is needed
+ * because the header cell factory already sets `background` inline via
+ * `CSSProperties`, which would otherwise win over plain stylesheet rules. */
+.istracked-datagrid[data-row-selected="true"] [role="columnheader"] {
+  background: var(--dg-header-selected-bg, #CBD5E1) !important;
+}
+


### PR DESCRIPTION
## Summary

Closes #70, #74, #75 — makes the row-number gutter read as a distinct darker frame, gives it a non-default cursor affordance, and ships the row-selection tint chain (header + gutter + data cells) with dark-theme parity and Escape-to-clear.

### #70 — Row-number gutter darker than adjacent data cell
- `--dg-row-number-bg` fallback switched from chaining to `--dg-header-bg` (which equals the alt-row tint) to a concrete `#e2e8f0`, so the gutter luminance is always below the adjacent data cell.
- `renderCell` now threads a `rowBackground` fallback (`--dg-row-bg` / `--dg-row-bg-alt`) through `styles.cell` so transparent cells resolve to a concrete colour for `getComputedStyle` probes. Consumer `getRowBackground` still shows through unchanged because the fallback is suppressed when a consumer colour is present.

### #74 — Row-number cursor affordance
- Gutter cursor changed from `pointer` to `e-resize`, distinct from the default pointer and signalling row-level selection.
- `ChromeRowNumberCell` now exposes `data-chrome="row-number"` and `data-selected` hooks for stable e2e selection.

### #75 — Row-select visual state
- Grid root sets `data-row-selected="true"` when any `CellRange` spans every visible column (either `kind: "row"` or anchor/focus matching first+last field).
- CSS rule darkens column headers to `--dg-header-selected-bg` while row-selected.
- Selected row-number cell paints `--dg-row-number-selected-bg` (semi-transparent blue); selected data cells paint the slightly darker `--dg-row-selected-bg` via the same `cellBackground` resolver used for range tints.
- Dark-theme cascade rule applies when `[data-theme="dark"]` is on an ancestor (e.g. `<body>`), not only the grid root, so tokens still resolve inside the grid.
- `handleRowNumberClick` focuses the grid container so the scope-guarded Escape handler fires and clears selection.
- `DataGrid.tsx` now imports `datagrid-theme.css` (was missing) so the token definitions and the new selected-header rule reach the DOM.

### Unit tests
Updated `range-chrome-composition` and `chrome-composition-scenarios` specs to the new contract: cells outside a range no longer assert `background === ''`; they now assert `not.toContain('--dg-range-bg')` and `toMatch(/--dg-row-bg/)`. `row-number-position` asserts the new `#e2e8f0` fallback and that the chain does NOT go via `--dg-header-bg`.

## Test plan

- [x] `pnpm exec vitest run packages/react` — 1186 tests pass
- [x] `pnpm exec vitest run packages/mui` — 27 tests pass
- [x] `pnpm -w typecheck` — clean
- [x] `pnpm exec playwright test e2e/row-number-bg.spec.ts e2e/row-number-cursor.spec.ts e2e/row-select-styling.spec.ts` — all 11 target tests pass
- [x] Pre-commit ran full workspace vitest — 1877 tests pass