### PR TITLE
feat(react)!: remove deprecated useGridWithAtoms / useGridAtomContext (closes #100)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,5 +25,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ### Removed (BREAKING, from PR #22)
 - `DataGridColumnMenuProps.isSortingEnabled`, `.onSortAsc`, `.onSortDesc` — sort actions now live in the Excel-365 filter dropdown. Migrate by removing these props from `<DataGridColumnMenu>` usages.
 
+### Removed (BREAKING, issue #100)
+- `useGridWithAtoms`, the `UseGridResult` type, and `useGridAtomContext` have been deleted from `@iasbuilt/datagrid-react`. They were kept as deprecated aliases when the Jotai shadow layer was removed in Phase 3 and only ever returned `{ model }` post-Phase-3. Migration:
+  - Replace `useGridWithAtoms(config)` with `useGrid(config)` (now returns the `GridModel` directly — drop the `.model` access).
+  - Replace `useGridAtomContext()` with `useGridContext()` (also returns the `GridModel` directly).
+  - For the pre-Phase-3 `store` / `atoms` use cases, reach into `model.graph` / `model.nodes` (causl) for fine-grained per-node subscriptions.
+
 ## [0.1.0] — 2026-04-15
 - Initial release of xldatagrid monorepo.

--- a/README.md
+++ b/README.md
@@ -732,21 +732,27 @@ function MyGrid() {
 }
 ```
 
-### Fine-Grained Atom Subscriptions
+### Fine-Grained Subscriptions
 
 ```tsx
-import { useGridWithAtoms } from '@iasbuilt/datagrid-react';
+import { useGrid } from '@iasbuilt/datagrid-react';
 
 function MyGrid() {
-  const { model, store, atoms } = useGridWithAtoms(config);
+  const model = useGrid(config);
 
-  // Read derived state
-  const sortState = store.get(atoms.base.sortAtom);
-  const processedData = store.get(atoms.derived.processedDataAtom);
+  // Subscribe to a single causl node — re-runs only when that node changes.
+  React.useEffect(() => {
+    return model.graph.subscribe(model.nodes.processedData, (data) => {
+      console.log('processed rows changed:', data.length);
+    });
+  }, [model]);
 
   return <DataGrid model={model} />;
 }
 ```
+
+> The pre-`0.2.0` `useGridWithAtoms({ model, store, atoms })` bundle was
+> removed; reach into `model.graph` / `model.nodes` instead.
 
 ---
 

--- a/e2e/issue-100-no-deprecated-aliases.spec.ts
+++ b/e2e/issue-100-no-deprecated-aliases.spec.ts
@@ -1,0 +1,81 @@
+/**
+ * End-to-end smoke test for issue #100 — the deprecated `useGridWithAtoms`,
+ * `useGridAtomContext`, and `UseGridResult` aliases were removed from the
+ * `@iasbuilt/datagrid-react` public API.
+ *
+ * The real coverage for this change is compile-time: if either symbol is
+ * still imported from `@iasbuilt/datagrid-react` anywhere in the repo,
+ * `tsc` (and the playground build) fail before this spec is reached. The
+ * checks below are belt-and-braces:
+ *
+ *   1. Drive the SPA-integration demo (which renders a grid via the
+ *      current `useGrid` hook + `useGridContext`) and confirm no console
+ *      errors fire while exercising filters — guards against any runtime
+ *      regression we might have introduced while pulling the aliases out
+ *      of the barrel.
+ *   2. Probe the bundled JS that the playground actually ships and assert
+ *      neither alias name appears in it. Vite serves source as ES modules,
+ *      so we hit the compiled barrel via `?import` and string-scan.
+ *
+ * If `webServer` boots the Vite playground (configured in
+ * `playwright.config.ts`), neither step needs any extra setup.
+ */
+import { test, expect } from '@playwright/test';
+
+test.use({ baseURL: 'http://localhost:5173' });
+
+const PAGE = '/spa-integration/';
+
+test.describe('issue #100 — deprecated aliases are gone', () => {
+  test('SPA-integration demo loads and renders without errors after alias removal', async ({ page }) => {
+    const consoleErrors: string[] = [];
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') consoleErrors.push(msg.text());
+    });
+    const pageErrors: string[] = [];
+    page.on('pageerror', (err) => {
+      pageErrors.push(err.message);
+    });
+
+    await page.goto(PAGE);
+    await page.locator('[role="grid"]').first().waitFor({ state: 'visible' });
+
+    // Exercise the grid through a filter button — this path uses the
+    // `useGrid` / `useGridContext` hooks that replaced the removed
+    // aliases. If anything wired through the React barrel is broken,
+    // a render error fires here.
+    await page.locator('button', { hasText: 'Salary > $100k' }).click();
+    await page.locator('button', { hasText: 'Clear filter' }).click();
+
+    expect(consoleErrors, `console errors fired:\n${consoleErrors.join('\n')}`).toEqual([]);
+    expect(pageErrors, `page errors fired:\n${pageErrors.join('\n')}`).toEqual([]);
+  });
+
+  test('public API barrel no longer ships useGridWithAtoms / useGridAtomContext', async ({ request }) => {
+    // The Vite dev server resolves bare specifier `@iasbuilt/datagrid-react`
+    // through its module graph. We pull the resolved JS the page would
+    // actually execute and assert the removed names do not appear as
+    // exported bindings. Substring match is sufficient: the names are
+    // not referenced anywhere in the post-removal source, so any hit
+    // means the deletion was incomplete.
+    const res = await request.get(
+      'http://localhost:5173/@id/@iasbuilt/datagrid-react/dist/index.js'
+    );
+
+    // Dev server may serve source instead of dist; fall back to the
+    // playground entry that imports from the package, which inlines
+    // re-exports.
+    let body = '';
+    if (res.ok()) {
+      body = await res.text();
+    } else {
+      const fallback = await request.get('http://localhost:5173/spa-integration/main.tsx');
+      // If even this fails we still want a useful error, not a hang.
+      expect(fallback.ok(), 'could not fetch any artifact to scan').toBeTruthy();
+      body = await fallback.text();
+    }
+
+    expect(body).not.toContain('useGridWithAtoms');
+    expect(body).not.toContain('useGridAtomContext');
+  });
+});

--- a/packages/react/src/DataGrid.tsx
+++ b/packages/react/src/DataGrid.tsx
@@ -16,7 +16,7 @@
  *   - This module owns only presentation state and event translation. The
  *     authoritative data model — rows, columns, sort/filter/group state, and
  *     edit transactions — lives in a `GridModel` from `@iasbuilt/datagrid-core`.
- *     The React tree bridges to it through {@link useGridWithAtoms} (which
+ *     The React tree bridges to it through {@link useGrid} (which
  *     instantiates the model) and {@link useGridStore} (which subscribes to it
  *     and produces snapshot-friendly state for rendering). All mutations flow
  *     through `model.*` methods; callbacks like `onSortChange` / `onFilterChange`
@@ -1191,7 +1191,7 @@ export function DataGrid<TData extends Record<string, unknown>>(props: DataGridP
   // grid. Recursion is handled by re-entering `<DataGrid>` with the parent
   // cell's array value as its `data` and the parent column's `subGridColumns`
   // as its `columns`. Every nested level receives its own `GridModel` via
-  // `useGridWithAtoms` so sort state, drag sessions, selection, and keyboard
+  // `useGrid` so sort state, drag sessions, selection, and keyboard
   // focus are scoped to that level.
   //
   // Depth tracking:

--- a/packages/react/src/__tests__/migration-contract/README.md
+++ b/packages/react/src/__tests__/migration-contract/README.md
@@ -6,8 +6,9 @@ this directory:
 
 1. Do not import `jotai` or `@causl/*` directly.
 2. Assert only on the public surface exposed from `@iasbuilt/datagrid-react`
-   (`useGrid`, `useGridWithAtoms`, `createAtomicGridModel`, `GridContext`) and
-   on the `GridModel` interface from `@iasbuilt/datagrid-core`.
+   (`useGrid`, `GridContext`) and on the `GridModel` interface from
+   `@iasbuilt/datagrid-core`. (The historical `useGridWithAtoms` and
+   `createAtomicGridModel` exports were removed in the post-`v0.1.0` major.)
 3. Cover the behaviors that have the highest risk of breaking during the swap:
    bundle return-shape, lifecycle (mount/unmount/destroy), mutation semantics
    (each action atom becomes a causl `commit`), and the EventBus dispatch

--- a/packages/react/src/__tests__/migration-contract/use-grid.contract.test.tsx
+++ b/packages/react/src/__tests__/migration-contract/use-grid.contract.test.tsx
@@ -1,14 +1,18 @@
 /**
- * Contract: `useGrid` / `useGridWithAtoms` lifecycle and stability.
+ * Contract: `useGrid` lifecycle and stability.
  *
  * Pins the React-side guarantees that consuming components rely on. Must pass
  * on both the current Jotai-backed implementation and the post-migration
  * causl-backed implementation.
+ *
+ * Note: the historical `useGridWithAtoms` alias was removed in the
+ * post-`v0.1.0` major (see CHANGELOG → "Removed (BREAKING)"); the section
+ * that used to assert its return shape lived here and was deleted with it.
  */
 import React from 'react';
 import { describe, it, expect } from 'vitest';
 import { renderHook, act, render } from '@testing-library/react';
-import { useGrid, useGridWithAtoms } from '../../use-grid';
+import { useGrid } from '../../use-grid';
 import type { GridConfig } from '@iasbuilt/datagrid-core';
 
 type Row = { id: string; name: string; age: number };
@@ -104,21 +108,3 @@ describe('useGrid — lifecycle contract', () => {
   });
 });
 
-describe('useGridWithAtoms — return shape contract', () => {
-  it('returns an object with at least { model } and a single grid runtime', () => {
-    const { result } = renderHook(() => useGridWithAtoms(makeConfig()));
-    expect(result.current).toBeDefined();
-    expect(result.current.model).toBeDefined();
-    expect(typeof result.current.model.getState).toBe('function');
-  });
-
-  it('model identity is stable across re-renders', () => {
-    const { result, rerender } = renderHook(
-      ({ config }) => useGridWithAtoms(config),
-      { initialProps: { config: makeConfig() } }
-    );
-    const first = result.current.model;
-    rerender({ config: makeConfig() });
-    expect(result.current.model).toBe(first);
-  });
-});

--- a/packages/react/src/context.ts
+++ b/packages/react/src/context.ts
@@ -40,16 +40,3 @@ export function useGridContext<TData extends Record<string, unknown>>(): GridMod
   if (!ctx) throw new Error('useGridContext must be used within a DataGrid');
   return ctx.model as GridModel<TData>;
 }
-
-/**
- * Backward-compatible alias for {@link useGridContext}. The pre-Phase-3
- * version returned a `{ model, store, atoms }` bundle; the latter two
- * fields no longer exist. New code should use {@link useGridContext}.
- *
- * @deprecated Use {@link useGridContext}.
- */
-export function useGridAtomContext<TData extends Record<string, unknown>>(): GridContextValue<TData> {
-  const ctx = useContext(GridContext);
-  if (!ctx) throw new Error('useGridAtomContext must be used within a DataGrid');
-  return ctx as unknown as GridContextValue<TData>;
-}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -15,12 +15,11 @@ export { lightThemeTokens, darkThemeTokens, toDatagridThemeTokens } from './styl
 export { GhostRow } from './GhostRow';
 export { MasterDetail } from './MasterDetail';
 export type { MasterDetailProps, DetailComponentProps } from './MasterDetail';
-export { useGrid, useGridWithAtoms } from './use-grid';
+export { useGrid } from './use-grid';
 export { useCauslDevtools } from './use-causl-devtools';
 export type { UseCauslDevtoolsOptions } from './use-causl-devtools';
-export type { UseGridResult } from './use-grid';
 export { useGridStore } from './use-grid-store';
-export { GridContext, useGridContext, useGridAtomContext } from './context';
+export { GridContext, useGridContext } from './context';
 export type { GridContextValue } from './context';
 // Phase 3: Jotai shadow layer removed. createAtomicGridModel,
 // AtomicGridBundle, AtomicStore, and the GridAtomSystem/BaseAtoms/

--- a/packages/react/src/use-grid.ts
+++ b/packages/react/src/use-grid.ts
@@ -67,27 +67,3 @@ export function useGrid<TData extends Record<string, unknown>>(
 
   return model;
 }
-
-/**
- * Backward-compatible alias retained for consumers that imported
- * `useGridWithAtoms` from the Jotai-era public API. Returns the same
- * shape callers got from `useGrid` (just `{ model }`); the `store` and
- * `atoms` fields no longer exist post-Phase-3.
- *
- * @deprecated Use {@link useGrid} directly. Will be removed in a future
- * major version.
- */
-export function useGridWithAtoms<TData extends Record<string, unknown>>(
-  config: GridConfig<TData>
-): UseGridResult<TData> {
-  return { model: useGrid(config) };
-}
-
-/**
- * Return type of {@link useGridWithAtoms}. Phase-3 reshape: contains
- * only `model`. The pre-Phase-3 `store` (Jotai vanilla store) and
- * `atoms` (3-tier base/derived/action atom system) are gone.
- */
-export interface UseGridResult<TData extends Record<string, unknown>> {
-  model: GridModel<TData>;
-}


### PR DESCRIPTION
## Summary

- Removes the deprecated `useGridWithAtoms` (+ `UseGridResult`) and `useGridAtomContext` exports from `@iasbuilt/datagrid-react`. They were retained as Phase-3 shims that only ever returned `{ model }`; with the next major they go away entirely.
- Drops them from the package barrel (`packages/react/src/index.ts`) and from internal JSDoc / README references; the migration-contract spec now pins only `useGrid`.
- Adds a CHANGELOG entry under "Removed (BREAKING, issue #100)" with the migration notes (`useGridWithAtoms(config)` -> `useGrid(config)`, `useGridAtomContext()` -> `useGridContext()`).
- Adds `e2e/issue-100-no-deprecated-aliases.spec.ts` — a Playwright smoke test that drives the SPA-integration demo, asserts no runtime errors, and string-scans the served bundle to confirm neither removed name ships.

## Migration

- `useGridWithAtoms(config)` -> `useGrid(config)`. The new hook returns the `GridModel` directly, so drop the `.model` access on the returned value.
- `useGridAtomContext()` -> `useGridContext()`, which likewise returns the `GridModel` directly.
- For the pre-Phase-3 `store` / `atoms` use cases, reach into `model.graph` / `model.nodes` (causl) for fine-grained per-node subscriptions.

## Test plan

- [x] `pnpm run typecheck` — clean.
- [x] `pnpm vitest run packages/` — 1939 / 1939 passed.
- [x] `pnpm exec playwright test e2e/issue-100-no-deprecated-aliases.spec.ts` — 2 / 2 passed against a freshly booted Storybook + Vite playground.
- [ ] Full `pnpm exec playwright test` — pre-existing infrastructure issue on this machine: the Storybook dev server crashes / refuses connections under the suite's parallel load. Same failure pattern reproduces on `main` at `f109567` with an identical near-zero pass rate; not introduced by this change. Pre-push hook ran with `SKIP_E2E=1` (its built-in escape hatch, not `--no-verify`) for that reason. CI should be the source of truth here.

Closes #100