### PR TITLE
feat(react): add useCauslDevtoolsForGraph(graph) overload (closes #105)

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,11 +490,11 @@ If multiple grids share a single causl graph (BYO-graph), call the hook
 connection per graph and refcounts internally:
 
 ```tsx
-import { createCausl, useCauslDevtools, useGrid } from '@iasbuilt/datagrid-react';
+import { createCausl, useCauslDevtoolsForGraph, useGrid } from '@iasbuilt/datagrid-react';
 
 function App() {
   const graph = useMemo(() => createCausl({ name: 'app' }), []);
-  useCauslDevtools({ graph } as any, { name: 'app' });  // wraps the shared graph
+  useCauslDevtoolsForGraph(graph, { name: 'app' });  // wraps the shared graph
   return (
     <>
       <EmployeesGrid graph={graph} />
@@ -503,10 +503,6 @@ function App() {
   );
 }
 ```
-
-(The `as any` is a pragmatic cast — the hook accepts a full `GridModel`
-today; a follow-up will add a `useCauslDevtoolsForGraph(graph, options)`
-overload that accepts a bare graph.)
 
 #### What you'll see in DevTools
 

--- a/e2e/issue-105-useCauslDevtoolsForGraph.spec.ts
+++ b/e2e/issue-105-useCauslDevtoolsForGraph.spec.ts
@@ -1,0 +1,100 @@
+/**
+ * End-to-end: issue #105 — `useCauslDevtoolsForGraph(graph, options)`
+ * overload smoke test.
+ *
+ * The SPA-integration playground page now calls
+ * `useCauslDevtoolsForGraph(graph, ...)` against its shared causl
+ * graph. This is the BYO-graph wiring described in README §"Sharing
+ * one DevTools panel across multiple grids" — previously the README
+ * had to use `useCauslDevtools({ graph } as any, ...)`.
+ *
+ * In headless chromium the Redux DevTools extension is not installed,
+ * so `connectDevtools` short-circuits to a no-op (see
+ * `@causl/devtools-bridge`'s zero-cost gate). The acceptance criterion
+ * for the overload is then twofold:
+ *
+ *   1. The page still renders — the hook call must not throw, must not
+ *      break the React render tree, and must not interfere with the
+ *      grid's mount or the pivot's first paint.
+ *   2. The grid + pivot remain atomic across a commit — applying a
+ *      filter through the demo buttons still updates the pivot inside
+ *      the same render the grid sees the new processed-data node.
+ *      This protects against a future regression where the bridge's
+ *      `subscribeCommits` listener (when an extension is present) or
+ *      the dev-bail logic accidentally serialises commits through an
+ *      extra tick.
+ *
+ * Page error / console-error capture surfaces any throw from the hook
+ * (or from the dynamic `@causl/devtools-bridge` import) that would
+ * otherwise be swallowed by the .catch in the hook body. The test
+ * fails fast if any of those fire.
+ */
+import { test, expect, type Page } from '@playwright/test';
+
+test.use({ baseURL: 'http://localhost:5173' });
+
+const PAGE = '/spa-integration/';
+
+async function metricValue(page: Page, label: string): Promise<number> {
+  const labelEl = page.locator(`text=${label}`).first();
+  await labelEl.waitFor({ state: 'visible' });
+  const text = await labelEl.locator('..').locator('div').nth(1).innerText();
+  return parseInt(text.replace(/\D/g, ''), 10);
+}
+
+test.describe('issue #105 — useCauslDevtoolsForGraph smoke', () => {
+  let pageErrors: Error[];
+  let consoleErrors: string[];
+
+  test.beforeEach(async ({ page }) => {
+    pageErrors = [];
+    consoleErrors = [];
+    page.on('pageerror', (err) => pageErrors.push(err));
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') {
+        consoleErrors.push(msg.text());
+      }
+    });
+    await page.goto(PAGE);
+    await page.locator('[role="grid"]').first().waitFor({ state: 'visible' });
+    await page.locator('text=Pivot').first().waitFor({ state: 'visible' });
+  });
+
+  test('demo still renders with useCauslDevtoolsForGraph wired in', async ({ page }) => {
+    // Pivot's "Visible" metric must equal the seeded row count, proving
+    // the grid registered its nodes on the shared graph and the pivot
+    // resolved its derived `app:pivot:metrics` node. If the devtools
+    // hook had thrown or deadlocked, this would fail or hang.
+    const visible = await metricValue(page, 'Visible');
+    expect(visible).toBe(200);
+    expect(pageErrors).toEqual([]);
+    expect(consoleErrors).toEqual([]);
+  });
+
+  test('pivot still updates atomically when filtered (shared-graph path)', async ({ page }) => {
+    const before = await metricValue(page, 'Visible');
+    expect(before).toBe(200);
+
+    await page.locator('button', { hasText: 'Salary > $100k' }).click();
+
+    // The atomicity contract from spa-integration-byo-graph.spec.ts —
+    // re-asserted here to confirm the new hook does not perturb the
+    // commit pipeline. The pivot's count and the DOM row count must
+    // never disagree after a commit.
+    await expect(async () => {
+      const after = await metricValue(page, 'Visible');
+      expect(after).toBeGreaterThan(0);
+      expect(after).toBeLessThan(200);
+      const domN = await page
+        .locator('[role="grid"] [role="gridcell"][data-row-id]')
+        .evaluateAll((els) => new Set(els.map((e) => e.getAttribute('data-row-id'))).size);
+      // Virtualisation may keep the rendered DOM smaller than the
+      // post-filter logical count; the pivot's number is the upper
+      // bound. The strict invariant is `domN <= pivot`.
+      expect(domN).toBeLessThanOrEqual(after);
+    }).toPass({ timeout: 5_000 });
+
+    expect(pageErrors).toEqual([]);
+    expect(consoleErrors).toEqual([]);
+  });
+});

--- a/packages/react/src/__tests__/use-causl-devtools-for-graph.test.tsx
+++ b/packages/react/src/__tests__/use-causl-devtools-for-graph.test.tsx
@@ -1,0 +1,142 @@
+/**
+ * Unit tests for the bare-graph overload {@link useCauslDevtoolsForGraph}.
+ *
+ * Contracts protected by this file:
+ * - The hook is callable with a bare `Graph` from `@causl/core` — no
+ *   `GridModel` wrapper required (this is the whole point of the
+ *   overload, issue #105).
+ * - When the Redux DevTools extension is present (mocked via
+ *   `globalThis.__REDUX_DEVTOOLS_EXTENSION__`), the bridge calls
+ *   `graph.subscribeCommits` to forward commits — we verify by counting
+ *   subscribe calls observed against a spy installed on the real graph.
+ * - Unmounting disposes the subscription: after `unmount()` the
+ *   per-graph refcount drops to zero and the underlying
+ *   `subscribeCommits` disposer fires.
+ *
+ * The bridge does its work inside a dynamic `import()`; the hook then
+ * calls `connectDevtools` only after that promise resolves. We use
+ * `waitFor` to let the microtask settle before asserting.
+ */
+
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+// The `@causl/core` primitives are re-exported via `@iasbuilt/datagrid-core`
+// so packages downstream of core do not have to declare a direct dep on
+// the engine. Tests follow the same import path the public API consumer
+// would use.
+import { createCausl, type Graph } from '@iasbuilt/datagrid-core';
+
+import { useCauslDevtoolsForGraph } from '../use-causl-devtools';
+
+// ---------------------------------------------------------------------------
+// Mock of the Redux DevTools Extension surface. The bridge calls
+// `__REDUX_DEVTOOLS_EXTENSION__.connect({ name })` once per graph and
+// then talks to the returned connection. We capture the connection so
+// the test can assert init/send/unsubscribe were invoked.
+// ---------------------------------------------------------------------------
+
+interface MockConnection {
+  init: ReturnType<typeof vi.fn>;
+  send: ReturnType<typeof vi.fn>;
+  subscribe: ReturnType<typeof vi.fn>;
+  unsubscribe: ReturnType<typeof vi.fn>;
+}
+
+function installMockExtension(): { connect: ReturnType<typeof vi.fn>; lastConnection: () => MockConnection | undefined } {
+  let last: MockConnection | undefined;
+  const connect = vi.fn((_opts?: { name?: string }) => {
+    const conn: MockConnection = {
+      init: vi.fn(),
+      send: vi.fn(),
+      // The bridge subscribes for reverse messages; return a no-op disposer.
+      subscribe: vi.fn(() => () => undefined),
+      unsubscribe: vi.fn(),
+    };
+    last = conn;
+    return conn;
+  });
+  (globalThis as unknown as { __REDUX_DEVTOOLS_EXTENSION__: unknown }).__REDUX_DEVTOOLS_EXTENSION__ = { connect };
+  return { connect, lastConnection: () => last };
+}
+
+function removeMockExtension(): void {
+  delete (globalThis as unknown as { __REDUX_DEVTOOLS_EXTENSION__?: unknown }).__REDUX_DEVTOOLS_EXTENSION__;
+}
+
+describe('useCauslDevtoolsForGraph', () => {
+  beforeEach(() => {
+    // The hook bails in production. The test runner sets NODE_ENV=test
+    // but be defensive in case some other test stamped it to 'production'.
+    if ((globalThis as { process?: { env?: { NODE_ENV?: string } } }).process?.env) {
+      (globalThis as { process: { env: { NODE_ENV?: string } } }).process.env.NODE_ENV = 'development';
+    }
+  });
+
+  afterEach(() => {
+    removeMockExtension();
+    vi.restoreAllMocks();
+  });
+
+  it('accepts a bare causl Graph (the #105 overload)', async () => {
+    // No extension installed — the bridge short-circuits inside the dynamic
+    // import. The hook must still resolve without throwing.
+    const graph = createCausl({ name: 'unit-bare-graph' });
+    const { unmount } = renderHook(() => useCauslDevtoolsForGraph(graph));
+    // Give the dynamic import a tick to settle so any throw surfaces.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(() => unmount()).not.toThrow();
+  });
+
+  it('subscribes to the graph when the DevTools extension is present', async () => {
+    const { connect, lastConnection } = installMockExtension();
+    const graph: Graph = createCausl({ name: 'unit-subscribe' });
+    const subscribeCommitsSpy = vi.spyOn(graph, 'subscribeCommits');
+
+    renderHook(() => useCauslDevtoolsForGraph(graph, { name: 'unit' }));
+
+    await waitFor(
+      () => {
+        expect(connect).toHaveBeenCalledTimes(1);
+      },
+      { timeout: 2_000 },
+    );
+    // The bridge initialises the panel with the current snapshot and
+    // wires a commit listener through `graph.subscribeCommits`.
+    expect(subscribeCommitsSpy).toHaveBeenCalledTimes(1);
+    expect(lastConnection()!.init).toHaveBeenCalledTimes(1);
+  });
+
+  it('disposes the subscription on unmount', async () => {
+    installMockExtension();
+    const graph: Graph = createCausl({ name: 'unit-dispose' });
+
+    // Track the disposer that subscribeCommits hands back so we can
+    // assert it actually runs at teardown. We wrap the real
+    // implementation so the bridge keeps working.
+    const realSubscribeCommits = graph.subscribeCommits.bind(graph);
+    const innerDisposer = vi.fn();
+    const subscribeCommitsSpy = vi
+      .spyOn(graph, 'subscribeCommits')
+      .mockImplementation((listener) => {
+        const dispose = realSubscribeCommits(listener);
+        return () => {
+          innerDisposer();
+          dispose();
+        };
+      });
+
+    const { unmount } = renderHook(() => useCauslDevtoolsForGraph(graph));
+
+    await waitFor(
+      () => {
+        expect(subscribeCommitsSpy).toHaveBeenCalledTimes(1);
+      },
+      { timeout: 2_000 },
+    );
+
+    unmount();
+    // Give the cleanup microtask a chance to run.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(innerDisposer).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -16,7 +16,7 @@ export { GhostRow } from './GhostRow';
 export { MasterDetail } from './MasterDetail';
 export type { MasterDetailProps, DetailComponentProps } from './MasterDetail';
 export { useGrid } from './use-grid';
-export { useCauslDevtools } from './use-causl-devtools';
+export { useCauslDevtools, useCauslDevtoolsForGraph } from './use-causl-devtools';
 export type { UseCauslDevtoolsOptions } from './use-causl-devtools';
 export { useGridStore } from './use-grid-store';
 export { GridContext, useGridContext } from './context';

--- a/packages/react/src/use-causl-devtools.ts
+++ b/packages/react/src/use-causl-devtools.ts
@@ -24,7 +24,7 @@
  *   4. In your DataGrid container: call `useCauslDevtools(model)` (or
  *      pass `devtools: true` to `useGrid` once that wiring lands).
  *
- * @example
+ * @example Per-grid wiring (most apps)
  * ```tsx
  * import { useGrid, useCauslDevtools } from '@iasbuilt/datagrid-react';
  *
@@ -35,10 +35,23 @@
  * }
  * ```
  *
+ * @example Shared-graph (BYO-graph) wiring — call once at the app level
+ * ```tsx
+ * import { createCausl, useCauslDevtoolsForGraph } from '@iasbuilt/datagrid-react';
+ *
+ * function App() {
+ *   const graph = useMemo(() => createCausl({ name: 'app' }), []);
+ *   useCauslDevtoolsForGraph(graph, { name: 'app' });
+ *   return <>...grids that share `graph`...</>;
+ * }
+ * ```
+ *
  * @module use-causl-devtools
  */
 import { useEffect } from 'react';
-import type { GridModel } from '@iasbuilt/datagrid-core';
+// `@causl/core` types reach us via the core package's re-export so the
+// react package does not need a direct dep on the engine.
+import type { GridModel, Graph } from '@iasbuilt/datagrid-core';
 
 /**
  * Optional knobs forwarded to `connectDevtools`.
@@ -57,8 +70,22 @@ export interface UseCauslDevtoolsOptions {
   forceInDev?: boolean;
 }
 
-export function useCauslDevtools<TData extends Record<string, unknown>>(
-  model: GridModel<TData>,
+/**
+ * Bare-graph overload: connect any causl `Graph` (typically the
+ * app-owned one in a BYO-graph / SPA-integration setup) to the
+ * Redux DevTools extension.
+ *
+ * Prefer this when one `Graph` is shared across multiple grids
+ * (or across grids + app-level derived nodes). The bridge keeps
+ * one connection per graph and refcounts internally, so a single
+ * top-level call is sufficient — per-grid calls would each open
+ * a separate DevTools instance pointing at the same graph.
+ *
+ * Same prod-bail and dynamic-import contract as
+ * {@link useCauslDevtools}.
+ */
+export function useCauslDevtoolsForGraph(
+  graph: Graph,
   options: UseCauslDevtoolsOptions = {},
 ): void {
   useEffect(() => {
@@ -79,7 +106,7 @@ export function useCauslDevtools<TData extends Record<string, unknown>>(
     void import('@causl/devtools-bridge')
       .then((mod) => {
         if (cancelled) return;
-        disconnect = mod.connectDevtools(model.graph, {
+        disconnect = mod.connectDevtools(graph, {
           name: options.name,
         });
       })
@@ -93,5 +120,17 @@ export function useCauslDevtools<TData extends Record<string, unknown>>(
       cancelled = true;
       disconnect?.();
     };
-  }, [model, options.name, options.enabled, options.forceInDev]);
+  }, [graph, options.name, options.enabled, options.forceInDev]);
+}
+
+/**
+ * `GridModel` overload — thin wrapper that forwards `model.graph`
+ * to {@link useCauslDevtoolsForGraph}. Kept as the headline API
+ * because the per-grid case is the common one.
+ */
+export function useCauslDevtools<TData extends Record<string, unknown>>(
+  model: GridModel<TData>,
+  options: UseCauslDevtoolsOptions = {},
+): void {
+  useCauslDevtoolsForGraph(model.graph, options);
 }

--- a/playground/spa-integration/main.tsx
+++ b/playground/spa-integration/main.tsx
@@ -13,7 +13,7 @@
  */
 import React, { useMemo, useSyncExternalStore } from 'react';
 import { createRoot } from 'react-dom/client';
-import { DataGrid, useCauslDevtools } from '@iasbuilt/datagrid-react';
+import { DataGrid, useCauslDevtools, useCauslDevtoolsForGraph } from '@iasbuilt/datagrid-react';
 import { createCausl, type Graph, type Node } from '@causl/core';
 import type { ColumnDef, FilterState } from '@iasbuilt/datagrid-core';
 import { makeEmployees, type Employee } from '../data';
@@ -96,6 +96,13 @@ function App() {
   // grid via config.graph; the grid registers its nodes on this graph
   // under the `employees:` namespace.
   const graph = useMemo(() => createCausl({ name: 'spa-integration-demo' }), []);
+
+  // Wire the shared graph to the Redux DevTools extension when present.
+  // No-op in headless browsers (e.g. Playwright's chromium) because the
+  // extension is not injected — `connectDevtools` short-circuits before
+  // allocating any subscription. Issue #105 acceptance: must not throw
+  // and must not break the grid + pivot atomicity contract below.
+  useCauslDevtoolsForGraph(graph, { name: 'spa-integration-demo' });
 
   // The DataGrid component itself uses useGrid(config) internally to
   // construct its model. We pass `graph` in `config` so the grid's


### PR DESCRIPTION
## Summary

- Adds the `useCauslDevtoolsForGraph(graph, options?)` overload alongside the existing `useCauslDevtools(model, options?)` so apps wiring a single shared causl `Graph` across multiple grids (BYO-graph / SPA-integration) can connect to the Redux DevTools panel without the `{ graph } as any` cast the README used to recommend.
- `useCauslDevtools(model, options)` is now a thin wrapper that forwards `model.graph` to the new hook. Same dynamic-import + prod-bail contract as before; both names are exported from `@iasbuilt/datagrid-react`.
- README "Sharing one DevTools panel across multiple grids" section updated to call `useCauslDevtoolsForGraph(graph, { name: 'app' })` directly; the "follow-up" caveat paragraph is gone.
- Playground `spa-integration` page now uses the new hook against its shared graph (no-op in headless browsers; the e2e relies on this).

Closes #105.

## Test plan

- [x] `pnpm vitest run packages/react/src/__tests__/use-causl-devtools-for-graph.test.tsx` — 3 unit tests pass: the hook accepts a bare `Graph` from `@causl/core`, calling it subscribes via `graph.subscribeCommits` when `__REDUX_DEVTOOLS_EXTENSION__` is present, and unmount disposes the subscription.
- [x] `pnpm exec playwright test e2e/issue-105-useCauslDevtoolsForGraph.spec.ts` — both smoke specs pass: the SPA-integration page still renders and the pivot still updates atomically with the new hook wired in. No `pageerror`/`console.error` fires.
- [x] Pre-commit hook (`typecheck` → `build` → `vitest` 1944 tests → `tokens:check` → `test:scripts` → `actionlint`) passes locally.
- [ ] Full Playwright suite gated behind `SKIP_E2E=1` on push — the local machine is currently saturated by concurrent worktree agents (5+ storybook instances using ~700MB each), so `:6006`/`:6206`/etc. storybook boots wedge and ~36-66 `ERR_CONNECTION_REFUSED` failures land in unrelated specs (cell-overflow, edit-commit-nav, etc.). Issue is reproducible on `main` under the same load. Remote CI should be green; please re-run the E2E workflow if it does not auto-trigger.