### PR TITLE
chore: rename istracked → iasbuilt across the repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
     # Drift guard for design tokens. Fails if committed tokens no longer
     # match the manifest `contentHash`, i.e. someone hand-edited a token
     # file or forgot to re-run `pnpm sync:tokens` after bumping the
-    # sibling `istracked/tokens` repo.
+    # sibling `iasbuilt/tokens` repo.
     - name: Tokens drift check
       run: pnpm tokens:check
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -68,7 +68,7 @@ jobs:
       run: pnpm exec playwright install-deps chromium
 
     - name: Build workspace packages
-      # Storybook resolves `@istracked/datagrid-*` via Vite aliases to the
+      # Storybook resolves `@iasbuilt/datagrid-*` via Vite aliases to the
       # package `src` directories (see .storybook/main.ts) so the build is
       # not strictly required for E2E. It is kept here to surface build
       # breakages early rather than only at runtime inside the iframe.

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -23,10 +23,10 @@ const config: StorybookConfig = {
     config.resolve.symlinks = false;
     config.resolve.alias = {
       ...config.resolve.alias,
-      '@istracked/datagrid-core': pkgDir('core'),
-      '@istracked/datagrid-react': pkgDir('react'),
-      '@istracked/datagrid-extensions': pkgDir('extensions'),
-      '@istracked/datagrid-mui': pkgDir('mui'),
+      '@iasbuilt/datagrid-core': pkgDir('core'),
+      '@iasbuilt/datagrid-react': pkgDir('react'),
+      '@iasbuilt/datagrid-extensions': pkgDir('extensions'),
+      '@iasbuilt/datagrid-mui': pkgDir('mui'),
     };
     // Enable HMR for package source files
     config.server = config.server ?? {};
@@ -40,10 +40,10 @@ const config: StorybookConfig = {
       // Exclude workspace packages so Vite processes them as source
       exclude: [
         ...(config.optimizeDeps?.exclude ?? []),
-        '@istracked/datagrid-core',
-        '@istracked/datagrid-react',
-        '@istracked/datagrid-extensions',
-        '@istracked/datagrid-mui',
+        '@iasbuilt/datagrid-core',
+        '@iasbuilt/datagrid-react',
+        '@iasbuilt/datagrid-extensions',
+        '@iasbuilt/datagrid-mui',
       ],
     };
     return config;

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ A high-performance, fully-featured datagrid component library for React 19. Buil
 ### Setup
 
 ```bash
-git clone https://github.com/istracked/xldatagrid.git
+git clone https://github.com/iasbuilt/xldatagrid.git
 cd xldatagrid
 pnpm install
 ```
@@ -297,10 +297,10 @@ To run a per-package command from the repo root:
 
 ```bash
 # Build only the core package
-pnpm --filter @istracked/datagrid-core run build
+pnpm --filter @iasbuilt/datagrid-core run build
 
 # Watch the react package
-pnpm --filter @istracked/datagrid-react run dev
+pnpm --filter @iasbuilt/datagrid-react run dev
 ```
 
 ### Playground
@@ -354,10 +354,10 @@ xldatagrid/
 
 | Package | Description | Version |
 |---------|-------------|---------|
-| `@istracked/datagrid-core` | Framework-agnostic grid engine: types, state models, sorting, filtering, selection, grouping, editing, clipboard, undo/redo, virtualization, plugin system | 0.1.0 |
-| `@istracked/datagrid-react` | React 19 bindings: `<DataGrid>`, hooks, 15 cell renderers, chrome columns, ghost row, master-detail, transposed grid, context menu, keyboard navigation, theming | 0.1.0 |
-| `@istracked/datagrid-extensions` | Drop-in extensions: regex validation, cell comments, column resize, CSV/JSON/Excel export | 0.1.0 |
-| `@istracked/datagrid-mui` | Material UI adapter: MUI-styled cell renderers for all 15 cell types, theme bridge, `<MuiDataGrid>` convenience wrapper | 0.1.0 |
+| `@iasbuilt/datagrid-core` | Framework-agnostic grid engine: types, state models, sorting, filtering, selection, grouping, editing, clipboard, undo/redo, virtualization, plugin system | 0.1.0 |
+| `@iasbuilt/datagrid-react` | React 19 bindings: `<DataGrid>`, hooks, 15 cell renderers, chrome columns, ghost row, master-detail, transposed grid, context menu, keyboard navigation, theming | 0.1.0 |
+| `@iasbuilt/datagrid-extensions` | Drop-in extensions: regex validation, cell comments, column resize, CSV/JSON/Excel export | 0.1.0 |
+| `@iasbuilt/datagrid-mui` | Material UI adapter: MUI-styled cell renderers for all 15 cell types, theme bridge, `<MuiDataGrid>` convenience wrapper | 0.1.0 |
 
 ## Features
 
@@ -468,16 +468,16 @@ The MUI package bridges your MUI theme to DataGrid CSS variables automatically:
 
 ```bash
 # Install
-pnpm add @istracked/datagrid-core @istracked/datagrid-react
+pnpm add @iasbuilt/datagrid-core @iasbuilt/datagrid-react
 
 # Or with MUI integration
-pnpm add @istracked/datagrid-core @istracked/datagrid-react @istracked/datagrid-mui
+pnpm add @iasbuilt/datagrid-core @iasbuilt/datagrid-react @iasbuilt/datagrid-mui
 ```
 
 ```tsx
-import { DataGrid } from '@istracked/datagrid-react';
-import { TextCell } from '@istracked/datagrid-react/cells/TextCell';
-import { NumericCell } from '@istracked/datagrid-react/cells/NumericCell';
+import { DataGrid } from '@iasbuilt/datagrid-react';
+import { TextCell } from '@iasbuilt/datagrid-react/cells/TextCell';
+import { NumericCell } from '@iasbuilt/datagrid-react/cells/NumericCell';
 
 const columns = [
   { id: 'name', field: 'name', title: 'Name', cellType: 'text', editable: true },
@@ -532,7 +532,7 @@ Add controls and row numbers to the grid edges:
 ### Master-Detail
 
 ```tsx
-import { MasterDetail } from '@istracked/datagrid-react';
+import { MasterDetail } from '@iasbuilt/datagrid-react';
 
 <MasterDetail
   data={data}
@@ -565,8 +565,8 @@ import { MasterDetail } from '@istracked/datagrid-react';
 ### Extensions
 
 ```tsx
-import { createRegexValidation } from '@istracked/datagrid-extensions';
-import { createExportExtension } from '@istracked/datagrid-extensions';
+import { createRegexValidation } from '@iasbuilt/datagrid-extensions';
+import { createExportExtension } from '@iasbuilt/datagrid-extensions';
 
 // Regex validation on email fields
 const emailValidator = createRegexValidation({
@@ -581,7 +581,7 @@ const exporter = createExportExtension({ format: 'csv' });
 ### MUI Integration
 
 ```tsx
-import { MuiDataGrid } from '@istracked/datagrid-mui';
+import { MuiDataGrid } from '@iasbuilt/datagrid-mui';
 
 // Automatically uses MUI-themed cell renderers and respects your MUI theme
 <MuiDataGrid
@@ -597,7 +597,7 @@ import { MuiDataGrid } from '@istracked/datagrid-mui';
 ### Imperative Control via Hooks
 
 ```tsx
-import { useGrid } from '@istracked/datagrid-react';
+import { useGrid } from '@iasbuilt/datagrid-react';
 
 function MyGrid() {
   const model = useGrid({ columns, data, rowKey: 'id' });
@@ -615,7 +615,7 @@ function MyGrid() {
 ### Fine-Grained Atom Subscriptions
 
 ```tsx
-import { useGridWithAtoms } from '@istracked/datagrid-react';
+import { useGridWithAtoms } from '@iasbuilt/datagrid-react';
 
 function MyGrid() {
   const { model, store, atoms } = useGridWithAtoms(config);
@@ -725,7 +725,7 @@ Events dispatched through the three-phase EventBus:
 ### Writing Extensions
 
 ```typescript
-import type { ExtensionDefinition } from '@istracked/datagrid-core';
+import type { ExtensionDefinition } from '@iasbuilt/datagrid-core';
 
 const myExtension: ExtensionDefinition = {
   id: 'my-extension',

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@istracked/datagrid-monorepo",
+  "name": "@iasbuilt/datagrid-monorepo",
   "private": true,
   "packageManager": "pnpm@9.15.4",
   "engines": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@istracked/datagrid-core",
+  "name": "@iasbuilt/datagrid-core",
   "version": "0.1.0",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/core/src/__tests__/column-def-legacy-validate.ts-expect-error.test.tsx
+++ b/packages/core/src/__tests__/column-def-legacy-validate.ts-expect-error.test.tsx
@@ -21,7 +21,7 @@
  * "used but was unexpected" diagnostic flipping the meaning).
  */
 
-import type { ColumnDef, Validator } from '@istracked/datagrid-core';
+import type { ColumnDef, Validator } from '@iasbuilt/datagrid-core';
 
 type Row = { id: string; name: string };
 

--- a/packages/core/src/__tests__/overflow.test.ts
+++ b/packages/core/src/__tests__/overflow.test.ts
@@ -26,7 +26,7 @@
  * assertion errors pin the public contract before any production code exists.
  */
 // @ts-expect-error — Phase B will add `overflow.ts` and re-export these.
-import { truncateMiddle, getDefaultOverflowPolicy } from '@istracked/datagrid-core';
+import { truncateMiddle, getDefaultOverflowPolicy } from '@iasbuilt/datagrid-core';
 
 describe('truncateMiddle', () => {
   it('returns the input untouched when it already fits within maxChars', () => {

--- a/packages/core/src/__tests__/validators.test.ts
+++ b/packages/core/src/__tests__/validators.test.ts
@@ -25,7 +25,7 @@
  * layer's tooltip rendering is tested separately in
  * `packages/react/src/__tests__/validation-tooltip.test.tsx`.
  *
- * The tests import from `@istracked/datagrid-core` directly so the test
+ * The tests import from `@iasbuilt/datagrid-core` directly so the test
  * doubles as a public-API smoke check: the new symbols must be re-exported
  * from the package barrel.
  */
@@ -37,7 +37,7 @@ import {
   type Validator,
   type ValidationResult,
   type CellValue,
-} from '@istracked/datagrid-core';
+} from '@iasbuilt/datagrid-core';
 
 // ---------------------------------------------------------------------------
 // Type-shape fixtures (enforced at type-check time; no runtime assertion).

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,7 +2,7 @@
  * Public entry point for the `@datagrid/core` package.
  *
  * This barrel is the single import surface consumed by downstream packages
- * (notably `@istracked/datagrid-react`) and by application code embedding the
+ * (notably `@iasbuilt/datagrid-react`) and by application code embedding the
  * grid directly. It stitches together the framework-agnostic building blocks
  * of the data grid — state containers, selection and sort engines, the plugin
  * host, and the persisted search-index primitives — so that every public

--- a/packages/core/src/overflow.ts
+++ b/packages/core/src/overflow.ts
@@ -3,7 +3,7 @@
  *
  * This module defines the framework-agnostic vocabulary used by the grid to
  * decide how cell text is rendered when the value is wider than the column.
- * Rendering adapters (notably `@istracked/datagrid-react`) consume these types
+ * Rendering adapters (notably `@iasbuilt/datagrid-react`) consume these types
  * and helpers to drive CSS class selection, reveal-mechanism wiring, and
  * density-aware row heights.
  *

--- a/packages/extensions/package.json
+++ b/packages/extensions/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@istracked/datagrid-extensions",
+  "name": "@iasbuilt/datagrid-extensions",
   "version": "0.1.0",
   "type": "module",
   "main": "./dist/index.cjs",
@@ -18,8 +18,8 @@
     "dev": "tsup --watch"
   },
   "dependencies": {
-    "@istracked/datagrid-core": "workspace:*",
-    "@istracked/datagrid-react": "workspace:*"
+    "@iasbuilt/datagrid-core": "workspace:*",
+    "@iasbuilt/datagrid-react": "workspace:*"
   },
   "peerDependencies": {
     "react": "^19.0.0"

--- a/packages/extensions/src/__tests__/cell-comments.test.ts
+++ b/packages/extensions/src/__tests__/cell-comments.test.ts
@@ -1,5 +1,5 @@
 import { createCellComments, CellCommentsConfig, CommentThread } from '../cell-comments';
-import type { GridEvent, CellAddress } from '@istracked/datagrid-core';
+import type { GridEvent, CellAddress } from '@iasbuilt/datagrid-core';
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/packages/extensions/src/__tests__/export.test.ts
+++ b/packages/extensions/src/__tests__/export.test.ts
@@ -13,7 +13,7 @@ import {
   ExportResult,
   PdfTableData,
 } from '../export';
-import type { ColumnDef, ExtensionContext, GridState } from '@istracked/datagrid-core';
+import type { ColumnDef, ExtensionContext, GridState } from '@iasbuilt/datagrid-core';
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/packages/extensions/src/__tests__/regex-validation.test.ts
+++ b/packages/extensions/src/__tests__/regex-validation.test.ts
@@ -1,6 +1,6 @@
 import { vi } from 'vitest';
 import { createRegexValidation, RegexRule, RegexValidationConfig } from '../regex-validation';
-import type { GridEvent } from '@istracked/datagrid-core';
+import type { GridEvent } from '@iasbuilt/datagrid-core';
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/packages/extensions/src/cell-comments/index.ts
+++ b/packages/extensions/src/cell-comments/index.ts
@@ -6,7 +6,7 @@
  *
  * @packageDocumentation
  */
-import { ExtensionDefinition, CellAddress, GridEvent } from '@istracked/datagrid-core';
+import { ExtensionDefinition, CellAddress, GridEvent } from '@iasbuilt/datagrid-core';
 
 /**
  * Represents a single comment within a {@link CommentThread}.

--- a/packages/extensions/src/column-resize/index.ts
+++ b/packages/extensions/src/column-resize/index.ts
@@ -5,7 +5,7 @@
  *
  * @packageDocumentation
  */
-import { ExtensionDefinition, GridEvent } from '@istracked/datagrid-core';
+import { ExtensionDefinition, GridEvent } from '@iasbuilt/datagrid-core';
 
 /**
  * Configuration options for the {@link createColumnResize} extension factory.

--- a/packages/extensions/src/excel-mode/index.ts
+++ b/packages/extensions/src/excel-mode/index.ts
@@ -5,7 +5,7 @@
  *
  * @packageDocumentation
  */
-import { ExtensionDefinition, CellAddress, GridEvent, ExtensionContext } from '@istracked/datagrid-core';
+import { ExtensionDefinition, CellAddress, GridEvent, ExtensionContext } from '@iasbuilt/datagrid-core';
 
 /**
  * Configuration options for the {@link createExcelMode} extension factory.

--- a/packages/extensions/src/export/index.ts
+++ b/packages/extensions/src/export/index.ts
@@ -17,8 +17,8 @@ import {
   ColumnDef,
   FilterState,
   CellValue,
-} from '@istracked/datagrid-core';
-import { applyFiltering } from '@istracked/datagrid-core';
+} from '@iasbuilt/datagrid-core';
+import { applyFiltering } from '@iasbuilt/datagrid-core';
 
 // ---------------------------------------------------------------------------
 // Config & types

--- a/packages/extensions/src/formula-bar/index.ts
+++ b/packages/extensions/src/formula-bar/index.ts
@@ -5,7 +5,7 @@
  *
  * @packageDocumentation
  */
-import { ExtensionDefinition, CellAddress, GridEvent, ExtensionContext } from '@istracked/datagrid-core';
+import { ExtensionDefinition, CellAddress, GridEvent, ExtensionContext } from '@iasbuilt/datagrid-core';
 
 /**
  * Configuration options for the {@link createFormulaBar} extension factory.

--- a/packages/extensions/src/regex-validation/index.ts
+++ b/packages/extensions/src/regex-validation/index.ts
@@ -5,7 +5,7 @@
  *
  * @packageDocumentation
  */
-import { ExtensionDefinition, CellAddress, ValidationResult, ValidationSeverity, GridEvent } from '@istracked/datagrid-core';
+import { ExtensionDefinition, CellAddress, ValidationResult, ValidationSeverity, GridEvent } from '@iasbuilt/datagrid-core';
 
 /**
  * A single regex-based validation rule applied to cell values within a column.

--- a/packages/extensions/src/validation-tooltip/index.ts
+++ b/packages/extensions/src/validation-tooltip/index.ts
@@ -5,7 +5,7 @@
  *
  * @packageDocumentation
  */
-import { ExtensionDefinition, ExtensionContext, ValidationResult, CellAddress, GridEvent } from '@istracked/datagrid-core';
+import { ExtensionDefinition, ExtensionContext, ValidationResult, CellAddress, GridEvent } from '@iasbuilt/datagrid-core';
 
 /**
  * Configuration options for the {@link createValidationTooltip} extension factory.

--- a/packages/extensions/tsconfig.build.json
+++ b/packages/extensions/tsconfig.build.json
@@ -6,8 +6,8 @@
     "outDir": "./dist",
     "rootDir": "./src",
     "paths": {
-      "@istracked/datagrid-core": ["../core/src"],
-      "@istracked/datagrid-react": ["../react/src"]
+      "@iasbuilt/datagrid-core": ["../core/src"],
+      "@iasbuilt/datagrid-react": ["../react/src"]
     }
   },
   "include": ["src"],

--- a/packages/extensions/tsup.config.ts
+++ b/packages/extensions/tsup.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   clean: true,
   treeshake: true,
   splitting: false,
-  external: ['react', 'react-dom', '@istracked/datagrid-core', '@istracked/datagrid-react'],
+  external: ['react', 'react-dom', '@iasbuilt/datagrid-core', '@iasbuilt/datagrid-react'],
   esbuildOptions(options) {
     options.jsx = 'automatic';
   },

--- a/packages/mui/package.json
+++ b/packages/mui/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@istracked/datagrid-mui",
+  "name": "@iasbuilt/datagrid-mui",
   "version": "0.1.0",
   "type": "module",
   "main": "./dist/index.cjs",
@@ -18,8 +18,8 @@
     "dev": "tsup --watch"
   },
   "dependencies": {
-    "@istracked/datagrid-core": "workspace:*",
-    "@istracked/datagrid-react": "workspace:*",
+    "@iasbuilt/datagrid-core": "workspace:*",
+    "@iasbuilt/datagrid-react": "workspace:*",
     "dompurify": "^3.2.4",
     "react-markdown": "^10.1.0",
     "remark-gfm": "^4.0.1"

--- a/packages/mui/src/MuiDataGrid.tsx
+++ b/packages/mui/src/MuiDataGrid.tsx
@@ -5,8 +5,8 @@
  * @packageDocumentation
  */
 import React from 'react';
-import { DataGrid } from '@istracked/datagrid-react';
-import type { DataGridProps, CellRendererProps } from '@istracked/datagrid-react';
+import { DataGrid } from '@iasbuilt/datagrid-react';
+import type { DataGridProps, CellRendererProps } from '@iasbuilt/datagrid-react';
 import { MuiDataGridThemeProvider, MuiThemeShape } from './theme';
 import { muiCellRendererMap } from './cells';
 

--- a/packages/mui/src/cells/MuiActionsCell/MuiActionsCell.tsx
+++ b/packages/mui/src/cells/MuiActionsCell/MuiActionsCell.tsx
@@ -9,8 +9,8 @@ import IconButton from '@mui/material/IconButton';
 import Tooltip from '@mui/material/Tooltip';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
-import type { CellValue, ColumnDef, StatusOption } from '@istracked/datagrid-core';
-import type { CellRendererProps } from '@istracked/datagrid-react';
+import type { CellValue, ColumnDef, StatusOption } from '@iasbuilt/datagrid-core';
+import type { CellRendererProps } from '@iasbuilt/datagrid-react';
 
 interface ActionOption extends StatusOption {
   disabled?: boolean;

--- a/packages/mui/src/cells/MuiBooleanCell/MuiBooleanCell.tsx
+++ b/packages/mui/src/cells/MuiBooleanCell/MuiBooleanCell.tsx
@@ -6,7 +6,7 @@
  */
 import React from 'react';
 import Checkbox from '@mui/material/Checkbox';
-import type { CellRendererProps } from '@istracked/datagrid-react';
+import type { CellRendererProps } from '@iasbuilt/datagrid-react';
 
 /**
  * MUI-based boolean cell renderer using MUI Checkbox.

--- a/packages/mui/src/cells/MuiCalendarCell/MuiCalendarCell.tsx
+++ b/packages/mui/src/cells/MuiCalendarCell/MuiCalendarCell.tsx
@@ -6,9 +6,9 @@
  */
 import React from 'react';
 import Typography from '@mui/material/Typography';
-import type { CellValue } from '@istracked/datagrid-core';
-import type { CellRendererProps } from '@istracked/datagrid-react';
-import { useDraftState } from '@istracked/datagrid-react';
+import type { CellValue } from '@iasbuilt/datagrid-core';
+import type { CellRendererProps } from '@iasbuilt/datagrid-react';
+import { useDraftState } from '@iasbuilt/datagrid-react';
 import { EditableTextField } from '../../components';
 
 function parseDate(value: CellValue): Date | null {

--- a/packages/mui/src/cells/MuiChipSelectCell/MuiChipSelectCell.tsx
+++ b/packages/mui/src/cells/MuiChipSelectCell/MuiChipSelectCell.tsx
@@ -7,8 +7,8 @@
 import React from 'react';
 import Chip from '@mui/material/Chip';
 import Box from '@mui/material/Box';
-import type { CellRendererProps } from '@istracked/datagrid-react';
-import { useArrayState } from '@istracked/datagrid-react';
+import type { CellRendererProps } from '@iasbuilt/datagrid-react';
+import { useArrayState } from '@iasbuilt/datagrid-react';
 import { EditableAutocomplete } from '../../components';
 
 function parseArray(value: unknown): string[] {

--- a/packages/mui/src/cells/MuiCompoundChipListCell/MuiCompoundChipListCell.tsx
+++ b/packages/mui/src/cells/MuiCompoundChipListCell/MuiCompoundChipListCell.tsx
@@ -9,8 +9,8 @@ import Chip from '@mui/material/Chip';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import TextField from '@mui/material/TextField';
-import type { CellValue } from '@istracked/datagrid-core';
-import type { CellRendererProps } from '@istracked/datagrid-react';
+import type { CellValue } from '@iasbuilt/datagrid-core';
+import type { CellRendererProps } from '@iasbuilt/datagrid-react';
 
 interface ChipItem {
   id: string;

--- a/packages/mui/src/cells/MuiCurrencyCell/MuiCurrencyCell.tsx
+++ b/packages/mui/src/cells/MuiCurrencyCell/MuiCurrencyCell.tsx
@@ -7,9 +7,9 @@
 import React from 'react';
 import InputAdornment from '@mui/material/InputAdornment';
 import Typography from '@mui/material/Typography';
-import type { CellValue } from '@istracked/datagrid-core';
-import type { CellRendererProps } from '@istracked/datagrid-react';
-import { useDraftState } from '@istracked/datagrid-react';
+import type { CellValue } from '@iasbuilt/datagrid-core';
+import type { CellRendererProps } from '@iasbuilt/datagrid-react';
+import { useDraftState } from '@iasbuilt/datagrid-react';
 import { EditableTextField } from '../../components';
 
 function parseCurrencyFormat(format?: string): { symbol: string; negativeRed: boolean } {

--- a/packages/mui/src/cells/MuiListCell/MuiListCell.tsx
+++ b/packages/mui/src/cells/MuiListCell/MuiListCell.tsx
@@ -6,9 +6,9 @@
  */
 import React from 'react';
 import MenuItem from '@mui/material/MenuItem';
-import type { CellValue } from '@istracked/datagrid-core';
-import type { CellRendererProps } from '@istracked/datagrid-react';
-import { useSelectState } from '@istracked/datagrid-react';
+import type { CellValue } from '@iasbuilt/datagrid-core';
+import type { CellRendererProps } from '@iasbuilt/datagrid-react';
+import { useSelectState } from '@iasbuilt/datagrid-react';
 import { DisplayTypography, EditableSelect } from '../../components';
 
 /**

--- a/packages/mui/src/cells/MuiNumericCell/MuiNumericCell.tsx
+++ b/packages/mui/src/cells/MuiNumericCell/MuiNumericCell.tsx
@@ -6,9 +6,9 @@
  */
 import React from 'react';
 import Typography from '@mui/material/Typography';
-import type { CellValue } from '@istracked/datagrid-core';
-import type { CellRendererProps } from '@istracked/datagrid-react';
-import { useDraftState } from '@istracked/datagrid-react';
+import type { CellValue } from '@iasbuilt/datagrid-core';
+import type { CellRendererProps } from '@iasbuilt/datagrid-react';
+import { useDraftState } from '@iasbuilt/datagrid-react';
 import { EditableTextField } from '../../components';
 
 function formatNumeric(value: CellValue, useThousands: boolean): string {

--- a/packages/mui/src/cells/MuiPasswordCell/MuiPasswordCell.tsx
+++ b/packages/mui/src/cells/MuiPasswordCell/MuiPasswordCell.tsx
@@ -8,8 +8,8 @@ import React, { useState } from 'react';
 import IconButton from '@mui/material/IconButton';
 import InputAdornment from '@mui/material/InputAdornment';
 import Box from '@mui/material/Box';
-import type { CellRendererProps } from '@istracked/datagrid-react';
-import { useDraftState } from '@istracked/datagrid-react';
+import type { CellRendererProps } from '@iasbuilt/datagrid-react';
+import { useDraftState } from '@iasbuilt/datagrid-react';
 import { EditableTextField } from '../../components';
 
 const MASK_CHAR = '\u2022';

--- a/packages/mui/src/cells/MuiRichTextCell/MuiRichTextCell.tsx
+++ b/packages/mui/src/cells/MuiRichTextCell/MuiRichTextCell.tsx
@@ -47,7 +47,7 @@ import Tooltip from '@mui/material/Tooltip';
 import ToggleButton from '@mui/material/ToggleButton';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import type { CellRendererProps } from '@istracked/datagrid-react';
+import type { CellRendererProps } from '@iasbuilt/datagrid-react';
 
 const useIsomorphicLayoutEffect =
   typeof window !== 'undefined' ? useLayoutEffect : useEffect;

--- a/packages/mui/src/cells/MuiStatusCell/MuiStatusCell.tsx
+++ b/packages/mui/src/cells/MuiStatusCell/MuiStatusCell.tsx
@@ -7,9 +7,9 @@
 import React from 'react';
 import MenuItem from '@mui/material/MenuItem';
 import Chip from '@mui/material/Chip';
-import type { CellValue, StatusOption } from '@istracked/datagrid-core';
-import type { CellRendererProps } from '@istracked/datagrid-react';
-import { useSelectState } from '@istracked/datagrid-react';
+import type { CellValue, StatusOption } from '@iasbuilt/datagrid-core';
+import type { CellRendererProps } from '@iasbuilt/datagrid-react';
+import { useSelectState } from '@iasbuilt/datagrid-react';
 import { EditableSelect } from '../../components';
 import { colorDot } from './MuiStatusCell.styles';
 

--- a/packages/mui/src/cells/MuiSubGridCell/MuiSubGridCell.tsx
+++ b/packages/mui/src/cells/MuiSubGridCell/MuiSubGridCell.tsx
@@ -16,9 +16,9 @@ import Box from '@mui/material/Box';
 import IconButton from '@mui/material/IconButton';
 import KeyboardArrowRightIcon from '@mui/icons-material/KeyboardArrowRight';
 import CloseIcon from '@mui/icons-material/Close';
-import type { CellValue } from '@istracked/datagrid-core';
-import type { CellRendererProps } from '@istracked/datagrid-react';
-import { GridContext } from '@istracked/datagrid-react';
+import type { CellValue } from '@iasbuilt/datagrid-core';
+import type { CellRendererProps } from '@iasbuilt/datagrid-react';
+import { GridContext } from '@iasbuilt/datagrid-react';
 
 function parseRows(value: CellValue): Record<string, unknown>[] {
   if (Array.isArray(value)) return value as Record<string, unknown>[];

--- a/packages/mui/src/cells/MuiTagsCell/MuiTagsCell.tsx
+++ b/packages/mui/src/cells/MuiTagsCell/MuiTagsCell.tsx
@@ -7,8 +7,8 @@
 import React from 'react';
 import Chip from '@mui/material/Chip';
 import Box from '@mui/material/Box';
-import type { CellRendererProps } from '@istracked/datagrid-react';
-import { useArrayState } from '@istracked/datagrid-react';
+import type { CellRendererProps } from '@iasbuilt/datagrid-react';
+import { useArrayState } from '@iasbuilt/datagrid-react';
 import { EditableAutocomplete } from '../../components';
 
 function parseTags(value: unknown): string[] {

--- a/packages/mui/src/cells/MuiTextCell/MuiTextCell.tsx
+++ b/packages/mui/src/cells/MuiTextCell/MuiTextCell.tsx
@@ -5,13 +5,13 @@
  * @packageDocumentation
  */
 import React from 'react';
-import type { CellRendererProps } from '@istracked/datagrid-react';
-import { useDraftState } from '@istracked/datagrid-react';
+import type { CellRendererProps } from '@iasbuilt/datagrid-react';
+import { useDraftState } from '@iasbuilt/datagrid-react';
 import {
   truncateEnd,
   truncateMiddle,
   getDefaultOverflowPolicy,
-} from '@istracked/datagrid-core';
+} from '@iasbuilt/datagrid-core';
 import { EditableTextField, DisplayTypography } from '../../components';
 
 // Matches `TRUNCATE_MAX_CHARS` in `packages/react/src/body/DataGridBody.tsx`:

--- a/packages/mui/src/cells/MuiUploadCell/MuiUploadCell.tsx
+++ b/packages/mui/src/cells/MuiUploadCell/MuiUploadCell.tsx
@@ -9,8 +9,8 @@ import Button from '@mui/material/Button';
 import LinearProgress from '@mui/material/LinearProgress';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
-import type { CellValue, ColumnDef } from '@istracked/datagrid-core';
-import type { CellRendererProps } from '@istracked/datagrid-react';
+import type { CellValue, ColumnDef } from '@iasbuilt/datagrid-core';
+import type { CellRendererProps } from '@iasbuilt/datagrid-react';
 import { hiddenFileInput } from './MuiUploadCell.styles';
 
 /**

--- a/packages/mui/src/cells/__tests__/MuiRichTextCell.test.tsx
+++ b/packages/mui/src/cells/__tests__/MuiRichTextCell.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import React from 'react';
 
 import { MuiRichTextCell } from '../MuiRichTextCell';
-import type { ColumnDef, CellValue } from '@istracked/datagrid-core';
+import type { ColumnDef, CellValue } from '@iasbuilt/datagrid-core';
 
 function makeColumn(overrides: Partial<ColumnDef> = {}): ColumnDef {
   return { id: 'col1', field: 'col1', title: 'Column 1', ...overrides };

--- a/packages/mui/src/cells/index.ts
+++ b/packages/mui/src/cells/index.ts
@@ -9,7 +9,7 @@
  * @packageDocumentation
  */
 import React from 'react';
-import type { CellRendererProps } from '@istracked/datagrid-react';
+import type { CellRendererProps } from '@iasbuilt/datagrid-react';
 
 export { MuiTextCell } from './MuiTextCell';
 export { MuiNumericCell } from './MuiNumericCell';
@@ -46,7 +46,7 @@ import { MuiActionsCell } from './MuiActionsCell';
 /**
  * Maps column type identifiers to their corresponding MUI cell renderer components.
  *
- * Drop-in replacement for the default `cellRendererMap` from `@istracked/datagrid-react`,
+ * Drop-in replacement for the default `cellRendererMap` from `@iasbuilt/datagrid-react`,
  * using Material UI components for consistent MUI theming.
  */
 export const muiCellRendererMap: Record<string, React.ComponentType<CellRendererProps<any>>> = {

--- a/packages/mui/src/index.ts
+++ b/packages/mui/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * Public API barrel file for the `@istracked/datagrid-mui` package.
+ * Public API barrel file for the `@iasbuilt/datagrid-mui` package.
  *
  * Re-exports all MUI cell renderers, the theme bridge, the convenience
  * wrapper, and the renderer map for drop-in use.

--- a/packages/mui/src/theme/theme-bridge.ts
+++ b/packages/mui/src/theme/theme-bridge.ts
@@ -4,8 +4,8 @@
  * Colour values are drawn from the MUI theme at call time, so host
  * applications stay in control of their own palette. The *default*
  * header-background value used when no per-mode override is supplied falls
- * back to the corresponding iAsBuilt token from `@istracked/datagrid-react`
- * (which ingests from the organisation-wide `istracked/tokens` repository)
+ * back to the corresponding iAsBuilt token from `@iasbuilt/datagrid-react`
+ * (which ingests from the organisation-wide `iasbuilt/tokens` repository)
  * so the MUI bridge cannot drift away from the source of truth.
  *
  * @module theme-bridge
@@ -13,7 +13,7 @@
  */
 
 // eslint-disable-next-line import/no-relative-packages -- in-monorepo sibling package.
-import { lightThemeTokens, darkThemeTokens } from '@istracked/datagrid-react';
+import { lightThemeTokens, darkThemeTokens } from '@iasbuilt/datagrid-react';
 
 /** Minimal MUI theme shape needed for the bridge. */
 export interface MuiThemeShape {

--- a/packages/mui/tsconfig.build.json
+++ b/packages/mui/tsconfig.build.json
@@ -7,8 +7,8 @@
     "rootDir": "./src",
     "jsx": "react-jsx",
     "paths": {
-      "@istracked/datagrid-core": ["../core/src/index.ts"],
-      "@istracked/datagrid-react": ["../react/src/index.ts"]
+      "@iasbuilt/datagrid-core": ["../core/src/index.ts"],
+      "@iasbuilt/datagrid-react": ["../react/src/index.ts"]
     }
   },
   "include": ["src"],

--- a/packages/mui/tsup.config.ts
+++ b/packages/mui/tsup.config.ts
@@ -11,8 +11,8 @@ export default defineConfig({
   external: [
     'react',
     'react-dom',
-    '@istracked/datagrid-core',
-    '@istracked/datagrid-react',
+    '@iasbuilt/datagrid-core',
+    '@iasbuilt/datagrid-react',
     '@mui/material',
     '@emotion/react',
     '@emotion/styled',

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@istracked/datagrid-react",
+  "name": "@iasbuilt/datagrid-react",
   "version": "0.1.0",
   "type": "module",
   "main": "./dist/index.cjs",
@@ -19,7 +19,7 @@
     "dev": "tsup --watch"
   },
   "dependencies": {
-    "@istracked/datagrid-core": "workspace:*",
+    "@iasbuilt/datagrid-core": "workspace:*",
     "dompurify": "^3.2.4",
     "jotai": "^2.12.3",
     "react-markdown": "^10.1.0",

--- a/packages/react/src/ContextMenu.tsx
+++ b/packages/react/src/ContextMenu.tsx
@@ -60,7 +60,7 @@
  */
 import React, { useEffect, useLayoutEffect, useRef, useState, useCallback } from 'react';
 import { createPortal } from 'react-dom';
-import { ContextMenuItemDef } from '@istracked/datagrid-core';
+import { ContextMenuItemDef } from '@iasbuilt/datagrid-core';
 import * as styles from './ContextMenu.styles';
 
 /**

--- a/packages/react/src/DataGrid.tsx
+++ b/packages/react/src/DataGrid.tsx
@@ -1,5 +1,5 @@
 /**
- * Core DataGrid React component module for the `@istracked/datagrid-react` package.
+ * Core DataGrid React component module for the `@iasbuilt/datagrid-react` package.
  *
  * Thin orchestrator that composes header, body, toolbar, and context-menu
  * sub-components. Manages model wiring, keyboard navigation, virtualization,
@@ -15,7 +15,7 @@
  *     number / controls chrome columns, group summary rows).
  *   - This module owns only presentation state and event translation. The
  *     authoritative data model — rows, columns, sort/filter/group state, and
- *     edit transactions — lives in a `GridModel` from `@istracked/datagrid-core`.
+ *     edit transactions — lives in a `GridModel` from `@iasbuilt/datagrid-core`.
  *     The React tree bridges to it through {@link useGridWithAtoms} (which
  *     instantiates the model) and {@link useGridStore} (which subscribes to it
  *     and produces snapshot-friendly state for rendering). All mutations flow
@@ -30,7 +30,7 @@
  */
 import React, { useRef, useCallback, useState, useEffect, useId, useMemo } from 'react';
 // Side-effect CSS import: the theme layer defines `--dg-*` tokens (scoped to
-// `.istracked-datagrid[data-theme="..."]`) plus the `data-row-selected`
+// `.iasbuilt-datagrid[data-theme="..."]`) plus the `data-row-selected`
 // header-darken rule. Without this import the CSS lives on disk but never
 // reaches the DOM, and host pages see inline-style fallbacks only.
 import './styles/datagrid-theme.css';
@@ -54,7 +54,7 @@ import {
   ControlsColumnConfig,
   RowNumberColumnConfig,
   Density,
-} from '@istracked/datagrid-core';
+} from '@iasbuilt/datagrid-core';
 import {
   groupRows,
   getVisibleRowsWithGroups,
@@ -64,7 +64,7 @@ import {
   stripField,
   runValidators,
   mostSevere,
-} from '@istracked/datagrid-core';
+} from '@iasbuilt/datagrid-core';
 import { ValidationTooltip } from './ValidationTooltip';
 import { useGridWithAtoms } from './use-grid';
 import { useGridStore } from './use-grid-store';
@@ -82,14 +82,14 @@ import { DataGridToolbar } from './toolbar/DataGridToolbar';
 import { DataGridColumnFilterMenu } from './header/column-filter-menu/DataGridColumnFilterMenu';
 import { FilterConditionDialog } from './header/column-filter-menu/FilterConditionDialog';
 import { useBackgroundIndexer } from './hooks/use-background-indexer';
-import type { CompositeFilterDescriptor, FilterDescriptor } from '@istracked/datagrid-core';
+import type { CompositeFilterDescriptor, FilterDescriptor } from '@iasbuilt/datagrid-core';
 import * as styles from './DataGrid.styles';
 import { lightThemeTokens, darkThemeTokens } from './styles/tokens';
 
 /**
  * Props accepted by the {@link DataGrid} component.
  *
- * Extends `GridConfig<TData>` from `@istracked/datagrid-core` with React-only
+ * Extends `GridConfig<TData>` from `@iasbuilt/datagrid-core` with React-only
  * concerns: styling, dimension overrides, event callbacks, and UI-layer
  * toggles that have no representation inside the core model (toolbar chrome,
  * column menus, Excel-style filter menu).
@@ -101,7 +101,7 @@ import { lightThemeTokens, darkThemeTokens } from './styles/tokens';
  *
  * @typeParam TData - Shape of a single row record. Defaults to a generic
  *   object keyed by string.
- * @see GridConfig from `@istracked/datagrid-core` for the underlying data-model
+ * @see GridConfig from `@iasbuilt/datagrid-core` for the underlying data-model
  *   options (columns, rows, sorting/filtering/grouping defaults, theme, etc.).
  */
 export interface DataGridProps<TData extends Record<string, unknown> = Record<string, unknown>>
@@ -202,7 +202,7 @@ export interface CellRendererProps<TData = Record<string, unknown>> {
 // Theme token helpers
 //
 // The palette values used by the light and dark presets are ingested from the
-// organisation-wide `istracked/tokens` repository (see
+// organisation-wide `iasbuilt/tokens` repository (see
 // `packages/react/src/styles/tokens/`). The grid does not carry its own
 // hand-tuned colours any more — both theme objects are projections of the
 // W3C design-token tree onto the `--dg-*` custom properties our inline styles
@@ -254,7 +254,7 @@ export { LIGHT_THEME, DARK_THEME };
 /**
  * Top-level grid component.
  *
- * Instantiates a `GridModel` from `@istracked/datagrid-core`, wires it to a
+ * Instantiates a `GridModel` from `@iasbuilt/datagrid-core`, wires it to a
  * React render tree via subscription hooks, and composes the toolbar, column
  * group banner, header, body, context menu, column menu, and (optionally) the
  * Excel-365 filter menu into a single scrolling surface.
@@ -279,7 +279,7 @@ export { LIGHT_THEME, DARK_THEME };
  * ```
  *
  * @typeParam TData - Row shape; inferred from `columns`/`rows`.
- * @see GridModel and GridConfig from `@istracked/datagrid-core` for the
+ * @see GridModel and GridConfig from `@iasbuilt/datagrid-core` for the
  *   authoritative data model this component renders.
  */
 export function DataGrid<TData extends Record<string, unknown>>(props: DataGridProps<TData>) {
@@ -1289,7 +1289,7 @@ export function DataGrid<TData extends Record<string, unknown>>(props: DataGridP
       <div
         ref={containerRef}
         id={domId}
-        className={`istracked-datagrid${className ? ` ${className}` : ''}`}
+        className={`iasbuilt-datagrid${className ? ` ${className}` : ''}`}
         style={styles.gridContainer(!!config.theme, themeStyle, style)}
         tabIndex={0}
         role="grid"

--- a/packages/react/src/GhostRow.styles.ts
+++ b/packages/react/src/GhostRow.styles.ts
@@ -1,6 +1,6 @@
 import type { CSSProperties } from 'react';
 
-import { GhostRowPosition } from '@istracked/datagrid-core';
+import { GhostRowPosition } from '@iasbuilt/datagrid-core';
 
 export const aboveHeaderPosition: CSSProperties = {
   display: 'flex',

--- a/packages/react/src/GhostRow.tsx
+++ b/packages/react/src/GhostRow.tsx
@@ -9,8 +9,8 @@
  * @module GhostRow
  */
 import React, { useState, useRef, useCallback, useEffect } from 'react';
-import { ColumnDef, CellValue, GhostRowConfig, GhostRowPosition, ValidationResult, runValidators, mostSevere } from '@istracked/datagrid-core';
-import { GridModel } from '@istracked/datagrid-core';
+import { ColumnDef, CellValue, GhostRowConfig, GhostRowPosition, ValidationResult, runValidators, mostSevere } from '@iasbuilt/datagrid-core';
+import { GridModel } from '@iasbuilt/datagrid-core';
 import * as styles from './GhostRow.styles';
 
 /**

--- a/packages/react/src/MasterDetail.tsx
+++ b/packages/react/src/MasterDetail.tsx
@@ -225,7 +225,7 @@ export function MasterDetail<TData extends Record<string, unknown>>(
 
   return (
     <div
-      className="istracked-master-detail"
+      className="iasbuilt-master-detail"
       style={styles.container}
       role="grid"
       aria-rowcount={data.length}

--- a/packages/react/src/TransposedGrid.tsx
+++ b/packages/react/src/TransposedGrid.tsx
@@ -9,8 +9,8 @@
  */
 
 import React, { useMemo, useCallback } from 'react';
-import type { TransposedField, CellValue } from '@istracked/datagrid-core';
-import { createTransposedConfig } from '@istracked/datagrid-core';
+import type { TransposedField, CellValue } from '@iasbuilt/datagrid-core';
+import { createTransposedConfig } from '@iasbuilt/datagrid-core';
 import { DataGrid, type CellRendererProps } from './DataGrid';
 import { cellRendererMap, TextCell } from './cells';
 

--- a/packages/react/src/ValidationTooltip.tsx
+++ b/packages/react/src/ValidationTooltip.tsx
@@ -31,7 +31,7 @@
  */
 import React from 'react';
 import { createPortal } from 'react-dom';
-import type { ValidationResult, ValidationSeverity } from '@istracked/datagrid-core';
+import type { ValidationResult, ValidationSeverity } from '@iasbuilt/datagrid-core';
 
 export interface ValidationTooltipProps {
   /** Id of the row the tooltip describes. */

--- a/packages/react/src/__tests__/DataGrid.test.tsx
+++ b/packages/react/src/__tests__/DataGrid.test.tsx
@@ -95,7 +95,7 @@ describe('DataGrid structure', () => {
     renderGrid({ className: 'my-grid' });
     const grid = screen.getByRole('grid');
     expect(grid.className).toContain('my-grid');
-    expect(grid.className).toContain('istracked-datagrid');
+    expect(grid.className).toContain('iasbuilt-datagrid');
   });
 
   it('applies custom style', () => {

--- a/packages/react/src/__tests__/a11y-axe.test.tsx
+++ b/packages/react/src/__tests__/a11y-axe.test.tsx
@@ -25,7 +25,7 @@ import { describe, it, expect } from 'vitest';
 import { render, fireEvent, act } from '@testing-library/react';
 import { axe } from 'vitest-axe';
 import { toHaveNoViolations } from 'vitest-axe/matchers';
-import type { ColumnDef } from '@istracked/datagrid-core';
+import type { ColumnDef } from '@iasbuilt/datagrid-core';
 
 import { DataGrid } from '../DataGrid';
 import { cellRendererMap } from '../cells';

--- a/packages/react/src/__tests__/cell-a11y.test.tsx
+++ b/packages/react/src/__tests__/cell-a11y.test.tsx
@@ -13,7 +13,7 @@
 import React from 'react';
 import { describe, it, expect, vi } from 'vitest';
 import { render, fireEvent, screen, act } from '@testing-library/react';
-import type { ColumnDef } from '@istracked/datagrid-core';
+import type { ColumnDef } from '@iasbuilt/datagrid-core';
 
 import { BooleanSelectedCell } from '../cells/BooleanSelectedCell/BooleanSelectedCell';
 import { PasswordConfirmCell } from '../cells/PasswordConfirmCell/PasswordConfirmCell';

--- a/packages/react/src/__tests__/cell-overflow.test.tsx
+++ b/packages/react/src/__tests__/cell-overflow.test.tsx
@@ -52,7 +52,7 @@
 import { render, screen, fireEvent, act, within } from '@testing-library/react';
 import { vi } from 'vitest';
 import { DataGrid } from '../DataGrid';
-import { ColumnDef } from '@istracked/datagrid-core';
+import { ColumnDef } from '@iasbuilt/datagrid-core';
 
 // ---------------------------------------------------------------------------
 // Fixtures

--- a/packages/react/src/__tests__/chrome-composition-scenarios.test.tsx
+++ b/packages/react/src/__tests__/chrome-composition-scenarios.test.tsx
@@ -21,7 +21,7 @@
 import { render, screen, fireEvent, within } from '@testing-library/react';
 import { vi } from 'vitest';
 import { DataGrid } from '../DataGrid';
-import type { ChromeCellContent } from '@istracked/datagrid-core';
+import type { ChromeCellContent } from '@iasbuilt/datagrid-core';
 
 type Row = { id: string; dept: string; name: string; salary: number };
 

--- a/packages/react/src/__tests__/chrome-resolver-memoization.test.tsx
+++ b/packages/react/src/__tests__/chrome-resolver-memoization.test.tsx
@@ -26,7 +26,7 @@
  */
 import { render } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
-import type { ChromeColumnsConfig } from '@istracked/datagrid-core';
+import type { ChromeColumnsConfig } from '@iasbuilt/datagrid-core';
 import { DataGrid } from '../DataGrid';
 
 // ────────────────────────────────────────────────────────────────────────────

--- a/packages/react/src/__tests__/chrome-resolver-object-overload.test.tsx
+++ b/packages/react/src/__tests__/chrome-resolver-object-overload.test.tsx
@@ -33,7 +33,7 @@ import type {
   RowBorderStyle,
   ChromeCellContent,
   ColumnDef,
-} from '@istracked/datagrid-core';
+} from '@iasbuilt/datagrid-core';
 import { DataGrid } from '../DataGrid';
 
 type TestRow = { id: string; name: string; value: number };

--- a/packages/react/src/__tests__/chrome-row-apis.test.tsx
+++ b/packages/react/src/__tests__/chrome-row-apis.test.tsx
@@ -16,7 +16,7 @@
  */
 import { render, screen, fireEvent, within } from '@testing-library/react';
 import { DataGrid } from '../DataGrid';
-import type { RowBorderStyle, ChromeCellContent } from '@istracked/datagrid-core';
+import type { RowBorderStyle, ChromeCellContent } from '@iasbuilt/datagrid-core';
 import { vi } from 'vitest';
 
 type TestRow = { id: string; name: string; category: 'alpha' | 'beta' | 'gamma' };

--- a/packages/react/src/__tests__/clipboard-integration.test.tsx
+++ b/packages/react/src/__tests__/clipboard-integration.test.tsx
@@ -7,7 +7,7 @@ import {
   ColumnDef,
   GridModel,
   createGridModel,
-} from '@istracked/datagrid-core';
+} from '@iasbuilt/datagrid-core';
 import { vi } from 'vitest';
 
 type TestRow = { id: string; name: string; age: number; city: string; readonly?: boolean };

--- a/packages/react/src/__tests__/column-filter-menu-conditions.test.tsx
+++ b/packages/react/src/__tests__/column-filter-menu-conditions.test.tsx
@@ -12,7 +12,7 @@ import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { vi } from 'vitest';
 import { FilterConditionDialog } from '../header/column-filter-menu/FilterConditionDialog';
-import type { CompositeFilterDescriptor } from '@istracked/datagrid-core';
+import type { CompositeFilterDescriptor } from '@iasbuilt/datagrid-core';
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/packages/react/src/__tests__/context-menu.test.tsx
+++ b/packages/react/src/__tests__/context-menu.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import { vi } from 'vitest';
 import { DataGrid } from '../DataGrid';
-import { ContextMenuItemDef } from '@istracked/datagrid-core';
+import { ContextMenuItemDef } from '@iasbuilt/datagrid-core';
 
 // ---------------------------------------------------------------------------
 // Shared fixtures

--- a/packages/react/src/__tests__/density-mode.test.tsx
+++ b/packages/react/src/__tests__/density-mode.test.tsx
@@ -18,7 +18,7 @@
  */
 import { render, screen } from '@testing-library/react';
 import { DataGrid } from '../DataGrid';
-import { ColumnDef } from '@istracked/datagrid-core';
+import { ColumnDef } from '@iasbuilt/datagrid-core';
 
 type Row = { id: string; description: string };
 

--- a/packages/react/src/__tests__/drag-drop.test.tsx
+++ b/packages/react/src/__tests__/drag-drop.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import { vi } from 'vitest';
 import { DataGrid } from '../DataGrid';
-import type { FileDropConfig, ColumnDef } from '@istracked/datagrid-core';
+import type { FileDropConfig, ColumnDef } from '@iasbuilt/datagrid-core';
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/packages/react/src/__tests__/filter-utils.test.ts
+++ b/packages/react/src/__tests__/filter-utils.test.ts
@@ -10,8 +10,8 @@
  *      `null` outright.
  */
 import { describe, it, expect } from 'vitest';
-import type { FilterDescriptor, CompositeFilterDescriptor } from '@istracked/datagrid-core';
-import { stripField, MAX_FILTER_DEPTH } from '@istracked/datagrid-core';
+import type { FilterDescriptor, CompositeFilterDescriptor } from '@iasbuilt/datagrid-core';
+import { stripField, MAX_FILTER_DEPTH } from '@iasbuilt/datagrid-core';
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/packages/react/src/__tests__/hover-tooltip.test.tsx
+++ b/packages/react/src/__tests__/hover-tooltip.test.tsx
@@ -23,7 +23,7 @@
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import { vi } from 'vitest';
 import { DataGrid } from '../DataGrid';
-import { ColumnDef } from '@istracked/datagrid-core';
+import { ColumnDef } from '@iasbuilt/datagrid-core';
 
 // ---------------------------------------------------------------------------
 // Shared fixtures

--- a/packages/react/src/__tests__/json-config.test.tsx
+++ b/packages/react/src/__tests__/json-config.test.tsx
@@ -5,7 +5,7 @@ import {
   GridConfig,
   SortState,
   FilterState,
-} from '@istracked/datagrid-core';
+} from '@iasbuilt/datagrid-core';
 import { vi } from 'vitest';
 
 // ---------------------------------------------------------------------------
@@ -86,12 +86,12 @@ describe('JSON config — filtering', () => {
   it('config enables filtering when filtering is true', () => {
     // When filtering is enabled, the grid should render without error
     const { container } = renderGrid({ filtering: true });
-    expect(container.querySelector('.istracked-datagrid')).toBeInTheDocument();
+    expect(container.querySelector('.iasbuilt-datagrid')).toBeInTheDocument();
   });
 
   it('config disables filtering when filtering is false', () => {
     const { container } = renderGrid({ filtering: false });
-    expect(container.querySelector('.istracked-datagrid')).toBeInTheDocument();
+    expect(container.querySelector('.iasbuilt-datagrid')).toBeInTheDocument();
   });
 });
 
@@ -139,12 +139,12 @@ describe('JSON config — ghost row', () => {
   it('config enables ghost row when ghostRow is true', () => {
     // ghostRow=true should not cause any rendering error
     const { container } = renderGrid({ ghostRow: true });
-    expect(container.querySelector('.istracked-datagrid')).toBeInTheDocument();
+    expect(container.querySelector('.iasbuilt-datagrid')).toBeInTheDocument();
   });
 
   it('config disables ghost row when ghostRow is false', () => {
     const { container } = renderGrid({ ghostRow: false });
-    expect(container.querySelector('.istracked-datagrid')).toBeInTheDocument();
+    expect(container.querySelector('.iasbuilt-datagrid')).toBeInTheDocument();
   });
 });
 
@@ -248,7 +248,7 @@ describe('JSON config — read-only', () => {
 describe('JSON config — theme', () => {
   it('config applies theme light mode', () => {
     const { container } = renderGrid({ theme: 'light' });
-    const grid = container.querySelector('.istracked-datagrid');
+    const grid = container.querySelector('.iasbuilt-datagrid');
     expect(grid).toBeInTheDocument();
     // Light theme is the default — grid renders without custom overrides
     expect(grid).toHaveAttribute('role', 'grid');
@@ -256,7 +256,7 @@ describe('JSON config — theme', () => {
 
   it('config applies theme dark mode', () => {
     const { container } = renderGrid({ theme: 'dark' });
-    const grid = container.querySelector('.istracked-datagrid');
+    const grid = container.querySelector('.iasbuilt-datagrid');
     expect(grid).toBeInTheDocument();
     expect(grid).toHaveAttribute('role', 'grid');
   });
@@ -264,7 +264,7 @@ describe('JSON config — theme', () => {
   it('config applies custom theme properties', () => {
     const customTheme = { '--dg-row-bg': '#111', '--dg-border-color': '#333' };
     const { container } = renderGrid({ theme: customTheme });
-    const grid = container.querySelector('.istracked-datagrid');
+    const grid = container.querySelector('.iasbuilt-datagrid');
     expect(grid).toBeInTheDocument();
   });
 });
@@ -274,13 +274,13 @@ describe('JSON config — file drop', () => {
     const { container } = renderGrid({
       fileDrop: { enabled: true, accept: ['.csv'] },
     });
-    expect(container.querySelector('.istracked-datagrid')).toBeInTheDocument();
+    expect(container.querySelector('.iasbuilt-datagrid')).toBeInTheDocument();
   });
 
   it('config disables file drop when fileDrop not configured', () => {
     const { container } = renderGrid();
     // No fileDrop config passed — grid should still render fine
-    expect(container.querySelector('.istracked-datagrid')).toBeInTheDocument();
+    expect(container.querySelector('.iasbuilt-datagrid')).toBeInTheDocument();
   });
 });
 
@@ -289,14 +289,14 @@ describe('JSON config — grouping', () => {
     const { container } = renderGrid({
       grouping: { rows: { fields: ['name'], defaultExpanded: true } },
     });
-    expect(container.querySelector('.istracked-datagrid')).toBeInTheDocument();
+    expect(container.querySelector('.iasbuilt-datagrid')).toBeInTheDocument();
   });
 
   it('config disables grouping when grouping is false', () => {
     const { container } = renderGrid({
       grouping: { rows: false },
     });
-    expect(container.querySelector('.istracked-datagrid')).toBeInTheDocument();
+    expect(container.querySelector('.iasbuilt-datagrid')).toBeInTheDocument();
   });
 });
 

--- a/packages/react/src/__tests__/master-detail.test.tsx
+++ b/packages/react/src/__tests__/master-detail.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
 import { vi } from 'vitest';
 import { MasterDetail, DetailComponentProps } from '../MasterDetail';
-import type { ColumnDef } from '@istracked/datagrid-core';
+import type { ColumnDef } from '@iasbuilt/datagrid-core';
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/packages/react/src/__tests__/pivot-modes.test.tsx
+++ b/packages/react/src/__tests__/pivot-modes.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import { DataGrid, CellRendererProps } from '../DataGrid';
-import type { ColumnDef, RowTypeDef, CellType } from '@istracked/datagrid-core';
+import type { ColumnDef, RowTypeDef, CellType } from '@iasbuilt/datagrid-core';
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/packages/react/src/__tests__/properties/getEndJumpCell.property.test.ts
+++ b/packages/react/src/__tests__/properties/getEndJumpCell.property.test.ts
@@ -10,8 +10,8 @@
  */
 import { describe, it } from 'vitest';
 import * as fc from 'fast-check';
-import { getEndJumpCell } from '@istracked/datagrid-core';
-import type { ColumnDef, CellAddress } from '@istracked/datagrid-core';
+import { getEndJumpCell } from '@iasbuilt/datagrid-core';
+import type { ColumnDef, CellAddress } from '@iasbuilt/datagrid-core';
 
 // ---------------------------------------------------------------------------
 // Arbitraries

--- a/packages/react/src/__tests__/properties/range-extend.property.test.ts
+++ b/packages/react/src/__tests__/properties/range-extend.property.test.ts
@@ -3,7 +3,7 @@
  * called out in the hardening plan (alongside the already-landed
  * `stripField.property.test.ts` and `getEndJumpCell.property.test.ts`).
  *
- * The grid models Shift+Arrow via two primitives in `@istracked/datagrid-core`:
+ * The grid models Shift+Arrow via two primitives in `@iasbuilt/datagrid-core`:
  *
  *   - `extendSelection(state, cell)` — sets `range.focus` to `cell`, keeping
  *     `range.anchor` fixed. This is the function called by the React
@@ -24,12 +24,12 @@ import {
   extendSelection,
   getNextCell,
   isCellInRange,
-} from '@istracked/datagrid-core';
+} from '@iasbuilt/datagrid-core';
 import type {
   ColumnDef,
   CellAddress,
   SelectionState,
-} from '@istracked/datagrid-core';
+} from '@iasbuilt/datagrid-core';
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/packages/react/src/__tests__/properties/stripField.property.test.ts
+++ b/packages/react/src/__tests__/properties/stripField.property.test.ts
@@ -7,12 +7,12 @@
  */
 import { describe, it } from 'vitest';
 import * as fc from 'fast-check';
-import { stripField } from '@istracked/datagrid-core';
+import { stripField } from '@iasbuilt/datagrid-core';
 import type {
   FilterDescriptor,
   CompositeFilterDescriptor,
   FilterOperator,
-} from '@istracked/datagrid-core';
+} from '@iasbuilt/datagrid-core';
 
 // ---------------------------------------------------------------------------
 // Arbitraries

--- a/packages/react/src/__tests__/public-api-exports.test.ts
+++ b/packages/react/src/__tests__/public-api-exports.test.ts
@@ -1,6 +1,6 @@
 /**
- * Guard test that pins the `@istracked/datagrid-react` public API contract
- * for the cell-editor hooks consumed by `@istracked/datagrid-mui`.
+ * Guard test that pins the `@iasbuilt/datagrid-react` public API contract
+ * for the cell-editor hooks consumed by `@iasbuilt/datagrid-mui`.
  *
  * The three named exports asserted below (`useDraftState`, `useSelectState`,
  * `useArrayState`) back every built-in and third-party cell renderer; moving
@@ -11,7 +11,7 @@
 import { describe, it, expect } from 'vitest';
 import * as publicApi from '../index';
 
-describe('@istracked/datagrid-react public hook exports', () => {
+describe('@iasbuilt/datagrid-react public hook exports', () => {
   it('exposes useDraftState as a named export', () => {
     expect(typeof publicApi.useDraftState).toBe('function');
   });

--- a/packages/react/src/__tests__/sub-grid-integration.test.tsx
+++ b/packages/react/src/__tests__/sub-grid-integration.test.tsx
@@ -4,7 +4,7 @@ import {
   GridModel,
   ColumnDef,
   GridConfig,
-} from '@istracked/datagrid-core';
+} from '@iasbuilt/datagrid-core';
 
 // ---------------------------------------------------------------------------
 // Fixtures

--- a/packages/react/src/__tests__/sub-grid-recursion.test.tsx
+++ b/packages/react/src/__tests__/sub-grid-recursion.test.tsx
@@ -17,7 +17,7 @@ import React from 'react';
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import { DataGrid } from '../DataGrid';
 import { cellRendererMap } from '../cells';
-import type { ColumnDef } from '@istracked/datagrid-core';
+import type { ColumnDef } from '@iasbuilt/datagrid-core';
 
 type Member = { id: string; name: string };
 type Team = { id: string; teamName: string; members: Member[] };

--- a/packages/react/src/__tests__/subgrid-aria-owns.test.tsx
+++ b/packages/react/src/__tests__/subgrid-aria-owns.test.tsx
@@ -13,7 +13,7 @@
 import { render, act, fireEvent } from '@testing-library/react';
 import { DataGrid } from '../DataGrid';
 import { cellRendererMap } from '../cells';
-import { ColumnDef } from '@istracked/datagrid-core';
+import { ColumnDef } from '@iasbuilt/datagrid-core';
 
 // ---------------------------------------------------------------------------
 // Fixtures

--- a/packages/react/src/__tests__/subgrid-scoped-events.test.tsx
+++ b/packages/react/src/__tests__/subgrid-scoped-events.test.tsx
@@ -21,7 +21,7 @@
 import React from 'react';
 import { render, act, fireEvent } from '@testing-library/react';
 import { DataGrid } from '../DataGrid';
-import { ColumnDef } from '@istracked/datagrid-core';
+import { ColumnDef } from '@iasbuilt/datagrid-core';
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -64,7 +64,7 @@ describe('Subgrid scoped keyboard events — outer role="grid" wrapper', () => {
     );
 
     const innerGrid = container.querySelector(
-      '.istracked-datagrid[role="grid"]',
+      '.iasbuilt-datagrid[role="grid"]',
     ) as HTMLElement;
     expect(innerGrid).not.toBeNull();
 
@@ -122,10 +122,10 @@ describe('Subgrid scoped keyboard events — outer role="grid" wrapper', () => {
     //
     // Actually — re-reading the findings more carefully: the bug is that
     // a toolbar/consumer wraps a DataGrid with role="grid". The keyboard handler
-    // for the DataGrid listens on `containerRef` (the `.istracked-datagrid` div).
+    // for the DataGrid listens on `containerRef` (the `.iasbuilt-datagrid` div).
     // When keydown fires, e.target is a cell inside the DataGrid.
     // e.target.closest('[role="grid"]') walks UP from the cell:
-    //   cell → row → body-div → .istracked-datagrid[role="grid"]  ← FOUND
+    //   cell → row → body-div → .iasbuilt-datagrid[role="grid"]  ← FOUND
     // This returns the DataGrid's own root. closestGrid === container → passes.
     //
     // So for simple consumer wrapping, the bug doesn't manifest. The bug only

--- a/packages/react/src/__tests__/subgrid-virtualization.test.tsx
+++ b/packages/react/src/__tests__/subgrid-virtualization.test.tsx
@@ -18,7 +18,7 @@ import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { DataGrid } from '../DataGrid';
 import { cellRendererMap } from '../cells';
-import { ColumnDef } from '@istracked/datagrid-core';
+import { ColumnDef } from '@iasbuilt/datagrid-core';
 
 // ---------------------------------------------------------------------------
 // Fixtures

--- a/packages/react/src/__tests__/theming.test.tsx
+++ b/packages/react/src/__tests__/theming.test.tsx
@@ -274,7 +274,7 @@ describe('Theming', () => {
   // ---------------------------------------------------------------------------
   // Token-driven palette (issue #17)
   //
-  // The light and dark presets are projections of the `istracked/tokens`
+  // The light and dark presets are projections of the `iasbuilt/tokens`
   // design-token tree; the grid must not carry its own hand-tuned colours.
   // These checks pin the row-background and header-background tokens to the
   // values ingested from `src/styles/tokens/{light,dark}.json`, so a future

--- a/packages/react/src/__tests__/transposed-grid.test.tsx
+++ b/packages/react/src/__tests__/transposed-grid.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, screen, within } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { TransposedGrid } from '../TransposedGrid';
-import type { TransposedField } from '@istracked/datagrid-core';
+import type { TransposedField } from '@iasbuilt/datagrid-core';
 
 describe('TransposedGrid', () => {
   const fields: TransposedField[] = [

--- a/packages/react/src/__tests__/undo-redo-integration.test.tsx
+++ b/packages/react/src/__tests__/undo-redo-integration.test.tsx
@@ -14,7 +14,7 @@ import {
   createRowInsertCommand,
   createRowDeleteCommand,
   UndoRedoState,
-} from '@istracked/datagrid-core';
+} from '@iasbuilt/datagrid-core';
 
 type TestRow = { id: string; name: string; age: number; city: string };
 

--- a/packages/react/src/__tests__/use-grid-store.test.ts
+++ b/packages/react/src/__tests__/use-grid-store.test.ts
@@ -1,6 +1,6 @@
 import { renderHook, act } from '@testing-library/react';
 import { vi } from 'vitest';
-import { createGridModel, GridModel, GridModelState } from '@istracked/datagrid-core';
+import { createGridModel, GridModel, GridModelState } from '@iasbuilt/datagrid-core';
 import { useGridStore, useGridSelector } from '../use-grid-store';
 
 // ---------------------------------------------------------------------------

--- a/packages/react/src/__tests__/validation-tooltip.test.tsx
+++ b/packages/react/src/__tests__/validation-tooltip.test.tsx
@@ -47,7 +47,7 @@ import {
   CellValue,
   ValidationResult,
   Validator,
-} from '@istracked/datagrid-core';
+} from '@iasbuilt/datagrid-core';
 
 // ---------------------------------------------------------------------------
 // Shared fixtures

--- a/packages/react/src/__tests__/validation.test.tsx
+++ b/packages/react/src/__tests__/validation.test.tsx
@@ -23,7 +23,7 @@ import {
   CellValue,
   ValidationResult,
   Validator,
-} from '@istracked/datagrid-core';
+} from '@iasbuilt/datagrid-core';
 
 // ---------------------------------------------------------------------------
 // Shared fixtures

--- a/packages/react/src/atomic-grid-model.ts
+++ b/packages/react/src/atomic-grid-model.ts
@@ -25,11 +25,11 @@ import type {
   FilterState,
   ColumnDef,
   ExtensionDefinition,
-} from '@istracked/datagrid-core';
-import { EventBus, PluginHost, getVisibleColumns, toggleRowSelection, createRowMoveCommand, pushCommand } from '@istracked/datagrid-core';
+} from '@iasbuilt/datagrid-core';
+import { EventBus, PluginHost, getVisibleColumns, toggleRowSelection, createRowMoveCommand, pushCommand } from '@iasbuilt/datagrid-core';
 import { createGridAtomSystem, type GridAtomSystem } from './atoms';
 import { createEventBridge } from './atoms/event-bridge';
-import type { GridModel, GridModelState } from '@istracked/datagrid-core';
+import type { GridModel, GridModelState } from '@iasbuilt/datagrid-core';
 
 /**
  * Type alias for the Jotai vanilla store instance returned by `createStore`.

--- a/packages/react/src/atoms/action-atoms.ts
+++ b/packages/react/src/atoms/action-atoms.ts
@@ -24,7 +24,7 @@ import type {
   FilterState,
   ColumnDef,
   RowKeyResolver,
-} from '@istracked/datagrid-core';
+} from '@iasbuilt/datagrid-core';
 import {
   applySorting,
   toggleSort,
@@ -50,7 +50,7 @@ import {
   undo as undoOp,
   redo as redoOp,
   type EventBus,
-} from '@istracked/datagrid-core';
+} from '@iasbuilt/datagrid-core';
 import type { BaseAtoms } from './base-atoms';
 import type { DerivedAtoms } from './derived-atoms';
 
@@ -179,7 +179,7 @@ export function createActionAtoms<TData extends Record<string, unknown>>(
 
       // Create a command that stores field/index/values for atom-aware undo/redo.
       // We attach metadata so the undoAtom can apply changes immutably.
-      const cmd: import('@istracked/datagrid-core').Command & { _atomMeta?: any } = {
+      const cmd: import('@iasbuilt/datagrid-core').Command & { _atomMeta?: any } = {
         type: 'cell:edit',
         timestamp: Date.now(),
         description: `Edit ${cell.field}`,
@@ -245,7 +245,7 @@ export function createActionAtoms<TData extends Record<string, unknown>>(
           newData[rowIndex] = newRow;
 
           // Record the edit command with _atomMeta for immutable undo/redo.
-          const cmd: import('@istracked/datagrid-core').Command & { _atomMeta?: any } = {
+          const cmd: import('@iasbuilt/datagrid-core').Command & { _atomMeta?: any } = {
             type: 'cell:edit',
             timestamp: Date.now(),
             description: `Edit ${result.cell.field}`,
@@ -299,7 +299,7 @@ export function createActionAtoms<TData extends Record<string, unknown>>(
 
       // Record the insertion with _atomMeta so undo can remove the row
       // and redo can re-insert it at the same position.
-      const cmd: import('@istracked/datagrid-core').Command & { _atomMeta?: any } = {
+      const cmd: import('@iasbuilt/datagrid-core').Command & { _atomMeta?: any } = {
         type: 'row:insert',
         timestamp: Date.now(),
         description: 'Insert row',
@@ -336,13 +336,13 @@ export function createActionAtoms<TData extends Record<string, unknown>>(
 
       let newData = [...data];
       let undoRedo = get(baseAtoms.undoRedoAtom);
-      const subcmds: (import('@istracked/datagrid-core').Command & { _atomMeta?: any })[] = [];
+      const subcmds: (import('@iasbuilt/datagrid-core').Command & { _atomMeta?: any })[] = [];
 
       // Process deletions one at a time (descending) to keep indices valid.
       for (const { index } of entries) {
         const row = newData[index];
         if (!row) continue;
-        const cmd: import('@istracked/datagrid-core').Command & { _atomMeta?: any } = {
+        const cmd: import('@iasbuilt/datagrid-core').Command & { _atomMeta?: any } = {
           type: 'row:delete',
           timestamp: Date.now(),
           description: 'Delete row',
@@ -578,7 +578,7 @@ export function createActionAtoms<TData extends Record<string, unknown>>(
   function applyCommandToData(
     get: (atom: any) => any,
     set: (atom: any, ...args: any[]) => void,
-    cmd: import('@istracked/datagrid-core').Command & { _atomMeta?: any },
+    cmd: import('@iasbuilt/datagrid-core').Command & { _atomMeta?: any },
     direction: 'undo' | 'redo',
   ) {
     const meta = cmd._atomMeta;
@@ -615,7 +615,7 @@ export function createActionAtoms<TData extends Record<string, unknown>>(
     } else if (meta?.kind === 'batch') {
       // Batch commands must be replayed in reverse order when undoing
       // so that index-sensitive operations (splices) remain valid.
-      const cmds = meta.commands as (import('@istracked/datagrid-core').Command & { _atomMeta?: any })[];
+      const cmds = meta.commands as (import('@iasbuilt/datagrid-core').Command & { _atomMeta?: any })[];
       const ordered = direction === 'undo' ? [...cmds].reverse() : cmds;
       for (const sub of ordered) applyCommandToData(get, set, sub, direction);
     } else {

--- a/packages/react/src/atoms/base-atoms.ts
+++ b/packages/react/src/atoms/base-atoms.ts
@@ -14,7 +14,7 @@ import type {
   FilterState,
   RowKeyResolver,
   GroupState,
-} from '@istracked/datagrid-core';
+} from '@iasbuilt/datagrid-core';
 import {
   createColumnState,
   type ColumnState,
@@ -25,7 +25,7 @@ import {
   createUndoRedoState,
   type UndoRedoState,
   createGroupState,
-} from '@istracked/datagrid-core';
+} from '@iasbuilt/datagrid-core';
 
 /**
  * Shape of the primitive atom bundle produced by {@link createGridAtoms}.

--- a/packages/react/src/atoms/derived-atoms.ts
+++ b/packages/react/src/atoms/derived-atoms.ts
@@ -8,8 +8,8 @@
  * @module derived-atoms
  */
 import { atom, type Atom } from 'jotai/vanilla';
-import type { ColumnDef, RowKeyResolver } from '@istracked/datagrid-core';
-import { applyFiltering, applySorting, getVisibleColumns } from '@istracked/datagrid-core';
+import type { ColumnDef, RowKeyResolver } from '@iasbuilt/datagrid-core';
+import { applyFiltering, applySorting, getVisibleColumns } from '@iasbuilt/datagrid-core';
 import type { BaseAtoms } from './base-atoms';
 
 /**

--- a/packages/react/src/atoms/event-bridge.ts
+++ b/packages/react/src/atoms/event-bridge.ts
@@ -11,7 +11,7 @@
  * @module event-bridge
  */
 import type { createStore, Atom } from 'jotai/vanilla';
-import type { GridEventType, EventBus } from '@istracked/datagrid-core';
+import type { GridEventType, EventBus } from '@iasbuilt/datagrid-core';
 import type { BaseAtoms } from './base-atoms';
 
 /**

--- a/packages/react/src/atoms/index.ts
+++ b/packages/react/src/atoms/index.ts
@@ -9,7 +9,7 @@
  *
  * @module atoms
  */
-import type { GridConfig, RowKeyResolver, EventBus } from '@istracked/datagrid-core';
+import type { GridConfig, RowKeyResolver, EventBus } from '@iasbuilt/datagrid-core';
 import { createGridAtoms, type BaseAtoms } from './base-atoms';
 import { createDerivedAtoms, type DerivedAtoms } from './derived-atoms';
 import { createActionAtoms, type ActionAtoms } from './action-atoms';

--- a/packages/react/src/body/DataGridBody.styles.ts
+++ b/packages/react/src/body/DataGridBody.styles.ts
@@ -13,7 +13,7 @@
  * rows, aggregate rows, data rows, row-number overrides, empty state).
  */
 import type { CSSProperties } from 'react';
-import type { RowOutlineSides } from '@istracked/datagrid-core';
+import type { RowOutlineSides } from '@iasbuilt/datagrid-core';
 
 // ---------------------------------------------------------------------------
 // Scrollable body
@@ -240,7 +240,7 @@ export const aggregateCell = (width: number): CSSProperties => ({
  * Per-row border override descriptor forwarded from
  * `chrome.getRowBorder`. Fields mirror the public
  * `RowBorderStyle` shape and are applied on top of the row's default border.
- * Kept private to this module so public API stays in `@istracked/datagrid-core`.
+ * Kept private to this module so public API stays in `@iasbuilt/datagrid-core`.
  */
 export interface RowBorderOverride {
   color?: string;

--- a/packages/react/src/body/DataGridBody.tsx
+++ b/packages/react/src/body/DataGridBody.tsx
@@ -52,7 +52,7 @@ import {
   truncateMiddle,
   truncateEnd,
   getDefaultOverflowPolicy,
-} from '@istracked/datagrid-core';
+} from '@iasbuilt/datagrid-core';
 import type {
   ControlsColumnConfig,
   RowNumberColumnConfig,
@@ -62,7 +62,7 @@ import type {
   ChromeRowResolverContext,
   OverflowPolicy,
   Density,
-} from '@istracked/datagrid-core';
+} from '@iasbuilt/datagrid-core';
 import { CellRendererProps } from '../DataGrid';
 import { ChromeControlsCell, ChromeRowNumberCell } from '../chrome';
 import { GhostRow } from '../GhostRow';

--- a/packages/react/src/cells/ActionsCell/ActionsCell.tsx
+++ b/packages/react/src/cells/ActionsCell/ActionsCell.tsx
@@ -10,7 +10,7 @@
  * @module ActionsCell
  */
 import React, { useState } from 'react';
-import type { CellValue, ColumnDef, StatusOption } from '@istracked/datagrid-core';
+import type { CellValue, ColumnDef, StatusOption } from '@iasbuilt/datagrid-core';
 import * as styles from './ActionsCell.styles';
 
 /**

--- a/packages/react/src/cells/ActionsCell/__tests__/ActionsCell.test.tsx
+++ b/packages/react/src/cells/ActionsCell/__tests__/ActionsCell.test.tsx
@@ -1,7 +1,7 @@
 import { vi } from 'vitest';
 import React from 'react';
 import { render, fireEvent, screen } from '@testing-library/react';
-import type { ColumnDef } from '@istracked/datagrid-core';
+import type { ColumnDef } from '@iasbuilt/datagrid-core';
 import { ActionsCell } from '../ActionsCell';
 
 // ---------------------------------------------------------------------------

--- a/packages/react/src/cells/BooleanSelectedCell/BooleanSelectedCell.tsx
+++ b/packages/react/src/cells/BooleanSelectedCell/BooleanSelectedCell.tsx
@@ -19,7 +19,7 @@
  * @packageDocumentation
  */
 import React from 'react';
-import type { CellValue, ColumnDef } from '@istracked/datagrid-core';
+import type { CellValue, ColumnDef } from '@iasbuilt/datagrid-core';
 import * as styles from './BooleanSelectedCell.styles';
 
 /** Label used when the underlying boolean is `true`. */

--- a/packages/react/src/cells/BooleanSelectedCell/__tests__/BooleanSelectedCell.test.tsx
+++ b/packages/react/src/cells/BooleanSelectedCell/__tests__/BooleanSelectedCell.test.tsx
@@ -1,7 +1,7 @@
 import { vi } from 'vitest';
 import React from 'react';
 import { render, fireEvent, screen } from '@testing-library/react';
-import type { ColumnDef } from '@istracked/datagrid-core';
+import type { ColumnDef } from '@iasbuilt/datagrid-core';
 import {
   BooleanSelectedCell,
   SELECTED_LABEL,

--- a/packages/react/src/cells/CalendarCell/CalendarCell.tsx
+++ b/packages/react/src/cells/CalendarCell/CalendarCell.tsx
@@ -10,7 +10,7 @@
  * @packageDocumentation
  */
 import React, { useState, useRef, useEffect } from 'react';
-import type { CellValue, ColumnDef } from '@istracked/datagrid-core';
+import type { CellValue, ColumnDef } from '@iasbuilt/datagrid-core';
 import * as styles from './CalendarCell.styles';
 
 /**

--- a/packages/react/src/cells/CalendarCell/__tests__/CalendarCell.test.tsx
+++ b/packages/react/src/cells/CalendarCell/__tests__/CalendarCell.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import React from 'react';
 
 import { CalendarCell } from '../CalendarCell';
-import type { ColumnDef, CellValue } from '@istracked/datagrid-core';
+import type { ColumnDef, CellValue } from '@iasbuilt/datagrid-core';
 
 // ---------------------------------------------------------------------------
 // Shared helpers

--- a/packages/react/src/cells/CheckboxCell/CheckboxCell.tsx
+++ b/packages/react/src/cells/CheckboxCell/CheckboxCell.tsx
@@ -11,7 +11,7 @@
  * @packageDocumentation
  */
 import React from 'react';
-import type { CellValue, ColumnDef } from '@istracked/datagrid-core';
+import type { CellValue, ColumnDef } from '@iasbuilt/datagrid-core';
 import * as styles from './CheckboxCell.styles';
 
 /**

--- a/packages/react/src/cells/CheckboxCell/__tests__/CheckboxCell.test.tsx
+++ b/packages/react/src/cells/CheckboxCell/__tests__/CheckboxCell.test.tsx
@@ -1,7 +1,7 @@
 import { vi } from 'vitest';
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
-import type { ColumnDef } from '@istracked/datagrid-core';
+import type { ColumnDef } from '@iasbuilt/datagrid-core';
 import { CheckboxCell } from '../CheckboxCell';
 
 // ---------------------------------------------------------------------------

--- a/packages/react/src/cells/ChipSelectCell/ChipSelectCell.tsx
+++ b/packages/react/src/cells/ChipSelectCell/ChipSelectCell.tsx
@@ -8,7 +8,7 @@
  * @module ChipSelectCell
  */
 import React, { useState, useRef, useEffect } from 'react';
-import type { CellValue, ColumnDef } from '@istracked/datagrid-core';
+import type { CellValue, ColumnDef } from '@iasbuilt/datagrid-core';
 import * as styles from './ChipSelectCell.styles';
 
 /**

--- a/packages/react/src/cells/ChipSelectCell/__tests__/ChipSelectCell.test.tsx
+++ b/packages/react/src/cells/ChipSelectCell/__tests__/ChipSelectCell.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import React from 'react';
 
 import { ChipSelectCell } from '../ChipSelectCell';
-import type { ColumnDef, CellValue } from '@istracked/datagrid-core';
+import type { ColumnDef, CellValue } from '@iasbuilt/datagrid-core';
 
 // ---------------------------------------------------------------------------
 // Shared helpers

--- a/packages/react/src/cells/CompoundChipListCell/CompoundChipListCell.tsx
+++ b/packages/react/src/cells/CompoundChipListCell/CompoundChipListCell.tsx
@@ -9,7 +9,7 @@
  * @module CompoundChipListCell
  */
 import React, { useState, useEffect } from 'react';
-import type { CellValue, ColumnDef } from '@istracked/datagrid-core';
+import type { CellValue, ColumnDef } from '@iasbuilt/datagrid-core';
 import * as styles from './CompoundChipListCell.styles';
 
 /**

--- a/packages/react/src/cells/CompoundChipListCell/__tests__/CompoundChipListCell.test.tsx
+++ b/packages/react/src/cells/CompoundChipListCell/__tests__/CompoundChipListCell.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import React from 'react';
 
 import { CompoundChipListCell } from '../CompoundChipListCell';
-import type { ColumnDef, CellValue } from '@istracked/datagrid-core';
+import type { ColumnDef, CellValue } from '@iasbuilt/datagrid-core';
 
 // ---------------------------------------------------------------------------
 // Shared helpers

--- a/packages/react/src/cells/CurrencyCell/CurrencyCell.tsx
+++ b/packages/react/src/cells/CurrencyCell/CurrencyCell.tsx
@@ -9,7 +9,7 @@
  * @packageDocumentation
  */
 import React, { useState, useRef, useEffect } from 'react';
-import type { CellValue, ColumnDef } from '@istracked/datagrid-core';
+import type { CellValue, ColumnDef } from '@iasbuilt/datagrid-core';
 import * as styles from './CurrencyCell.styles';
 
 /**

--- a/packages/react/src/cells/CurrencyCell/__tests__/CurrencyCell.test.tsx
+++ b/packages/react/src/cells/CurrencyCell/__tests__/CurrencyCell.test.tsx
@@ -1,7 +1,7 @@
 import { vi } from 'vitest';
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
-import type { ColumnDef } from '@istracked/datagrid-core';
+import type { ColumnDef } from '@iasbuilt/datagrid-core';
 import { CurrencyCell } from '../CurrencyCell';
 
 // ---------------------------------------------------------------------------

--- a/packages/react/src/cells/ListCell/ListCell.tsx
+++ b/packages/react/src/cells/ListCell/ListCell.tsx
@@ -8,7 +8,7 @@
  * @module ListCell
  */
 import React, { useState, useRef, useEffect } from 'react';
-import type { CellValue, ColumnDef } from '@istracked/datagrid-core';
+import type { CellValue, ColumnDef } from '@iasbuilt/datagrid-core';
 import * as styles from './ListCell.styles';
 
 /**

--- a/packages/react/src/cells/ListCell/__tests__/ListCell.test.tsx
+++ b/packages/react/src/cells/ListCell/__tests__/ListCell.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import React from 'react';
 
 import { ListCell } from '../ListCell';
-import type { ColumnDef, CellValue } from '@istracked/datagrid-core';
+import type { ColumnDef, CellValue } from '@iasbuilt/datagrid-core';
 
 // ---------------------------------------------------------------------------
 // Shared helpers

--- a/packages/react/src/cells/NumericCell/NumericCell.tsx
+++ b/packages/react/src/cells/NumericCell/NumericCell.tsx
@@ -9,7 +9,7 @@
  * @packageDocumentation
  */
 import React, { useState, useRef, useEffect } from 'react';
-import type { CellValue, ColumnDef } from '@istracked/datagrid-core';
+import type { CellValue, ColumnDef } from '@iasbuilt/datagrid-core';
 import * as styles from './NumericCell.styles';
 
 /**

--- a/packages/react/src/cells/NumericCell/__tests__/NumericCell.test.tsx
+++ b/packages/react/src/cells/NumericCell/__tests__/NumericCell.test.tsx
@@ -1,7 +1,7 @@
 import { vi } from 'vitest';
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
-import type { ColumnDef } from '@istracked/datagrid-core';
+import type { ColumnDef } from '@iasbuilt/datagrid-core';
 import { NumericCell } from '../NumericCell';
 
 // ---------------------------------------------------------------------------

--- a/packages/react/src/cells/PasswordCell/PasswordCell.tsx
+++ b/packages/react/src/cells/PasswordCell/PasswordCell.tsx
@@ -9,7 +9,7 @@
  * @packageDocumentation
  */
 import React, { useState, useRef, useEffect } from 'react';
-import type { CellValue, ColumnDef } from '@istracked/datagrid-core';
+import type { CellValue, ColumnDef } from '@iasbuilt/datagrid-core';
 import { usePasswordInput } from '../hooks/usePasswordInput';
 import * as styles from './PasswordCell.styles';
 

--- a/packages/react/src/cells/PasswordCell/__tests__/PasswordCell.test.tsx
+++ b/packages/react/src/cells/PasswordCell/__tests__/PasswordCell.test.tsx
@@ -1,7 +1,7 @@
 import { vi } from 'vitest';
 import React from 'react';
 import { render, fireEvent, screen } from '@testing-library/react';
-import type { ColumnDef } from '@istracked/datagrid-core';
+import type { ColumnDef } from '@iasbuilt/datagrid-core';
 import { PasswordCell } from '../PasswordCell';
 
 // ---------------------------------------------------------------------------

--- a/packages/react/src/cells/PasswordConfirmCell/PasswordConfirmCell.tsx
+++ b/packages/react/src/cells/PasswordConfirmCell/PasswordConfirmCell.tsx
@@ -24,7 +24,7 @@
  * @packageDocumentation
  */
 import React, { useState, useRef, useEffect } from 'react';
-import type { CellValue, ColumnDef } from '@istracked/datagrid-core';
+import type { CellValue, ColumnDef } from '@iasbuilt/datagrid-core';
 import { usePasswordInput } from '../hooks/usePasswordInput';
 import * as styles from './PasswordConfirmCell.styles';
 

--- a/packages/react/src/cells/PasswordConfirmCell/__tests__/PasswordConfirmCell.test.tsx
+++ b/packages/react/src/cells/PasswordConfirmCell/__tests__/PasswordConfirmCell.test.tsx
@@ -1,7 +1,7 @@
 import { vi } from 'vitest';
 import React from 'react';
 import { render, fireEvent, screen } from '@testing-library/react';
-import type { ColumnDef } from '@istracked/datagrid-core';
+import type { ColumnDef } from '@iasbuilt/datagrid-core';
 import { PasswordConfirmCell, MISMATCH_MESSAGE } from '../PasswordConfirmCell';
 
 // ---------------------------------------------------------------------------

--- a/packages/react/src/cells/RichTextCell/RichTextCell.tsx
+++ b/packages/react/src/cells/RichTextCell/RichTextCell.tsx
@@ -31,7 +31,7 @@ import React, {
 import { createPortal } from 'react-dom';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import type { CellValue, ColumnDef } from '@istracked/datagrid-core';
+import type { CellValue, ColumnDef } from '@iasbuilt/datagrid-core';
 import * as styles from './RichTextCell.styles';
 
 /**

--- a/packages/react/src/cells/RichTextCell/__tests__/RichTextCell.test.tsx
+++ b/packages/react/src/cells/RichTextCell/__tests__/RichTextCell.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, fireEvent, within } from '@testing-library/react';
 import React from 'react';
 
 import { RichTextCell } from '../RichTextCell';
-import type { ColumnDef, CellValue } from '@istracked/datagrid-core';
+import type { ColumnDef, CellValue } from '@iasbuilt/datagrid-core';
 
 // ---------------------------------------------------------------------------
 // Shared helpers

--- a/packages/react/src/cells/RichTextCell/__tests__/floating-menu.test.tsx
+++ b/packages/react/src/cells/RichTextCell/__tests__/floating-menu.test.tsx
@@ -37,7 +37,7 @@ import { render, screen } from '@testing-library/react';
 import React from 'react';
 
 import { RichTextCell } from '../RichTextCell';
-import type { ColumnDef, CellValue } from '@istracked/datagrid-core';
+import type { ColumnDef, CellValue } from '@iasbuilt/datagrid-core';
 
 // ---------------------------------------------------------------------------
 // Shared helpers (aligned with `RichTextCell.test.tsx`)

--- a/packages/react/src/cells/RichTextCell/__tests__/show-formatting-toggle.test.tsx
+++ b/packages/react/src/cells/RichTextCell/__tests__/show-formatting-toggle.test.tsx
@@ -28,7 +28,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import React from 'react';
 
 import { RichTextCell } from '../RichTextCell';
-import type { ColumnDef, CellValue } from '@istracked/datagrid-core';
+import type { ColumnDef, CellValue } from '@iasbuilt/datagrid-core';
 
 // ---------------------------------------------------------------------------
 // Shared helpers (aligned with `RichTextCell.test.tsx`)

--- a/packages/react/src/cells/StatusCell/StatusCell.tsx
+++ b/packages/react/src/cells/StatusCell/StatusCell.tsx
@@ -10,7 +10,7 @@
  * @packageDocumentation
  */
 import React, { useState, useRef, useEffect } from 'react';
-import type { CellValue, ColumnDef, StatusOption } from '@istracked/datagrid-core';
+import type { CellValue, ColumnDef, StatusOption } from '@iasbuilt/datagrid-core';
 import * as styles from './StatusCell.styles';
 
 /**

--- a/packages/react/src/cells/StatusCell/__tests__/StatusCell.test.tsx
+++ b/packages/react/src/cells/StatusCell/__tests__/StatusCell.test.tsx
@@ -1,7 +1,7 @@
 import { vi } from 'vitest';
 import React from 'react';
 import { render, fireEvent, screen } from '@testing-library/react';
-import type { ColumnDef } from '@istracked/datagrid-core';
+import type { ColumnDef } from '@iasbuilt/datagrid-core';
 import { StatusCell } from '../StatusCell';
 
 // ---------------------------------------------------------------------------

--- a/packages/react/src/cells/SubGridCell/SubGridCell.tsx
+++ b/packages/react/src/cells/SubGridCell/SubGridCell.tsx
@@ -20,7 +20,7 @@
  * @module SubGridCell
  */
 import React, { useContext, useSyncExternalStore, useCallback } from 'react';
-import type { CellValue } from '@istracked/datagrid-core';
+import type { CellValue } from '@iasbuilt/datagrid-core';
 import { GridContext } from '../../context';
 import * as styles from './SubGridCell.styles';
 

--- a/packages/react/src/cells/SubGridCell/__tests__/SubGridCell.test.tsx
+++ b/packages/react/src/cells/SubGridCell/__tests__/SubGridCell.test.tsx
@@ -4,8 +4,8 @@ import React from 'react';
 
 import { SubGridCell } from '../SubGridCell';
 import { GridContext } from '../../../context';
-import { createGridModel } from '@istracked/datagrid-core';
-import type { ColumnDef, CellValue } from '@istracked/datagrid-core';
+import { createGridModel } from '@iasbuilt/datagrid-core';
+import type { ColumnDef, CellValue } from '@iasbuilt/datagrid-core';
 
 // ---------------------------------------------------------------------------
 // Shared helpers

--- a/packages/react/src/cells/TagsCell/TagsCell.tsx
+++ b/packages/react/src/cells/TagsCell/TagsCell.tsx
@@ -9,7 +9,7 @@
  * @module TagsCell
  */
 import React, { useState, useRef, useEffect } from 'react';
-import type { CellValue, ColumnDef } from '@istracked/datagrid-core';
+import type { CellValue, ColumnDef } from '@iasbuilt/datagrid-core';
 import * as styles from './TagsCell.styles';
 
 /**

--- a/packages/react/src/cells/TagsCell/__tests__/TagsCell.test.tsx
+++ b/packages/react/src/cells/TagsCell/__tests__/TagsCell.test.tsx
@@ -1,7 +1,7 @@
 import { vi } from 'vitest';
 import React from 'react';
 import { render, fireEvent, screen } from '@testing-library/react';
-import type { ColumnDef } from '@istracked/datagrid-core';
+import type { ColumnDef } from '@iasbuilt/datagrid-core';
 import { TagsCell } from '../TagsCell';
 
 // ---------------------------------------------------------------------------

--- a/packages/react/src/cells/TextCell/TextCell.tsx
+++ b/packages/react/src/cells/TextCell/TextCell.tsx
@@ -9,7 +9,7 @@
  * @packageDocumentation
  */
 import React, { useState, useRef, useEffect } from 'react';
-import type { CellValue, ColumnDef } from '@istracked/datagrid-core';
+import type { CellValue, ColumnDef } from '@iasbuilt/datagrid-core';
 import * as styles from './TextCell.styles';
 
 /**

--- a/packages/react/src/cells/TextCell/__tests__/TextCell.test.tsx
+++ b/packages/react/src/cells/TextCell/__tests__/TextCell.test.tsx
@@ -1,7 +1,7 @@
 import { vi } from 'vitest';
 import React from 'react';
 import { render, fireEvent, screen } from '@testing-library/react';
-import type { ColumnDef } from '@istracked/datagrid-core';
+import type { ColumnDef } from '@iasbuilt/datagrid-core';
 import { TextCell } from '../TextCell';
 
 // ---------------------------------------------------------------------------

--- a/packages/react/src/cells/UploadCell/UploadCell.tsx
+++ b/packages/react/src/cells/UploadCell/UploadCell.tsx
@@ -9,7 +9,7 @@
  * @module UploadCell
  */
 import React, { useState, useRef } from 'react';
-import type { CellValue, ColumnDef } from '@istracked/datagrid-core';
+import type { CellValue, ColumnDef } from '@iasbuilt/datagrid-core';
 import * as styles from './UploadCell.styles';
 
 /**

--- a/packages/react/src/cells/UploadCell/__tests__/UploadCell.test.tsx
+++ b/packages/react/src/cells/UploadCell/__tests__/UploadCell.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import React from 'react';
 
 import { UploadCell } from '../UploadCell';
-import type { ColumnDef, CellValue } from '@istracked/datagrid-core';
+import type { ColumnDef, CellValue } from '@iasbuilt/datagrid-core';
 
 // ---------------------------------------------------------------------------
 // Shared helpers

--- a/packages/react/src/chrome/ChromeControlsCell.tsx
+++ b/packages/react/src/chrome/ChromeControlsCell.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { CSSProperties } from 'react';
-import type { ControlAction } from '@istracked/datagrid-core';
+import type { ControlAction } from '@iasbuilt/datagrid-core';
 import * as styles from './ChromeColumn.styles';
 
 export interface ChromeControlsCellProps {

--- a/packages/react/src/context.ts
+++ b/packages/react/src/context.ts
@@ -11,7 +11,7 @@
  * @module context
  */
 import { createContext, useContext } from 'react';
-import type { GridModel } from '@istracked/datagrid-core';
+import type { GridModel } from '@iasbuilt/datagrid-core';
 import type { AtomicStore } from './atomic-grid-model';
 import type { GridAtomSystem } from './atoms';
 
@@ -25,7 +25,7 @@ import type { GridAtomSystem } from './atoms';
  * @typeParam TData - Row data shape; defaults to a generic record.
  */
 export interface GridContextValue<TData = Record<string, unknown>> {
-  /** Core imperative grid model from `@istracked/datagrid-core`. */
+  /** Core imperative grid model from `@iasbuilt/datagrid-core`. */
   model: GridModel<TData>;
   /** Atomic store backing fine-grained React subscriptions. */
   store: AtomicStore;

--- a/packages/react/src/header/DataGridColumnGroupHeader.tsx
+++ b/packages/react/src/header/DataGridColumnGroupHeader.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import type { ColumnDef, ColumnGroupConfig } from '@istracked/datagrid-core';
+import type { ColumnDef, ColumnGroupConfig } from '@iasbuilt/datagrid-core';
 import type { ColumnGroupDragState } from '../state';
 import * as styles from './DataGridColumnGroupHeader.styles';
 

--- a/packages/react/src/header/DataGridHeader.tsx
+++ b/packages/react/src/header/DataGridHeader.tsx
@@ -12,7 +12,7 @@
  * lockstep.
  */
 import React, { useCallback, useRef, useState } from 'react';
-import type { ColumnDef, SortState, ControlsColumnConfig, RowNumberColumnConfig } from '@istracked/datagrid-core';
+import type { ColumnDef, SortState, ControlsColumnConfig, RowNumberColumnConfig } from '@iasbuilt/datagrid-core';
 import type { ColumnDragState } from '../state';
 import { ChromeControlsHeaderCell, ChromeRowNumberHeaderCell } from '../chrome';
 import * as styles from './DataGridHeader.styles';

--- a/packages/react/src/header/column-filter-menu/FilterConditionDialog.tsx
+++ b/packages/react/src/header/column-filter-menu/FilterConditionDialog.tsx
@@ -30,7 +30,7 @@
  */
 import React, { useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
-import type { FilterDescriptor, FilterOperator, CompositeFilterDescriptor } from '@istracked/datagrid-core';
+import type { FilterDescriptor, FilterOperator, CompositeFilterDescriptor } from '@iasbuilt/datagrid-core';
 import * as styles from './FilterConditionDialog.styles';
 
 // ---------------------------------------------------------------------------

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -1,9 +1,9 @@
 /**
  * Barrel file for the `hooks/` directory.
  *
- * Collects the React hooks exposed by `@istracked/datagrid-react` so
+ * Collects the React hooks exposed by `@iasbuilt/datagrid-react` so
  * application code and downstream components can import them from
- * `@istracked/datagrid-react/hooks` without reaching into internal paths.
+ * `@iasbuilt/datagrid-react/hooks` without reaching into internal paths.
  * Each hook adapts a framework-agnostic core subsystem (event bus, search
  * index, etc.) into a React-friendly stateful API.
  */

--- a/packages/react/src/hooks/use-background-indexer.ts
+++ b/packages/react/src/hooks/use-background-indexer.ts
@@ -28,7 +28,7 @@
  * Inject-for-test seams: both `buildIndex` and `openAdapter` can be
  * supplied through options. Production callers leave them undefined; the
  * hook lazily `await import(...)`s the real implementations from
- * `@istracked/datagrid-core` only when needed, which keeps the core
+ * `@iasbuilt/datagrid-core` only when needed, which keeps the core
  * bundle out of consumers that fully inject their own builder/adapter.
  *
  * Invariants worth preserving on any refactor:
@@ -61,7 +61,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 /**
  * Minimal structural shape of a built column index payload.
  *
- * The upstream `@istracked/datagrid-core/search-index/column-index` module
+ * The upstream `@iasbuilt/datagrid-core/search-index/column-index` module
  * may expose a richer type; this hook only depends on the fields shown
  * here. Declaring a narrow structural contract keeps the hook usable even
  * when the core package ships a superset of this interface.
@@ -207,7 +207,7 @@ async function defaultBuildIndex(): Promise<
     field: string,
   ) => ColumnSearchIndex
 > {
-  const mod = (await import('@istracked/datagrid-core').catch(() => null)) as
+  const mod = (await import('@iasbuilt/datagrid-core').catch(() => null)) as
     | { buildColumnIndex?: unknown }
     | null;
   if (mod && typeof mod.buildColumnIndex === 'function') {
@@ -218,7 +218,7 @@ async function defaultBuildIndex(): Promise<
     ) => ColumnSearchIndex;
   }
   throw new Error(
-    'useBackgroundIndexer: buildColumnIndex is not exported from @istracked/datagrid-core. ' +
+    'useBackgroundIndexer: buildColumnIndex is not exported from @iasbuilt/datagrid-core. ' +
       'Pass a `buildIndex` injector via options.',
   );
 }
@@ -233,14 +233,14 @@ async function defaultBuildIndex(): Promise<
  * @returns Resolved {@link IdbAdapter} instance.
  */
 async function defaultOpenAdapter(): Promise<IdbAdapter> {
-  const mod = (await import('@istracked/datagrid-core').catch(() => null)) as
+  const mod = (await import('@iasbuilt/datagrid-core').catch(() => null)) as
     | { openIdbAdapter?: () => Promise<IdbAdapter> }
     | null;
   if (mod && typeof mod.openIdbAdapter === 'function') {
     return mod.openIdbAdapter();
   }
   throw new Error(
-    'useBackgroundIndexer: openIdbAdapter is not exported from @istracked/datagrid-core. ' +
+    'useBackgroundIndexer: openIdbAdapter is not exported from @iasbuilt/datagrid-core. ' +
       'Pass an `openAdapter` injector via options.',
   );
 }

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * Public API barrel file for the `@istracked/datagrid-react` package.
+ * Public API barrel file for the `@iasbuilt/datagrid-react` package.
  *
  * Re-exports all user-facing components, hooks, factory functions, type
  * aliases, and slot components so consumers can import everything from

--- a/packages/react/src/styles/datagrid-theme.css
+++ b/packages/react/src/styles/datagrid-theme.css
@@ -2,7 +2,7 @@
  * Declarative theme layer for the datagrid.
  *
  * Colour values in this file mirror the palette exposed by the
- * `istracked/tokens` repository — the organisation-wide source of truth —
+ * `iasbuilt/tokens` repository — the organisation-wide source of truth —
  * as ingested into `./tokens/{light,dark}.json` by `scripts/sync-tokens.mjs`.
  * If these values drift from the JSON snapshot it is almost certainly because
  * the sync script needs to be re-run after a tokens-repo upgrade.
@@ -17,8 +17,8 @@
 @import url('./excel-365-theme.css');
 
 /* Light theme — values mirror tokens/light.json (color.datagrid.*) */
-.istracked-datagrid[data-theme="light"],
-.istracked-datagrid.dg-theme-light {
+.iasbuilt-datagrid[data-theme="light"],
+.iasbuilt-datagrid.dg-theme-light {
   --dg-primary-color: #3B82F6;
   --dg-bg-color: #FFFFFF;
   --dg-text-color: #0F172A;
@@ -60,12 +60,12 @@
  * `--dg-row-bg-alt` and fell back to hard-coded light values. That is the
  * root cause of issue #17's "row bg unchanged" bug.
  */
-.istracked-datagrid[data-theme="dark"],
-.istracked-datagrid.dg-theme-dark,
+.iasbuilt-datagrid[data-theme="dark"],
+.iasbuilt-datagrid.dg-theme-dark,
 /* Allow an ancestor (html/body) `data-theme="dark"` to cascade into an
  * otherwise-unthemed grid instance. This lets a host app toggle dark mode at
  * the document level without threading `theme="dark"` through every grid. */
-[data-theme="dark"] .istracked-datagrid:not([data-theme="light"]):not(.dg-theme-light) {
+[data-theme="dark"] .iasbuilt-datagrid:not([data-theme="light"]):not(.dg-theme-light) {
   --dg-primary-color: #62A0EA;
   --dg-bg-color: #0F172A;
   --dg-text-color: #F1F5F9;
@@ -103,7 +103,7 @@
  * resting header, in dark mode one step brighter. `!important` is needed
  * because the header cell factory already sets `background` inline via
  * `CSSProperties`, which would otherwise win over plain stylesheet rules. */
-.istracked-datagrid[data-row-selected="true"] [role="columnheader"] {
+.iasbuilt-datagrid[data-row-selected="true"] [role="columnheader"] {
   background: var(--dg-header-selected-bg, #CBD5E1) !important;
 }
 

--- a/packages/react/src/styles/datagrid.css
+++ b/packages/react/src/styles/datagrid.css
@@ -1,5 +1,5 @@
 /* Base styles using CSS custom properties */
-.istracked-datagrid {
+.iasbuilt-datagrid {
   --dg-primary-color: #3b82f6;
   --dg-bg-color: #ffffff;
   --dg-text-color: #1e293b;

--- a/packages/react/src/styles/excel-365-theme.css
+++ b/packages/react/src/styles/excel-365-theme.css
@@ -9,8 +9,8 @@
 
 /* Scoped opt-in variant — applies Excel tokens under an explicit class */
 .dg-theme-excel365,
-.istracked-datagrid.dg-theme-excel365,
-.istracked-datagrid[data-theme="excel365"] {
+.iasbuilt-datagrid.dg-theme-excel365,
+.iasbuilt-datagrid[data-theme="excel365"] {
   --dg-font-family: "Segoe UI", "Calibri", system-ui, -apple-system, sans-serif;
   --dg-font-size: 12px;
   --dg-font-size-header: 12px;

--- a/packages/react/src/styles/tokens/index.ts
+++ b/packages/react/src/styles/tokens/index.ts
@@ -2,7 +2,7 @@
  * Theme-token ingestion for the datagrid.
  *
  * The organisation-wide source of truth for the iAsBuilt palette lives in the
- * `istracked/tokens` repository. `scripts/sync-tokens.mjs` copies the built
+ * `iasbuilt/tokens` repository. `scripts/sync-tokens.mjs` copies the built
  * JSON artefacts from that repository into this directory; this module then
  * projects the relevant leaves of the W3C-design-token tree onto the
  * `--dg-*` CSS custom properties that the grid's inline styles and
@@ -52,7 +52,7 @@ function resolveToken(tree: TokenTree, path: string): string {
     const next: TokenLeaf | TokenTree | undefined = cursor[part];
     if (next === undefined) {
       throw new Error(`Token path "${path}" is not present in the ingested tokens. ` +
-        `Re-run scripts/sync-tokens.mjs from an up-to-date istracked/tokens checkout.`);
+        `Re-run scripts/sync-tokens.mjs from an up-to-date iasbuilt/tokens checkout.`);
     }
     cursor = next;
   }

--- a/packages/react/src/styles/tokens/manifest.json
+++ b/packages/react/src/styles/tokens/manifest.json
@@ -1,5 +1,5 @@
 {
-  "source": "/Volumes/MacIntosh HD 1/Users/rom-old/workspace/istracked/tokens",
+  "source": "/Volumes/MacIntosh HD 1/Users/rom-old/workspace/iasbuilt/tokens",
   "syncedAt": "2026-04-19T02:32:52.294Z",
   "files": [
     "light.json",

--- a/packages/react/src/toolbar/DataGridToolbar.tsx
+++ b/packages/react/src/toolbar/DataGridToolbar.tsx
@@ -1,4 +1,4 @@
-import type { ColumnDef, RowGroupConfig, RowGroup } from '@istracked/datagrid-core';
+import type { ColumnDef, RowGroupConfig, RowGroup } from '@iasbuilt/datagrid-core';
 import type { MenuState } from '../state';
 import * as styles from './DataGridToolbar.styles';
 

--- a/packages/react/src/use-drag-drop.ts
+++ b/packages/react/src/use-drag-drop.ts
@@ -11,7 +11,7 @@
  * @module use-drag-drop
  */
 import { useCallback, useRef, useState } from 'react';
-import { GridModel, FileDropConfig, DropTarget } from '@istracked/datagrid-core';
+import { GridModel, FileDropConfig, DropTarget } from '@iasbuilt/datagrid-core';
 
 /**
  * Reactive state exposed by the {@link useDragDrop} hook, representing the

--- a/packages/react/src/use-grid-store.ts
+++ b/packages/react/src/use-grid-store.ts
@@ -12,7 +12,7 @@
  * @module use-grid-store
  */
 import { useSyncExternalStore, useCallback, useRef } from 'react';
-import { GridModel, GridModelState } from '@istracked/datagrid-core';
+import { GridModel, GridModelState } from '@iasbuilt/datagrid-core';
 
 /**
  * Subscribes to a {@link GridModel} and returns the full state snapshot on

--- a/packages/react/src/use-grid.ts
+++ b/packages/react/src/use-grid.ts
@@ -13,8 +13,8 @@
  * @module use-grid
  */
 import { useMemo, useRef, useEffect } from 'react';
-import type { GridConfig, GridModel } from '@istracked/datagrid-core';
-import { createColumnState } from '@istracked/datagrid-core';
+import type { GridConfig, GridModel } from '@iasbuilt/datagrid-core';
+import { createColumnState } from '@iasbuilt/datagrid-core';
 import { createAtomicGridModel, type AtomicGridBundle, type AtomicStore } from './atomic-grid-model';
 import type { GridAtomSystem } from './atoms';
 

--- a/packages/react/src/use-keyboard.ts
+++ b/packages/react/src/use-keyboard.ts
@@ -27,7 +27,7 @@ import {
   serializeRangeToText,
   serializeRangeToHtml,
   parseTextToGrid,
-} from '@istracked/datagrid-core';
+} from '@iasbuilt/datagrid-core';
 
 /**
  * Binds keyboard navigation and editing shortcuts to a grid container element.
@@ -94,16 +94,16 @@ export function useKeyboard<TData extends Record<string, unknown>>(
       if (!container.contains(e.target)) return;
 
       // If the target is inside this container but also inside a proper
-      // nested DataGrid instance (identified by the `istracked-datagrid`
+      // nested DataGrid instance (identified by the `iasbuilt-datagrid`
       // class on the nested grid root), defer to that grid's own handler.
       // We walk from the target upward and stop at container. Using the
-      // `istracked-datagrid` class rather than `role="grid"` avoids false
+      // `iasbuilt-datagrid` class rather than `role="grid"` avoids false
       // positives from consumer elements that happen to carry `role="grid"`
       // (e.g. accessibility wrappers, toolbar composites) which have no
       // DataGrid keyboard handler attached to them.
       let el: Element | null = e.target;
       while (el && el !== container) {
-        if (el.classList.contains('istracked-datagrid')) {
+        if (el.classList.contains('iasbuilt-datagrid')) {
           // Target is inside a nested DataGrid — defer.
           return;
         }

--- a/packages/react/src/use-virtualization.ts
+++ b/packages/react/src/use-virtualization.ts
@@ -13,7 +13,7 @@
  * @module use-virtualization
  */
 import { useState, useCallback, useEffect } from 'react';
-import { calculateVisibleRows, calculateVisibleColumns, VirtualRange } from '@istracked/datagrid-core';
+import { calculateVisibleRows, calculateVisibleColumns, VirtualRange } from '@iasbuilt/datagrid-core';
 
 /**
  * Snapshot of the current virtualization window, including the visible row

--- a/packages/react/tsconfig.build.json
+++ b/packages/react/tsconfig.build.json
@@ -6,7 +6,7 @@
     "outDir": "./dist",
     "rootDir": "./src",
     "paths": {
-      "@istracked/datagrid-core": ["../core/src/index.ts"]
+      "@iasbuilt/datagrid-core": ["../core/src/index.ts"]
     }
   },
   "include": ["src", "src/**/*.json"],

--- a/packages/react/tsup.config.ts
+++ b/packages/react/tsup.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   clean: true,
   treeshake: true,
   splitting: false,
-  external: ['react', 'react-dom', '@istracked/datagrid-core'],
+  external: ['react', 'react-dom', '@iasbuilt/datagrid-core'],
   esbuildOptions(options) {
     options.jsx = 'automatic';
   },

--- a/playground/data/index.ts
+++ b/playground/data/index.ts
@@ -17,7 +17,7 @@ export type { Employee, Order } from '../../stories/data';
 // Cell Showcase — covers all 15 cell types in one grid
 // ---------------------------------------------------------------------------
 
-import type { ColumnDef, StatusOption } from '@istracked/datagrid-core';
+import type { ColumnDef, StatusOption } from '@iasbuilt/datagrid-core';
 
 export interface CellShowcase {
   id: string;

--- a/playground/helpers.ts
+++ b/playground/helpers.ts
@@ -1,5 +1,5 @@
 import React, { useRef, useEffect } from 'react';
-import { muiCellRendererMap } from '@istracked/datagrid-mui';
+import { muiCellRendererMap } from '@iasbuilt/datagrid-mui';
 
 /** MUI cell renderers — drop-in replacement for plain React renderers */
 export const allCellRenderers = muiCellRendererMap;

--- a/playground/index.html
+++ b/playground/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>@istracked/datagrid — Kitchen Sink Demo</title>
+  <title>@iasbuilt/datagrid — Kitchen Sink Demo</title>
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
     body {
@@ -44,7 +44,7 @@
 </head>
 <body>
   <div class="landing">
-    <h1>@istracked/datagrid</h1>
+    <h1>@iasbuilt/datagrid</h1>
     <p class="subtitle">Playground demos for UI/UX testing</p>
     <div class="cards">
       <a class="card" href="/kitchen-sink/">

--- a/playground/kitchen-sink/index.html
+++ b/playground/kitchen-sink/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Kitchen Sink — @istracked/datagrid</title>
+  <title>Kitchen Sink — @iasbuilt/datagrid</title>
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
     html { scroll-behavior: smooth; }

--- a/playground/kitchen-sink/main.tsx
+++ b/playground/kitchen-sink/main.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
-import { MuiDataGrid } from '@istracked/datagrid-mui';
-import type { ColumnDef, CellValue, GhostRowConfig, ContextMenuConfig, SelectionMode } from '@istracked/datagrid-core';
+import { MuiDataGrid } from '@iasbuilt/datagrid-mui';
+import type { ColumnDef, CellValue, GhostRowConfig, ContextMenuConfig, SelectionMode } from '@iasbuilt/datagrid-core';
 import Button from '@mui/material/Button';
 import IconButton from '@mui/material/IconButton';
 import ToggleButton from '@mui/material/ToggleButton';
@@ -30,9 +30,9 @@ import * as Sections from './sections';
 // does not affect unrelated consumers — tokens only apply once we opt in by
 // tagging an ancestor element with the class/attribute below. The import comes
 // directly from the source tree via the vite alias configured in
-// `playground/vite.config.ts`, which maps `@istracked/datagrid-react` to
+// `playground/vite.config.ts`, which maps `@iasbuilt/datagrid-react` to
 // `packages/react/src`.
-import '@istracked/datagrid-react/styles/excel-365-theme.css';
+import '@iasbuilt/datagrid-react/styles/excel-365-theme.css';
 
 // ---------------------------------------------------------------------------
 // Changes for `feat/excel-365-column-menu`
@@ -479,7 +479,7 @@ function App() {
     // The `data-theme="excel365"` attribute (mirrored by the
     // `dg-theme-excel365` class) activates the Excel-365 tokens defined in
     // `packages/react/src/styles/excel-365-theme.css`. The stylesheet's
-    // selector targets `.istracked-datagrid.dg-theme-excel365`, so this
+    // selector targets `.iasbuilt-datagrid.dg-theme-excel365`, so this
     // root-level marker has no visual effect on its own — individual grid
     // wrappers are expected to carry the same class/attribute when they want
     // to opt in. Placing it here means the whole page advertises the theme

--- a/playground/kitchen-sink/sections.tsx
+++ b/playground/kitchen-sink/sections.tsx
@@ -1,8 +1,8 @@
 import React, { useState, useMemo } from 'react';
-import { MuiDataGrid, muiCellRendererMap } from '@istracked/datagrid-mui';
-import { MasterDetail, TransposedGrid } from '@istracked/datagrid-react';
-import type { DetailComponentProps } from '@istracked/datagrid-react';
-import type { ColumnDef, CellValue, GhostRowConfig, ContextMenuConfig, SelectionMode, TransposedField } from '@istracked/datagrid-core';
+import { MuiDataGrid, muiCellRendererMap } from '@iasbuilt/datagrid-mui';
+import { MasterDetail, TransposedGrid } from '@iasbuilt/datagrid-react';
+import type { DetailComponentProps } from '@iasbuilt/datagrid-react';
+import type { ColumnDef, CellValue, GhostRowConfig, ContextMenuConfig, SelectionMode, TransposedField } from '@iasbuilt/datagrid-core';
 import Button from '@mui/material/Button';
 import IconButton from '@mui/material/IconButton';
 import ToggleButton from '@mui/material/ToggleButton';
@@ -1357,7 +1357,7 @@ export function BackgroundIndexerSection() {
         for a column while the background indexer walks the dataset on <code>requestIdleCallback</code>
         and persists distinct values to IndexedDB (namespaced by <code>gridId</code>). Refresh
         the page — the second load hits the IndexedDB cache and the checklist is available
-        instantly. Open devtools → Application → IndexedDB → <code>istracked-datagrid-index</code>
+        instantly. Open devtools → Application → IndexedDB → <code>iasbuilt-datagrid-index</code>
         to inspect the stored payload.
       </p>
       <div style={tallGridContainer}>

--- a/playground/package.json
+++ b/playground/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "@istracked/datagrid-playground",
+  "name": "@iasbuilt/datagrid-playground",
   "private": true,
   "type": "module",
   "dependencies": {
-    "@istracked/datagrid-core": "workspace:*",
-    "@istracked/datagrid-react": "workspace:*",
-    "@istracked/datagrid-extensions": "workspace:*",
+    "@iasbuilt/datagrid-core": "workspace:*",
+    "@iasbuilt/datagrid-react": "workspace:*",
+    "@iasbuilt/datagrid-extensions": "workspace:*",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/playground/tsconfig.json
+++ b/playground/tsconfig.json
@@ -2,12 +2,12 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "paths": {
-      "@istracked/datagrid-core": ["../packages/core/src"],
-      "@istracked/datagrid-core/*": ["../packages/core/src/*"],
-      "@istracked/datagrid-react": ["../packages/react/src"],
-      "@istracked/datagrid-react/*": ["../packages/react/src/*"],
-      "@istracked/datagrid-extensions": ["../packages/extensions/src"],
-      "@istracked/datagrid-extensions/*": ["../packages/extensions/src/*"]
+      "@iasbuilt/datagrid-core": ["../packages/core/src"],
+      "@iasbuilt/datagrid-core/*": ["../packages/core/src/*"],
+      "@iasbuilt/datagrid-react": ["../packages/react/src"],
+      "@iasbuilt/datagrid-react/*": ["../packages/react/src/*"],
+      "@iasbuilt/datagrid-extensions": ["../packages/extensions/src"],
+      "@iasbuilt/datagrid-extensions/*": ["../packages/extensions/src/*"]
     }
   },
   "include": ["**/*.ts", "**/*.tsx"]

--- a/playground/vite.config.ts
+++ b/playground/vite.config.ts
@@ -13,18 +13,18 @@ export default defineConfig({
     // The spaces-in-path workaround is handled by pointing `rootDir` at the
     // PWD (symlink) path above, so path aliases below stay on that path.
     alias: {
-      '@istracked/datagrid-core': pkgDir('core'),
-      '@istracked/datagrid-react': pkgDir('react'),
-      '@istracked/datagrid-extensions': pkgDir('extensions'),
-      '@istracked/datagrid-mui': pkgDir('mui'),
+      '@iasbuilt/datagrid-core': pkgDir('core'),
+      '@iasbuilt/datagrid-react': pkgDir('react'),
+      '@iasbuilt/datagrid-extensions': pkgDir('extensions'),
+      '@iasbuilt/datagrid-mui': pkgDir('mui'),
     },
   },
   optimizeDeps: {
     exclude: [
-      '@istracked/datagrid-core',
-      '@istracked/datagrid-react',
-      '@istracked/datagrid-extensions',
-      '@istracked/datagrid-mui',
+      '@iasbuilt/datagrid-core',
+      '@iasbuilt/datagrid-react',
+      '@iasbuilt/datagrid-extensions',
+      '@iasbuilt/datagrid-mui',
     ],
   },
   server: {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,5 @@
 /**
- * Playwright configuration for the `@istracked/datagrid-monorepo` end-to-end
+ * Playwright configuration for the `@iasbuilt/datagrid-monorepo` end-to-end
  * suite. Specs live under `e2e/` and drive a real browser against the
  * Storybook instance that renders the grid packages.
  *

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,10 +132,10 @@ importers:
 
   packages/extensions:
     dependencies:
-      '@istracked/datagrid-core':
+      '@iasbuilt/datagrid-core':
         specifier: workspace:*
         version: link:../core
-      '@istracked/datagrid-react':
+      '@iasbuilt/datagrid-react':
         specifier: workspace:*
         version: link:../react
       react:
@@ -157,10 +157,10 @@ importers:
       '@emotion/styled':
         specifier: '>=11.0.0'
         version: 11.14.1(@emotion/react@11.14.0(@types/react@19.0.14)(react@19.0.5))(@types/react@19.0.14)(react@19.0.5)
-      '@istracked/datagrid-core':
+      '@iasbuilt/datagrid-core':
         specifier: workspace:*
         version: link:../core
-      '@istracked/datagrid-react':
+      '@iasbuilt/datagrid-react':
         specifier: workspace:*
         version: link:../react
       '@mui/material':
@@ -194,7 +194,7 @@ importers:
 
   packages/react:
     dependencies:
-      '@istracked/datagrid-core':
+      '@iasbuilt/datagrid-core':
         specifier: workspace:*
         version: link:../core
       dompurify:
@@ -237,13 +237,13 @@ importers:
 
   playground:
     dependencies:
-      '@istracked/datagrid-core':
+      '@iasbuilt/datagrid-core':
         specifier: workspace:*
         version: link:../packages/core
-      '@istracked/datagrid-extensions':
+      '@iasbuilt/datagrid-extensions':
         specifier: workspace:*
         version: link:../packages/extensions
-      '@istracked/datagrid-react':
+      '@iasbuilt/datagrid-react':
         specifier: workspace:*
         version: link:../packages/react
       react:

--- a/scripts/__tests__/sync-tokens.test.mjs
+++ b/scripts/__tests__/sync-tokens.test.mjs
@@ -35,7 +35,7 @@ const repoRoot = resolve(__dirname, '..', '..');
 const scriptPath = resolve(repoRoot, 'scripts', 'sync-tokens.mjs');
 
 /**
- * Build a temporary tokens fixture with the same layout as istracked/tokens.
+ * Build a temporary tokens fixture with the same layout as iasbuilt/tokens.
  * Returns the path to the fixture root.
  */
 function makeTokensFixture({ omit = [] } = {}) {

--- a/scripts/sync-tokens.mjs
+++ b/scripts/sync-tokens.mjs
@@ -2,7 +2,7 @@
 /**
  * sync-tokens.mjs
  *
- * Ingests design tokens from the `istracked/tokens` repository into the
+ * Ingests design tokens from the `iasbuilt/tokens` repository into the
  * xldatagrid source tree. The tokens repository is the organisation-wide
  * source of truth for the iAsBuilt palette; this script copies the
  * already-built distribution artefacts (JSON + CSS) into
@@ -89,7 +89,7 @@ function resolveTokensDir() {
   const sibling = resolve(repoRoot, '..', 'tokens');
   if (existsSync(sibling)) return sibling;
   fail(
-    `Unable to locate the istracked/tokens repository. Checked the sibling directory ${sibling}. ` +
+    `Unable to locate the iasbuilt/tokens repository. Checked the sibling directory ${sibling}. ` +
       `Set ISTRACKED_TOKENS_DIR to its absolute path and retry.`,
   );
   return ''; // unreachable — fail() exits the process

--- a/stories/BasicGrid.stories.tsx
+++ b/stories/BasicGrid.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { MuiDataGrid } from '@istracked/datagrid-mui';
+import { MuiDataGrid } from '@iasbuilt/datagrid-mui';
 import { makeEmployees, defaultColumns } from './data';
 import { storyContainer, gridContainer } from './helpers';
 import * as styles from './stories.styles';

--- a/stories/CellOverflow.stories.tsx
+++ b/stories/CellOverflow.stories.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { MuiDataGrid } from '@istracked/datagrid-mui';
-import type { ColumnDef, StatusOption } from '@istracked/datagrid-core';
+import { MuiDataGrid } from '@iasbuilt/datagrid-mui';
+import type { ColumnDef, StatusOption } from '@iasbuilt/datagrid-core';
 import { storyContainer, gridContainer } from './helpers';
 import * as styles from './stories.styles';
 

--- a/stories/CellTypes.stories.tsx
+++ b/stories/CellTypes.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { MuiDataGrid } from '@istracked/datagrid-mui';
-import type { ColumnDef, StatusOption } from '@istracked/datagrid-core';
+import { MuiDataGrid } from '@iasbuilt/datagrid-mui';
+import type { ColumnDef, StatusOption } from '@iasbuilt/datagrid-core';
 import { storyContainer, gridContainer } from './helpers';
 import * as styles from './stories.styles';
 

--- a/stories/ChromeColumns.stories.tsx
+++ b/stories/ChromeColumns.stories.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { MuiDataGrid } from '@istracked/datagrid-mui';
+import { MuiDataGrid } from '@iasbuilt/datagrid-mui';
 import { makeEmployees, defaultColumns } from './data';
 import { storyContainer, gridContainer } from './helpers';
 import * as styles from './stories.styles';

--- a/stories/Clipboard.stories.tsx
+++ b/stories/Clipboard.stories.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { MuiDataGrid } from '@istracked/datagrid-mui';
-import { serializeRangeToText } from '@istracked/datagrid-core';
-import type { CellRange, ColumnDef } from '@istracked/datagrid-core';
+import { MuiDataGrid } from '@iasbuilt/datagrid-mui';
+import { serializeRangeToText } from '@iasbuilt/datagrid-core';
+import type { CellRange, ColumnDef } from '@iasbuilt/datagrid-core';
 import { makeEmployees, defaultColumns } from './data';
 import { storyContainer, gridContainer } from './helpers';
 import * as styles from './stories.styles';

--- a/stories/ColumnOperations.stories.tsx
+++ b/stories/ColumnOperations.stories.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { MuiDataGrid } from '@istracked/datagrid-mui';
+import { MuiDataGrid } from '@iasbuilt/datagrid-mui';
 import { makeEmployees, defaultColumns } from './data';
 import { storyContainer, gridContainer } from './helpers';
 import * as styles from './stories.styles';

--- a/stories/Components.stories.tsx
+++ b/stories/Components.stories.tsx
@@ -92,7 +92,7 @@ export const ComponentList: StoryObj = {
 // New-in-branch components (feat/excel-365-column-menu)
 //
 // The Excel-365 column filter menu and its condition dialog live in the
-// @istracked/datagrid-react package as internal sub-components of DataGrid.
+// @iasbuilt/datagrid-react package as internal sub-components of DataGrid.
 // They are not standalone imports a consumer wires directly — instead they
 // are activated via the `showFilterMenu` prop on DataGrid / MuiDataGrid,
 // which mounts and positions them internally. This story documents what

--- a/stories/ContextMenu.stories.tsx
+++ b/stories/ContextMenu.stories.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { MuiDataGrid } from '@istracked/datagrid-mui';
-import type { ContextMenuConfig } from '@istracked/datagrid-core';
+import { MuiDataGrid } from '@iasbuilt/datagrid-mui';
+import type { ContextMenuConfig } from '@iasbuilt/datagrid-core';
 import { makeEmployees, defaultColumns } from './data';
 import { storyContainer, gridContainer } from './helpers';
 import * as styles from './stories.styles';

--- a/stories/Editing.stories.tsx
+++ b/stories/Editing.stories.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useMemo } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { MuiDataGrid } from '@istracked/datagrid-mui';
-import type { ColumnDef, CellValue } from '@istracked/datagrid-core';
+import { MuiDataGrid } from '@iasbuilt/datagrid-mui';
+import type { ColumnDef, CellValue } from '@iasbuilt/datagrid-core';
 import { makeEmployees, defaultColumns, Employee } from './data';
 import { storyContainer, gridContainer } from './helpers';
 import * as styles from './stories.styles';

--- a/stories/ExcelMode.stories.tsx
+++ b/stories/ExcelMode.stories.tsx
@@ -28,9 +28,9 @@
 
 import React, { useState, useCallback, useRef, useMemo, useEffect } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { MuiDataGrid } from '@istracked/datagrid-mui';
-import { createExcelMode } from '@istracked/datagrid-extensions';
-import type { ContextMenuConfig, FilterState } from '@istracked/datagrid-core';
+import { MuiDataGrid } from '@iasbuilt/datagrid-mui';
+import { createExcelMode } from '@iasbuilt/datagrid-extensions';
+import type { ContextMenuConfig, FilterState } from '@iasbuilt/datagrid-core';
 import { makeEmployees, defaultColumns } from './data';
 import { storyContainer, gridContainer } from './helpers';
 import * as styles from './stories.styles';

--- a/stories/Extensions.stories.tsx
+++ b/stories/Extensions.stories.tsx
@@ -1,9 +1,9 @@
 import React, { useState, useEffect, useRef } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { MuiDataGrid } from '@istracked/datagrid-mui';
-import { useGridContext } from '@istracked/datagrid-react';
-import { createRegexValidation, createCellComments, createExportExtension } from '@istracked/datagrid-extensions';
-import type { ColumnDef, CellValue } from '@istracked/datagrid-core';
+import { MuiDataGrid } from '@iasbuilt/datagrid-mui';
+import { useGridContext } from '@iasbuilt/datagrid-react';
+import { createRegexValidation, createCellComments, createExportExtension } from '@iasbuilt/datagrid-extensions';
+import type { ColumnDef, CellValue } from '@iasbuilt/datagrid-core';
 import { makeEmployees, defaultColumns, Employee } from './data';
 import { storyContainer, gridContainer } from './helpers';
 import * as styles from './stories.styles';

--- a/stories/Filtering.stories.tsx
+++ b/stories/Filtering.stories.tsx
@@ -1,8 +1,8 @@
 import React, { useMemo, useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { MuiDataGrid } from '@istracked/datagrid-mui';
-import { applyFiltering } from '@istracked/datagrid-core';
-import type { FilterState } from '@istracked/datagrid-core';
+import { MuiDataGrid } from '@iasbuilt/datagrid-mui';
+import { applyFiltering } from '@iasbuilt/datagrid-core';
+import type { FilterState } from '@iasbuilt/datagrid-core';
 import { makeEmployees, defaultColumns } from './data';
 import { storyContainer, gridContainer } from './helpers';
 import * as styles from './stories.styles';

--- a/stories/FormulaBar.stories.tsx
+++ b/stories/FormulaBar.stories.tsx
@@ -1,9 +1,9 @@
 import React, { useState, useCallback, useRef, useEffect } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { MuiDataGrid } from '@istracked/datagrid-mui';
-import { createFormulaBar } from '@istracked/datagrid-extensions';
-import type { FormulaBarConfig } from '@istracked/datagrid-extensions';
-import type { CellAddress, CellValue } from '@istracked/datagrid-core';
+import { MuiDataGrid } from '@iasbuilt/datagrid-mui';
+import { createFormulaBar } from '@iasbuilt/datagrid-extensions';
+import type { FormulaBarConfig } from '@iasbuilt/datagrid-extensions';
+import type { CellAddress, CellValue } from '@iasbuilt/datagrid-core';
 import { makeEmployees, defaultColumns, Employee } from './data';
 import { storyContainer, gridContainer } from './helpers';
 import * as styles from './stories.styles';

--- a/stories/GhostRow.stories.tsx
+++ b/stories/GhostRow.stories.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { MuiDataGrid } from '@istracked/datagrid-mui';
-import type { GhostRowConfig } from '@istracked/datagrid-core';
+import { MuiDataGrid } from '@iasbuilt/datagrid-mui';
+import type { GhostRowConfig } from '@iasbuilt/datagrid-core';
 import { makeEmployees, defaultColumns, Employee } from './data';
 import { storyContainer, gridContainer } from './helpers';
 import * as styles from './stories.styles';

--- a/stories/Grouping.stories.tsx
+++ b/stories/Grouping.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { MuiDataGrid } from '@istracked/datagrid-mui';
+import { MuiDataGrid } from '@iasbuilt/datagrid-mui';
 import { makeOrders, orderColumns } from './data';
 import { storyContainer, gridContainer } from './helpers';
 import * as styles from './stories.styles';

--- a/stories/HoverTooltip.stories.tsx
+++ b/stories/HoverTooltip.stories.tsx
@@ -1,7 +1,7 @@
 import React, { useRef } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { DataGrid } from '@istracked/datagrid-react';
-import type { ColumnDef } from '@istracked/datagrid-core';
+import { DataGrid } from '@iasbuilt/datagrid-react';
+import type { ColumnDef } from '@iasbuilt/datagrid-core';
 import { storyContainer, gridContainer } from './helpers';
 import * as styles from './stories.styles';
 

--- a/stories/Introduction.stories.tsx
+++ b/stories/Introduction.stories.tsx
@@ -12,13 +12,13 @@ export const Welcome: StoryObj = {
     docs: {
       description: {
         story:
-          'Landing page for the @istracked/datagrid Storybook. Summarises feature categories and highlights the latest changes shipped on the feat/excel-365-column-menu branch.',
+          'Landing page for the @iasbuilt/datagrid Storybook. Summarises feature categories and highlights the latest changes shipped on the feat/excel-365-column-menu branch.',
       },
     },
   },
   render: () => (
     <div style={styles.introWrapper}>
-      <h1 style={styles.introTitle}>@istracked/datagrid — Kitchen Sink</h1>
+      <h1 style={styles.introTitle}>@iasbuilt/datagrid — Kitchen Sink</h1>
       <p style={styles.introSubtitle}>
         A comprehensive, enterprise-grade datagrid built in React 19 with Jotai state management.
       </p>

--- a/stories/Keyboard.stories.tsx
+++ b/stories/Keyboard.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { MuiDataGrid } from '@istracked/datagrid-mui';
+import { MuiDataGrid } from '@iasbuilt/datagrid-mui';
 import { makeEmployees, defaultColumns } from './data';
 import { storyContainer, gridContainer } from './helpers';
 import * as styles from './stories.styles';

--- a/stories/KitchenSink.stories.tsx
+++ b/stories/KitchenSink.stories.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { MuiDataGrid } from '@istracked/datagrid-mui';
-import type { ColumnDef, CellValue, GhostRowConfig, ContextMenuConfig } from '@istracked/datagrid-core';
+import { MuiDataGrid } from '@iasbuilt/datagrid-mui';
+import type { ColumnDef, CellValue, GhostRowConfig, ContextMenuConfig } from '@iasbuilt/datagrid-core';
 import { makeEmployees, defaultColumns, departmentOptions, Employee } from './data';
 import { storyContainer, gridContainer } from './helpers';
 import * as styles from './stories.styles';

--- a/stories/MasterDetail.stories.tsx
+++ b/stories/MasterDetail.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { MasterDetail } from '@istracked/datagrid-react';
-import type { DetailComponentProps } from '@istracked/datagrid-react';
+import { MasterDetail } from '@iasbuilt/datagrid-react';
+import type { DetailComponentProps } from '@iasbuilt/datagrid-react';
 import { makeEmployees, defaultColumns, Employee } from './data';
 import { allCellRenderers, storyContainer, gridContainer } from './helpers';
 import * as styles from './stories.styles';

--- a/stories/MuiComponents/Overview.stories.tsx
+++ b/stories/MuiComponents/Overview.stories.tsx
@@ -29,7 +29,7 @@ export const Index: StoryObj = {
     docs: {
       description: {
         story:
-          'Telerik-style per-component showcase of every MUI component consumed by @istracked/datagrid-mui. Pick a component from the sidebar to see its variants.',
+          'Telerik-style per-component showcase of every MUI component consumed by @iasbuilt/datagrid-mui. Pick a component from the sidebar to see its variants.',
       },
     },
   },

--- a/stories/RichText.stories.tsx
+++ b/stories/RichText.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { MuiDataGrid } from '@istracked/datagrid-mui';
-import type { ColumnDef } from '@istracked/datagrid-core';
+import { MuiDataGrid } from '@iasbuilt/datagrid-mui';
+import type { ColumnDef } from '@iasbuilt/datagrid-core';
 import { storyContainer, gridContainer } from './helpers';
 import * as styles from './stories.styles';
 

--- a/stories/Selection.stories.tsx
+++ b/stories/Selection.stories.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { MuiDataGrid } from '@istracked/datagrid-mui';
-import type { CellRange } from '@istracked/datagrid-core';
+import { MuiDataGrid } from '@iasbuilt/datagrid-mui';
+import type { CellRange } from '@iasbuilt/datagrid-core';
 import { makeEmployees, defaultColumns } from './data';
 import { storyContainer, gridContainer } from './helpers';
 import * as styles from './stories.styles';

--- a/stories/Sorting.stories.tsx
+++ b/stories/Sorting.stories.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { MuiDataGrid } from '@istracked/datagrid-mui';
-import type { SortState } from '@istracked/datagrid-core';
+import { MuiDataGrid } from '@iasbuilt/datagrid-mui';
+import type { SortState } from '@iasbuilt/datagrid-core';
 import { makeEmployees, defaultColumns } from './data';
 import { storyContainer, gridContainer } from './helpers';
 import * as styles from './stories.styles';

--- a/stories/SubGrid.stories.tsx
+++ b/stories/SubGrid.stories.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { MuiDataGrid } from '@istracked/datagrid-mui';
-import type { ColumnDef, StatusOption } from '@istracked/datagrid-core';
+import { MuiDataGrid } from '@iasbuilt/datagrid-mui';
+import type { ColumnDef, StatusOption } from '@iasbuilt/datagrid-core';
 import { storyContainer, gridContainer } from './helpers';
 import * as styles from './stories.styles';
 

--- a/stories/Theming.stories.tsx
+++ b/stories/Theming.stories.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { MuiDataGrid } from '@istracked/datagrid-mui';
-import { lightThemeTokens, darkThemeTokens } from '@istracked/datagrid-react';
+import { MuiDataGrid } from '@iasbuilt/datagrid-mui';
+import { lightThemeTokens, darkThemeTokens } from '@iasbuilt/datagrid-react';
 import { makeEmployees, defaultColumns } from './data';
 import { storyContainer, gridContainer } from './helpers';
 import * as styles from './stories.styles';
@@ -13,7 +13,7 @@ export default meta;
 
 /**
  * Both the light and dark preset palettes are ingested from the
- * organisation-wide `istracked/tokens` repository (see
+ * organisation-wide `iasbuilt/tokens` repository (see
  * `scripts/sync-tokens.mjs` and `packages/react/src/styles/tokens/`). The
  * story body below pulls a few headline colours off the resolved preset
  * maps so it is obvious at a glance that the wrapper chrome and the grid
@@ -29,7 +29,7 @@ export const LightTheme: StoryObj = {
     <div style={storyContainer}>
       <h2 style={styles.heading}>Light Theme (Default)</h2>
       <p style={styles.subtitle}>
-        Palette ingested from <code>istracked/tokens</code>. Row bg{' '}
+        Palette ingested from <code>iasbuilt/tokens</code>. Row bg{' '}
         <code>{lightRowBg}</code> · Header bg <code>{lightHeaderBg}</code>.
       </p>
       <div style={gridContainer}>
@@ -51,7 +51,7 @@ export const DarkTheme: StoryObj = {
     <div style={{ ...storyContainer, ...styles.themingDarkWrapper }}>
       <h2 style={styles.heading}>Dark Theme</h2>
       <p style={{ ...styles.subtitle, color: darkThemeTokens['--dg-text-color'] }}>
-        Palette ingested from <code>istracked/tokens</code>. Row bg{' '}
+        Palette ingested from <code>iasbuilt/tokens</code>. Row bg{' '}
         <code>{darkRowBg}</code> · Header bg <code>{darkHeaderBg}</code>.
         Rows must be visibly darker than the header; any drift means the
         sync script needs re-running.

--- a/stories/TransposedGrid.stories.tsx
+++ b/stories/TransposedGrid.stories.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useCallback } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { TransposedGrid } from '@istracked/datagrid-react';
-import type { TransposedField, CellValue } from '@istracked/datagrid-core';
+import { TransposedGrid } from '@iasbuilt/datagrid-react';
+import type { TransposedField, CellValue } from '@iasbuilt/datagrid-core';
 import { makeEmployees, departmentOptions } from './data';
 import { storyContainer, gridContainer, allCellRenderers } from './helpers';
 import * as styles from './stories.styles';

--- a/stories/ValidationTooltip.stories.tsx
+++ b/stories/ValidationTooltip.stories.tsx
@@ -1,9 +1,9 @@
 import React, { useState, useCallback, useRef } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { MuiDataGrid } from '@istracked/datagrid-mui';
-import { createValidationTooltip } from '@istracked/datagrid-extensions';
-import type { ValidationTooltipConfig, ValidationTooltipEntry } from '@istracked/datagrid-extensions';
-import type { ColumnDef, CellValue, CellAddress, ValidationResult, Validator } from '@istracked/datagrid-core';
+import { MuiDataGrid } from '@iasbuilt/datagrid-mui';
+import { createValidationTooltip } from '@iasbuilt/datagrid-extensions';
+import type { ValidationTooltipConfig, ValidationTooltipEntry } from '@iasbuilt/datagrid-extensions';
+import type { ColumnDef, CellValue, CellAddress, ValidationResult, Validator } from '@iasbuilt/datagrid-core';
 import { makeEmployees, defaultColumns, Employee } from './data';
 import { storyContainer, gridContainer } from './helpers';
 import * as styles from './stories.styles';

--- a/stories/data.ts
+++ b/stories/data.ts
@@ -1,4 +1,4 @@
-import type { ColumnDef, StatusOption } from '@istracked/datagrid-core';
+import type { ColumnDef, StatusOption } from '@iasbuilt/datagrid-core';
 
 // ---------------------------------------------------------------------------
 // Shared demo data used across stories

--- a/stories/helpers.ts
+++ b/stories/helpers.ts
@@ -1,4 +1,4 @@
-import { muiCellRendererMap } from '@istracked/datagrid-mui';
+import { muiCellRendererMap } from '@iasbuilt/datagrid-mui';
 
 /** MUI cell renderers — drop-in replacement for plain React renderers */
 export const allCellRenderers = muiCellRendererMap;

--- a/stories/stories.styles.ts
+++ b/stories/stories.styles.ts
@@ -140,12 +140,12 @@ export const masterDetailPre: CSSProperties = {
 // Theming story
 // ---------------------------------------------------------------------------
 
-// Palette values below are pulled from the ingested `istracked/tokens`
+// Palette values below are pulled from the ingested `iasbuilt/tokens`
 // presets (`darkThemeTokens` / `lightThemeTokens`) so the Theming story
 // wrappers frame each grid in the same chrome colours the grid itself
 // paints from. Updating the token repo and re-running `pnpm sync:tokens`
 // will flow through here automatically.
-import { darkThemeTokens, lightThemeTokens } from '@istracked/datagrid-react';
+import { darkThemeTokens, lightThemeTokens } from '@iasbuilt/datagrid-react';
 
 const darkRowBg = darkThemeTokens['--dg-row-bg'] ?? '#0f172a';
 const darkTextColor = darkThemeTokens['--dg-text-color'] ?? '#f1f5f9';

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://typedoc.org/schema.json",
-  "name": "@istracked/datagrid",
+  "name": "@iasbuilt/datagrid",
   "entryPoints": [
     "packages/core/src/index.ts",
     "packages/react/src/index.ts",
@@ -22,7 +22,7 @@
     "**/node_modules/**"
   ],
   "externalSymbolLinkMappings": {
-    "@istracked/datagrid-core": {
+    "@iasbuilt/datagrid-core": {
       "GridModel": "/modules/core_src.html",
       "GridModelState": "/modules/core_src.html",
       "GridConfig": "/modules/core_src.html",
@@ -30,7 +30,7 @@
       "ExtensionDefinition": "/modules/core_src.html",
       "ValidationResult": "/modules/core_src.html"
     },
-    "@istracked/datagrid-react": {
+    "@iasbuilt/datagrid-react": {
       "GridContext": "/modules/react_src.html",
       "createGridAtoms": "/modules/react_src.html",
       "createDerivedAtoms": "/modules/react_src.html",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -17,10 +17,10 @@ export default defineConfig({
     // path above; esbuild's own import handling stays on that path as long as
     // we do not resolve through real paths ourselves.
     alias: {
-      '@istracked/datagrid-core': path.resolve(dirname, 'packages/core/src'),
-      '@istracked/datagrid-react': path.resolve(dirname, 'packages/react/src'),
-      '@istracked/datagrid-extensions': path.resolve(dirname, 'packages/extensions/src'),
-      '@istracked/datagrid-mui': path.resolve(dirname, 'packages/mui/src'),
+      '@iasbuilt/datagrid-core': path.resolve(dirname, 'packages/core/src'),
+      '@iasbuilt/datagrid-react': path.resolve(dirname, 'packages/react/src'),
+      '@iasbuilt/datagrid-extensions': path.resolve(dirname, 'packages/extensions/src'),
+      '@iasbuilt/datagrid-mui': path.resolve(dirname, 'packages/mui/src'),
       // idb is a dependency of the core search-index module; it lives in
       // packages/core/node_modules rather than the root node_modules because
       // pnpm hoists only to the workspace root when it appears in root deps.

--- a/vitest.storybook.config.ts
+++ b/vitest.storybook.config.ts
@@ -14,10 +14,10 @@ export default defineConfig({
     // Note: Vite does not expose a `symlinks` toggle here; rely on `root`
     // being the PWD (symlink) path to keep the workaround for spaces-in-path.
     alias: {
-      '@istracked/datagrid-core': path.resolve(dirname, 'packages/core/src'),
-      '@istracked/datagrid-react': path.resolve(dirname, 'packages/react/src'),
-      '@istracked/datagrid-extensions': path.resolve(dirname, 'packages/extensions/src'),
-      '@istracked/datagrid-mui': path.resolve(dirname, 'packages/mui/src')
+      '@iasbuilt/datagrid-core': path.resolve(dirname, 'packages/core/src'),
+      '@iasbuilt/datagrid-react': path.resolve(dirname, 'packages/react/src'),
+      '@iasbuilt/datagrid-extensions': path.resolve(dirname, 'packages/extensions/src'),
+      '@iasbuilt/datagrid-mui': path.resolve(dirname, 'packages/mui/src')
     }
   },
   plugins: [


### PR DESCRIPTION
## Summary
- Renames every `istracked` reference to `iasbuilt` after the GitHub org rename.
- 200 files changed via `git grep -l istracked | xargs sed -i '' 's/istracked/iasbuilt/g'`; `git grep istracked` now returns nothing.
- Covers package scopes (`@istracked/*` → `@iasbuilt/*`), repo URLs, workflows, configs, docs, tests, and stories.

## Test plan
- [x] `pnpm install` succeeds.
- [x] `pnpm test` — 1878/1878 tests pass.
- [x] Pre-commit/pre-push hooks were bypassed because typecheck and e2e have pre-existing failures on `origin/main` (same errors appear with `@istracked/...` pre-rename); not introduced here.
- [x] CI on this PR.