### PR TITLE
feat(react): lift DataGrid.tsx local UI state into causl (closes #106)

### DIFF
--- a/e2e/issue-106-interaction-state-lifted.spec.ts
+++ b/e2e/issue-106-interaction-state-lifted.spec.ts
@@ -1,0 +1,159 @@
+/**
+ * End-to-end: issue #106 — the four remaining DataGrid.tsx `useState`
+ * holders (rowGroupExpanded / rowDragState / filterMenuOpen /
+ * conditionDialogOpen) now live on the unified causl interaction node.
+ *
+ * The lift is a pure refactor: there is no new user-visible feature and no
+ * existing behaviour should regress. This spec is the user-facing
+ * "contract" guard for the lift — it drives the three behaviours powered
+ * by those state holders end-to-end so a future regression in the
+ * causl-backed wiring surfaces immediately:
+ *
+ *   1. Row drag — initiating a drag exposes the `data-drop-indicator`
+ *      attribute (per #68's contract) and committing the drop clears it.
+ *      This proves `rowDragState` round-trips through the causl node
+ *      (start-row-drag → end-row-drag) without losing the source-row info
+ *      the model uses for `moveRow`.
+ *
+ *   2. Excel filter menu — clicking the filter icon opens the dropdown
+ *      and pressing Escape closes it. This proves `filterMenuOpen`
+ *      (now `filterMenu: { type: 'open', field, anchor }`) is read off
+ *      the unified state correctly and that `closeFilterMenu` short-
+ *      circuits the reducer back to `closed`.
+ *
+ *   3. Row group collapse/expand — clicking the chevron on a group header
+ *      flips `aria-expanded` (or, equivalently, hides the data rows for
+ *      that group). This proves `rowGroupExpanded` toggles correctly via
+ *      the new `toggleRowGroup` action.
+ *
+ * Stories:
+ *   - Kitchen Sink (`examples-kitchen-sink--everything-at-once`) provides
+ *     the MUI grid with `showFilterMenu` + reorderable row numbers — used
+ *     for the row-drag and filter-menu checks.
+ *   - Grouped Kitchen Sink (`pages-kitchen-sink--grouped-kitchen-sink`)
+ *     groups rows by department with `defaultExpanded: true` — used for
+ *     the row-group expand/collapse check.
+ */
+import { test, expect, type Locator, type Page } from '@playwright/test';
+
+const KITCHEN_SINK_URL =
+  '/iframe.html?viewMode=story&id=pages-kitchen-sink--everything-at-once';
+const GROUPED_KITCHEN_SINK_URL =
+  '/iframe.html?viewMode=story&id=pages-kitchen-sink--grouped-kitchen-sink';
+
+async function waitForGrid(page: Page): Promise<void> {
+  // Kitchen-sink stories are heavy first-paints (MUI theme bootstrap +
+  // background indexer warm-up), so give the initial compile / render a
+  // generous window before we conclude the grid never mounted.
+  await page
+    .locator('[role="grid"]')
+    .first()
+    .waitFor({ state: 'visible', timeout: 30_000 });
+}
+
+function rowNumberCell(page: Page, rowIndex: number): Locator {
+  return page.locator('[data-chrome="row-number"]').nth(rowIndex);
+}
+
+test.describe('Issue #106 — DataGrid local UI state lifted into causl', () => {
+  test('row drag: starting a drag exposes the drop indicator and dropping clears it', async ({
+    page,
+  }) => {
+    await page.goto(KITCHEN_SINK_URL);
+    await waitForGrid(page);
+
+    const source = rowNumberCell(page, 0);
+    const target = rowNumberCell(page, 2);
+    await expect(source).toBeVisible();
+    await expect(target).toBeVisible();
+
+    const srcBox = await source.boundingBox();
+    const tgtBox = await target.boundingBox();
+    if (!srcBox || !tgtBox) throw new Error('boundingBox unavailable');
+
+    const startX = srcBox.x + srcBox.width / 2;
+    const startY = srcBox.y + srcBox.height / 2;
+    const endX = tgtBox.x + tgtBox.width / 2;
+    // Aim for the upper third so the indicator resolves to "above".
+    const endY = tgtBox.y + tgtBox.height * 0.25;
+
+    await page.mouse.move(startX, startY);
+    await page.mouse.down();
+    await page.mouse.move(startX, startY + 5, { steps: 2 });
+    await page.mouse.move(endX, endY, { steps: 10 });
+
+    // Mid-drag: the start-row-drag action committed via causl, so the
+    // drop indicator (driven off the source row's existence) must paint.
+    await expect(target).toHaveAttribute('data-drop-indicator', 'above');
+
+    await page.mouse.up();
+
+    // After the drop, `end-row-drag` flips `rowDrag` back to idle and the
+    // indicator clears from every chrome cell.
+    const withIndicator = page.locator(
+      '[data-chrome="row-number"][data-drop-indicator]',
+    );
+    await expect(withIndicator).toHaveCount(0);
+  });
+
+  test('filter menu: clicking the column filter trigger opens the Excel dropdown and Escape closes it', async ({
+    page,
+  }) => {
+    await page.goto(KITCHEN_SINK_URL);
+    await waitForGrid(page);
+
+    // The header's filter button has `aria-haspopup="menu"`. Pick the
+    // first filterable column (the kitchen sink enables `showFilterMenu`
+    // for all columns) to drive the open transition.
+    const filterTrigger = page.locator('button[aria-haspopup="menu"]').first();
+    await expect(filterTrigger).toBeVisible();
+    await filterTrigger.click();
+
+    const menu = page.locator('[data-testid="column-filter-menu"]');
+    await expect(menu).toBeVisible();
+
+    // Pressing Escape (or clicking outside) dispatches close-filter-menu,
+    // which the reducer reads off the unified node and short-circuits to
+    // `closed`. The menu unmounts on the next render.
+    await page.keyboard.press('Escape');
+    await expect(menu).toHaveCount(0);
+  });
+
+  test('row group: clicking a group header chevron collapses the group and re-clicking expands it', async ({
+    page,
+  }) => {
+    await page.goto(GROUPED_KITCHEN_SINK_URL);
+    await waitForGrid(page);
+
+    // Grouped Kitchen Sink groups by `department` with defaultExpanded:
+    // true. The body therefore renders one group-header-row per
+    // department, each tagged with `data-group-key="<department>"`. Pick
+    // the first group header to exercise the toggle.
+    const firstGroupHeader = page
+      .locator('[data-testid="group-header-row"]')
+      .first();
+    await expect(firstGroupHeader).toBeVisible();
+    const groupKey = await firstGroupHeader.getAttribute('data-group-key');
+    expect(groupKey).not.toBeNull();
+
+    // Initially expanded → the aggregate row for THIS group is rendered.
+    const aggregateRow = page.locator(
+      `[data-testid="group-aggregate-row"][data-group-key="${groupKey}"]`,
+    );
+    await expect(aggregateRow).toHaveCount(1);
+
+    // Click the header → toggle-row-group commits, `rowGroupExpanded`
+    // loses this key, and the aggregate row unmounts. The Grouped
+    // Kitchen Sink pins a ghost row to the bottom of the viewport, and
+    // Playwright's scroll-into-view machinery sometimes parks the
+    // group header behind it. Dispatch a synthetic click via the DOM to
+    // sidestep pointer-event interception while still exercising the
+    // same React onClick handler.
+    await firstGroupHeader.dispatchEvent('click');
+    await expect(aggregateRow).toHaveCount(0);
+
+    // Click again → back to expanded.
+    await firstGroupHeader.dispatchEvent('click');
+    await expect(aggregateRow).toHaveCount(1);
+  });
+});

--- a/packages/react/src/DataGrid.tsx
+++ b/packages/react/src/DataGrid.tsx
@@ -346,8 +346,13 @@ export function DataGrid<TData extends Record<string, unknown>>(props: DataGridP
   // Unified interaction state (replaces 12 separate useState calls)
   const interaction = useGridInteraction();
 
-  // Row grouping state (kept separate — different lifecycle)
-  const [rowGroupExpanded, setRowGroupExpanded] = useState<Set<string>>(new Set());
+  // Row grouping expand/collapse — now lives on the unified interaction node
+  // (issue #106). The local alias preserves call-site ergonomics while the
+  // setter routes through the causl-backed `setRowGroupExpanded` helper so
+  // every change is observable on the same graph as the other interaction
+  // state.
+  const rowGroupExpanded = interaction.state.rowGroupExpanded;
+  const setRowGroupExpanded = interaction.setRowGroupExpanded;
   const [rowGroupsInitialized, setRowGroupsInitialized] = useState(false);
   const [validationErrors, setValidationErrors] = useState<Record<string, ValidationResult[]>>({});
   // Per-cell tooltip-open state. Keyed by `${rowId}:${field}`, value is the
@@ -890,12 +895,8 @@ export function DataGrid<TData extends Record<string, unknown>>(props: DataGridP
 
   // --- Body handlers ---
   const handleGroupToggle = useCallback((groupKey: string) => {
-    setRowGroupExpanded(prev => {
-      const next = new Set(prev);
-      if (next.has(groupKey)) next.delete(groupKey); else next.add(groupKey);
-      return next;
-    });
-  }, []);
+    interaction.toggleRowGroup(groupKey);
+  }, [interaction]);
 
   // ---------------------------------------------------------------------------
   // Chrome column handlers
@@ -922,18 +923,19 @@ export function DataGrid<TData extends Record<string, unknown>>(props: DataGridP
     containerRef.current?.focus({ preventScroll: true });
   }, [model]);
 
-  const [rowDragState, setRowDragState] = useState<{ sourceRowId: string; sourceIndex: number } | null>(null);
+  // Row drag session is now part of the unified interaction node (issue #106).
+  const rowDragState = interaction.state.rowDrag;
 
   const handleRowDragStart = useCallback((rowId: string, rowIndex: number) => {
-    setRowDragState({ sourceRowId: rowId, sourceIndex: rowIndex });
-  }, []);
+    interaction.startRowDrag(rowId, rowIndex);
+  }, [interaction]);
 
   const handleRowDragOver = useCallback((_rowId: string, _rowIndex: number) => {
     // Visual indicator could be added here in the future
   }, []);
 
   const handleRowDrop = useCallback((targetRowId: string, rowIndex: number) => {
-    if (rowDragState) {
+    if (rowDragState.type === 'dragging') {
       model.moveRow(rowDragState.sourceIndex, rowIndex);
       onRowReorder?.({
         sourceRowId: rowDragState.sourceRowId,
@@ -941,9 +943,9 @@ export function DataGrid<TData extends Record<string, unknown>>(props: DataGridP
         fromIndex: rowDragState.sourceIndex,
         toIndex: rowIndex,
       });
-      setRowDragState(null);
+      interaction.endRowDrag();
     }
-  }, [model, rowDragState, onRowReorder]);
+  }, [model, rowDragState, onRowReorder, interaction]);
 
   const handleSelectAll = useCallback(() => {
     model.selectAllCells();
@@ -999,22 +1001,14 @@ export function DataGrid<TData extends Record<string, unknown>>(props: DataGridP
     disabled: !filterMenuEnabled,
   });
 
-  // `FilterMenuOpen` models the open state of the Excel dropdown: either a
-  // specific field is open (with the anchoring header-button rect needed for
-  // positioning) or no dropdown is open. Keeping it as a local discriminated
-  // value avoids polluting the shared interaction reducer with concerns that
-  // are specific to this feature.
-  type FilterMenuOpen = {
-    field: string;
-    anchor: { top: number; left: number; bottom: number; right: number };
-  } | null;
-
-  // `filterMenuOpen` tracks the Excel dropdown; `conditionDialogOpen` tracks
-  // the "Custom filter…" conditional dialog that the dropdown can launch. Only
-  // one of each can be open at a time, and the dropdown closes itself before
-  // the dialog opens.
-  const [filterMenuOpen, setFilterMenuOpen] = useState<FilterMenuOpen>(null);
-  const [conditionDialogOpen, setConditionDialogOpen] = useState<{ field: string } | null>(null);
+  // The Excel filter dropdown and the "Custom filter…" condition dialog both
+  // live on the unified interaction node (issue #106). Local discriminants
+  // capture the "open with field X (anchored at rect Y)" shape; we materialise
+  // them here as plain values for the JSX below so call sites stay readable.
+  const filterMenuOpen =
+    interaction.state.filterMenu.type === 'open' ? interaction.state.filterMenu : null;
+  const conditionDialogOpen =
+    interaction.state.conditionDialog.type === 'open' ? interaction.state.conditionDialog : null;
 
   // Opening the Excel dropdown must force the legacy column menu closed so
   // they never overlap visually or compete for keyboard focus. The anchor
@@ -1023,25 +1017,22 @@ export function DataGrid<TData extends Record<string, unknown>>(props: DataGridP
   const handleFilterMenuTrigger = useCallback((field: string, anchor: DOMRect) => {
     // Mutual exclusion: close the legacy column menu when the Excel filter menu opens.
     interaction.closeMenu();
-    setFilterMenuOpen({
-      field,
-      anchor: {
-        top: anchor.top,
-        left: anchor.left,
-        bottom: anchor.bottom,
-        right: anchor.right,
-      },
+    interaction.openFilterMenu(field, {
+      top: anchor.top,
+      left: anchor.left,
+      bottom: anchor.bottom,
+      right: anchor.right,
     });
   }, [interaction]);
 
-  const closeFilterMenu = useCallback(() => setFilterMenuOpen(null), []);
+  const closeFilterMenu = useCallback(() => interaction.closeFilterMenu(), [interaction]);
 
   // Mirror of the mutual-exclusion rule on the other side: when the legacy
   // column menu is opened (from the header's caret button), the Excel filter
   // dropdown is dismissed so only one menu is visible per column at a time.
   const handleColumnMenuTrigger = useCallback((field: string) => {
     // Mutual exclusion: close the Excel filter menu when the legacy column menu opens.
-    setFilterMenuOpen(null);
+    interaction.closeFilterMenu();
     interaction.openColumnMenu(field);
   }, [interaction]);
 
@@ -1144,8 +1135,8 @@ export function DataGrid<TData extends Record<string, unknown>>(props: DataGridP
   // builds richer predicates (between / starts-with / and-or chains). Opening
   // the dialog simply records which field it should target.
   const handleOpenConditionDialog = useCallback((field: string) => {
-    setConditionDialogOpen({ field });
-  }, []);
+    interaction.openConditionDialog(field);
+  }, [interaction]);
 
   // Receives the composite predicate produced by the condition dialog and
   // routes it through the same field-scoped replace helper so the behaviour
@@ -1445,9 +1436,9 @@ export function DataGrid<TData extends Record<string, unknown>>(props: DataGridP
             dataType={resolveColumnDataType(conditionDialogOpen.field)}
             onApply={(filter) => {
               handleApplyConditionFilter(conditionDialogOpen.field, filter);
-              setConditionDialogOpen(null);
+              interaction.closeConditionDialog();
             }}
-            onClose={() => setConditionDialogOpen(null)}
+            onClose={() => interaction.closeConditionDialog()}
           />
         )}
 

--- a/packages/react/src/__tests__/state/grid-interaction-causl.contract.test.tsx
+++ b/packages/react/src/__tests__/state/grid-interaction-causl.contract.test.tsx
@@ -104,6 +104,66 @@ describe('useGridInteraction — causl substrate contract', () => {
     expect(result.current.state.menu).toEqual({ type: 'columnVisibility' });
   });
 
+  // Issue #106 — the four ex-useState holders now route through causl. One
+  // assertion per new field that dispatch produces an `interaction:<action>`
+  // commit on the host graph.
+
+  it('toggleRowGroup emits a causl commit', () => {
+    const graph = createCausl({ name: 'host' });
+    const intents: string[] = [];
+    graph.subscribeCommits((c) => intents.push(c.intent));
+
+    const { result } = renderHook(() => useGridInteraction({ graph }));
+    act(() => result.current.toggleRowGroup('g1'));
+    expect(intents).toEqual(['interaction:toggle-row-group']);
+    expect(result.current.state.rowGroupExpanded.has('g1')).toBe(true);
+  });
+
+  it('startRowDrag emits a causl commit', () => {
+    const graph = createCausl({ name: 'host' });
+    const intents: string[] = [];
+    graph.subscribeCommits((c) => intents.push(c.intent));
+
+    const { result } = renderHook(() => useGridInteraction({ graph }));
+    act(() => result.current.startRowDrag('row-3', 3));
+    expect(intents).toEqual(['interaction:start-row-drag']);
+    expect(result.current.state.rowDrag).toEqual({
+      type: 'dragging',
+      sourceRowId: 'row-3',
+      sourceIndex: 3,
+    });
+  });
+
+  it('openFilterMenu emits a causl commit', () => {
+    const graph = createCausl({ name: 'host' });
+    const intents: string[] = [];
+    graph.subscribeCommits((c) => intents.push(c.intent));
+
+    const { result } = renderHook(() => useGridInteraction({ graph }));
+    const anchor = { top: 10, left: 20, bottom: 30, right: 40 };
+    act(() => result.current.openFilterMenu('email', anchor));
+    expect(intents).toEqual(['interaction:open-filter-menu']);
+    expect(result.current.state.filterMenu).toEqual({
+      type: 'open',
+      field: 'email',
+      anchor,
+    });
+  });
+
+  it('openConditionDialog emits a causl commit', () => {
+    const graph = createCausl({ name: 'host' });
+    const intents: string[] = [];
+    graph.subscribeCommits((c) => intents.push(c.intent));
+
+    const { result } = renderHook(() => useGridInteraction({ graph }));
+    act(() => result.current.openConditionDialog('amount'));
+    expect(intents).toEqual(['interaction:open-condition-dialog']);
+    expect(result.current.state.conditionDialog).toEqual({
+      type: 'open',
+      field: 'amount',
+    });
+  });
+
   it('two grids on the same graph have non-colliding interaction state via namespace', () => {
     const graph = createCausl({ name: 'host' });
     const a = renderHook(() => useGridInteraction({ graph, namespace: 'gridA' }));

--- a/packages/react/src/__tests__/state/grid-interaction-state.test.ts
+++ b/packages/react/src/__tests__/state/grid-interaction-state.test.ts
@@ -21,6 +21,10 @@ describe('gridInteractionReducer', () => {
     expect(init.hiddenColumns).toEqual(new Set());
     expect(init.frozenOverrides).toEqual({});
     expect(init.collapsedColumnGroups).toEqual(new Set());
+    expect(init.rowGroupExpanded).toEqual(new Set());
+    expect(init.rowDrag).toEqual({ type: 'idle' });
+    expect(init.filterMenu).toEqual({ type: 'closed' });
+    expect(init.conditionDialog).toEqual({ type: 'closed' });
   });
 
   // ---- Menu actions ----
@@ -268,6 +272,117 @@ describe('gridInteractionReducer', () => {
     it('sets the column order override', () => {
       const next = reduce(init, { type: 'set-column-order', order: ['c', 'b', 'a'] });
       expect(next.columnOrderOverride).toEqual(['c', 'b', 'a']);
+    });
+  });
+
+  // ---- Row group expand/collapse ----
+
+  describe('row group expand/collapse', () => {
+    it('toggle-row-group adds a group key when absent', () => {
+      const next = reduce(init, { type: 'toggle-row-group', groupId: 'g1' });
+      expect(next.rowGroupExpanded.has('g1')).toBe(true);
+    });
+
+    it('toggle-row-group removes the group key when present', () => {
+      let state = reduce(init, { type: 'toggle-row-group', groupId: 'g1' });
+      state = reduce(state, { type: 'toggle-row-group', groupId: 'g1' });
+      expect(state.rowGroupExpanded.has('g1')).toBe(false);
+    });
+
+    it('toggle-row-group does not mutate the original set', () => {
+      const first = reduce(init, { type: 'toggle-row-group', groupId: 'g1' });
+      const second = reduce(first, { type: 'toggle-row-group', groupId: 'g2' });
+      expect(first.rowGroupExpanded.has('g2')).toBe(false);
+      expect(second.rowGroupExpanded.has('g1')).toBe(true);
+      expect(second.rowGroupExpanded.has('g2')).toBe(true);
+    });
+
+    it('set-row-group-expanded replaces the expanded set', () => {
+      const next = reduce(init, {
+        type: 'set-row-group-expanded',
+        expanded: new Set(['a', 'b']),
+      });
+      expect(next.rowGroupExpanded).toEqual(new Set(['a', 'b']));
+    });
+  });
+
+  // ---- Row drag ----
+
+  describe('row drag', () => {
+    it('start-row-drag transitions to dragging with source info', () => {
+      const next = reduce(init, {
+        type: 'start-row-drag',
+        sourceRowId: 'row-7',
+        sourceIndex: 7,
+      });
+      expect(next.rowDrag).toEqual({
+        type: 'dragging',
+        sourceRowId: 'row-7',
+        sourceIndex: 7,
+      });
+    });
+
+    it('end-row-drag resets to idle when dragging', () => {
+      let state = reduce(init, {
+        type: 'start-row-drag',
+        sourceRowId: 'row-7',
+        sourceIndex: 7,
+      });
+      state = reduce(state, { type: 'end-row-drag' });
+      expect(state.rowDrag).toEqual({ type: 'idle' });
+    });
+
+    it('end-row-drag from idle is a no-op (returns same state ref)', () => {
+      const next = reduce(init, { type: 'end-row-drag' });
+      expect(next).toBe(init);
+    });
+  });
+
+  // ---- Filter menu ----
+
+  describe('filter menu', () => {
+    const anchor = { top: 10, left: 20, bottom: 30, right: 40 };
+
+    it('open-filter-menu sets filterMenu to open with field + anchor', () => {
+      const next = reduce(init, { type: 'open-filter-menu', field: 'email', anchor });
+      expect(next.filterMenu).toEqual({ type: 'open', field: 'email', anchor });
+    });
+
+    it('close-filter-menu resets filterMenu to closed when open', () => {
+      let state = reduce(init, { type: 'open-filter-menu', field: 'email', anchor });
+      state = reduce(state, { type: 'close-filter-menu' });
+      expect(state.filterMenu).toEqual({ type: 'closed' });
+    });
+
+    it('close-filter-menu from closed is a no-op (returns same state ref)', () => {
+      const next = reduce(init, { type: 'close-filter-menu' });
+      expect(next).toBe(init);
+    });
+
+    it('opening a filter menu for another field replaces the previous one', () => {
+      let state = reduce(init, { type: 'open-filter-menu', field: 'email', anchor });
+      state = reduce(state, { type: 'open-filter-menu', field: 'name', anchor });
+      expect(state.filterMenu).toEqual({ type: 'open', field: 'name', anchor });
+    });
+  });
+
+  // ---- Condition dialog ----
+
+  describe('condition dialog', () => {
+    it('open-condition-dialog sets dialog to open for a field', () => {
+      const next = reduce(init, { type: 'open-condition-dialog', field: 'amount' });
+      expect(next.conditionDialog).toEqual({ type: 'open', field: 'amount' });
+    });
+
+    it('close-condition-dialog resets to closed when open', () => {
+      let state = reduce(init, { type: 'open-condition-dialog', field: 'amount' });
+      state = reduce(state, { type: 'close-condition-dialog' });
+      expect(state.conditionDialog).toEqual({ type: 'closed' });
+    });
+
+    it('close-condition-dialog from closed is a no-op (returns same state ref)', () => {
+      const next = reduce(init, { type: 'close-condition-dialog' });
+      expect(next).toBe(init);
     });
   });
 

--- a/packages/react/src/state/grid-interaction-state.ts
+++ b/packages/react/src/state/grid-interaction-state.ts
@@ -23,6 +23,30 @@ export type MenuState =
   | { type: 'column'; field: string }
   | { type: 'columnVisibility' };
 
+export type RowDragState =
+  | { type: 'idle' }
+  | { type: 'dragging'; sourceRowId: string; sourceIndex: number };
+
+/**
+ * Anchor rect captured at the moment the Excel filter dropdown opens.
+ * Stored as plain numbers (rather than a live DOMRect) so the popup
+ * positioning is decoupled from the header button's layout lifecycle.
+ */
+export interface FilterMenuAnchor {
+  top: number;
+  left: number;
+  bottom: number;
+  right: number;
+}
+
+export type FilterMenuState =
+  | { type: 'closed' }
+  | { type: 'open'; field: string; anchor: FilterMenuAnchor };
+
+export type ConditionDialogState =
+  | { type: 'closed' }
+  | { type: 'open'; field: string };
+
 // ---- Combined state ----
 
 export interface GridInteractionState {
@@ -36,6 +60,14 @@ export interface GridInteractionState {
   hiddenColumns: Set<string>;
   frozenOverrides: Record<string, 'left' | 'right' | null>;
   collapsedColumnGroups: Set<string>;
+  // Phase-3 follow-up (issue #106): the four ex-useState holders that
+  // also track "grid-domain interaction state" now live on the same
+  // node as menu/columnDrag/resize so SPA-side derivations can read
+  // them atomically alongside the rest.
+  rowGroupExpanded: Set<string>;
+  rowDrag: RowDragState;
+  filterMenu: FilterMenuState;
+  conditionDialog: ConditionDialogState;
 }
 
 export const initialGridInteractionState: GridInteractionState = {
@@ -49,6 +81,10 @@ export const initialGridInteractionState: GridInteractionState = {
   hiddenColumns: new Set(),
   frozenOverrides: {},
   collapsedColumnGroups: new Set(),
+  rowGroupExpanded: new Set(),
+  rowDrag: { type: 'idle' },
+  filterMenu: { type: 'closed' },
+  conditionDialog: { type: 'closed' },
 };
 
 // ---- Action union ----
@@ -75,7 +111,19 @@ export type GridInteractionAction =
   | { type: 'unfreeze-column'; field: string }
   | { type: 'toggle-column-group-collapse'; groupId: string }
   | { type: 'set-column-order'; order: string[] }
-  | { type: 'set-column-group-order'; order: string[] };
+  | { type: 'set-column-group-order'; order: string[] }
+  // Row grouping — caller-driven expand/collapse of grouped rows.
+  | { type: 'toggle-row-group'; groupId: string }
+  | { type: 'set-row-group-expanded'; expanded: Set<string> }
+  // Row drag — active row-reorder session.
+  | { type: 'start-row-drag'; sourceRowId: string; sourceIndex: number }
+  | { type: 'end-row-drag' }
+  // Excel-style column filter menu.
+  | { type: 'open-filter-menu'; field: string; anchor: FilterMenuAnchor }
+  | { type: 'close-filter-menu' }
+  // "Custom filter…" condition dialog.
+  | { type: 'open-condition-dialog'; field: string }
+  | { type: 'close-condition-dialog' };
 
 // ---- Helpers ----
 
@@ -273,6 +321,59 @@ export function gridInteractionReducer(
         ...state,
         columnGroupOrder: action.order,
       };
+
+    // -- Row group expand/collapse --
+    case 'toggle-row-group': {
+      const next = new Set(state.rowGroupExpanded);
+      if (next.has(action.groupId)) {
+        next.delete(action.groupId);
+      } else {
+        next.add(action.groupId);
+      }
+      return { ...state, rowGroupExpanded: next };
+    }
+
+    case 'set-row-group-expanded':
+      return { ...state, rowGroupExpanded: action.expanded };
+
+    // -- Row drag --
+    case 'start-row-drag':
+      return {
+        ...state,
+        rowDrag: {
+          type: 'dragging',
+          sourceRowId: action.sourceRowId,
+          sourceIndex: action.sourceIndex,
+        },
+      };
+
+    case 'end-row-drag':
+      // No-op short-circuit so the no-op end (e.g. a stray drop outside a
+      // valid target) does not generate a dead causl commit.
+      if (state.rowDrag.type === 'idle') return state;
+      return { ...state, rowDrag: { type: 'idle' } };
+
+    // -- Excel filter menu --
+    case 'open-filter-menu':
+      return {
+        ...state,
+        filterMenu: { type: 'open', field: action.field, anchor: action.anchor },
+      };
+
+    case 'close-filter-menu':
+      if (state.filterMenu.type === 'closed') return state;
+      return { ...state, filterMenu: { type: 'closed' } };
+
+    // -- Condition dialog --
+    case 'open-condition-dialog':
+      return {
+        ...state,
+        conditionDialog: { type: 'open', field: action.field },
+      };
+
+    case 'close-condition-dialog':
+      if (state.conditionDialog.type === 'closed') return state;
+      return { ...state, conditionDialog: { type: 'closed' } };
 
     default:
       return state;

--- a/packages/react/src/state/index.ts
+++ b/packages/react/src/state/index.ts
@@ -1,10 +1,14 @@
 export {
   type ColumnDragState,
   type ColumnGroupDragState,
+  type ConditionDialogState,
+  type FilterMenuAnchor,
+  type FilterMenuState,
   type GridInteractionAction,
   type GridInteractionState,
   type MenuState,
   type ResizeState,
+  type RowDragState,
   gridInteractionReducer,
   initialGridInteractionState,
 } from './grid-interaction-state';

--- a/packages/react/src/state/use-grid-interaction.ts
+++ b/packages/react/src/state/use-grid-interaction.ts
@@ -30,6 +30,7 @@ import {
   initialGridInteractionState,
   type GridInteractionState,
   type GridInteractionAction,
+  type FilterMenuAnchor,
 } from './grid-interaction-state';
 
 export interface UseGridInteractionOptions {
@@ -70,6 +71,18 @@ export interface UseGridInteractionReturn {
   unfreezeColumn: (field: string) => void;
   toggleColumnGroupCollapse: (groupId: string) => void;
   setColumnOrder: (order: string[]) => void;
+  // Row groups
+  toggleRowGroup: (groupId: string) => void;
+  setRowGroupExpanded: (expanded: Set<string>) => void;
+  // Row drag session
+  startRowDrag: (sourceRowId: string, sourceIndex: number) => void;
+  endRowDrag: () => void;
+  // Excel filter menu
+  openFilterMenu: (field: string, anchor: FilterMenuAnchor) => void;
+  closeFilterMenu: () => void;
+  // Custom-filter condition dialog
+  openConditionDialog: (field: string) => void;
+  closeConditionDialog: () => void;
 }
 
 export function useGridInteraction(
@@ -182,6 +195,37 @@ export function useGridInteraction(
     (order: string[]) => dispatch({ type: 'set-column-order', order }),
     [dispatch],
   );
+  const toggleRowGroup = useCallback(
+    (groupId: string) => dispatch({ type: 'toggle-row-group', groupId }),
+    [dispatch],
+  );
+  const setRowGroupExpanded = useCallback(
+    (expanded: Set<string>) => dispatch({ type: 'set-row-group-expanded', expanded }),
+    [dispatch],
+  );
+  const startRowDrag = useCallback(
+    (sourceRowId: string, sourceIndex: number) =>
+      dispatch({ type: 'start-row-drag', sourceRowId, sourceIndex }),
+    [dispatch],
+  );
+  const endRowDrag = useCallback(() => dispatch({ type: 'end-row-drag' }), [dispatch]);
+  const openFilterMenu = useCallback(
+    (field: string, anchor: FilterMenuAnchor) =>
+      dispatch({ type: 'open-filter-menu', field, anchor }),
+    [dispatch],
+  );
+  const closeFilterMenu = useCallback(
+    () => dispatch({ type: 'close-filter-menu' }),
+    [dispatch],
+  );
+  const openConditionDialog = useCallback(
+    (field: string) => dispatch({ type: 'open-condition-dialog', field }),
+    [dispatch],
+  );
+  const closeConditionDialog = useCallback(
+    () => dispatch({ type: 'close-condition-dialog' }),
+    [dispatch],
+  );
 
   return useMemo(
     () => ({
@@ -206,6 +250,14 @@ export function useGridInteraction(
       unfreezeColumn,
       toggleColumnGroupCollapse,
       setColumnOrder,
+      toggleRowGroup,
+      setRowGroupExpanded,
+      startRowDrag,
+      endRowDrag,
+      openFilterMenu,
+      closeFilterMenu,
+      openConditionDialog,
+      closeConditionDialog,
     }),
     [
       state,
@@ -229,6 +281,14 @@ export function useGridInteraction(
       unfreezeColumn,
       toggleColumnGroupCollapse,
       setColumnOrder,
+      toggleRowGroup,
+      setRowGroupExpanded,
+      startRowDrag,
+      endRowDrag,
+      openFilterMenu,
+      closeFilterMenu,
+      openConditionDialog,
+      closeConditionDialog,
     ],
   );
 }


### PR DESCRIPTION
## Summary

Phase 3 lifted `useGridInteraction` onto a causl input node, but four `useState` holders in `DataGrid.tsx` were left behind even though they track the same shape of "grid-domain interaction state":

- `rowGroupExpanded: Set<string>` — collapsed/expanded group ids
- `rowDragState` — active row-drag session info
- `filterMenuOpen` — which column's Excel-style dropdown is open (+ anchor rect)
- `conditionDialogOpen` — open state of the custom-filter modal launched from the dropdown

Those holders are now first-class members of `GridInteractionState` under the same `interaction:state` causl node as menu / column-drag / resize, so SPA-side `graph.derived(...)` nodes can read every piece of grid interaction state atomically alongside data state.

### State changes

- `grid-interaction-state.ts` gains four discriminated sub-state types (`RowDragState`, `FilterMenuState`, `ConditionDialogState`, plus `FilterMenuAnchor` for the captured popup geometry) and eight new actions: `toggle-row-group`, `set-row-group-expanded`, `start-row-drag`, `end-row-drag`, `open-filter-menu`, `close-filter-menu`, `open-condition-dialog`, `close-condition-dialog`. Close/end actions follow the existing no-op short-circuit pattern so closing an already-closed menu does not generate dead causl commits.
- `use-grid-interaction.ts` exposes stable convenience helpers matching the existing surface: `toggleRowGroup`, `setRowGroupExpanded`, `startRowDrag`, `endRowDrag`, `openFilterMenu`, `closeFilterMenu`, `openConditionDialog`, `closeConditionDialog`.
- `DataGrid.tsx` drops the four `useState` calls and now reads / writes through the unified hook. Local consts (`rowGroupExpanded`, `rowDragState`, `filterMenuOpen`, `conditionDialogOpen`) preserve call-site ergonomics; behaviour is identical, just routed through the graph.

### Out of scope (kept local — different lifecycle / pure UI)

`validationErrors`, `tooltipState`, `theme`, `focusedCell`, and `MasterDetail.tsx`'s local state.

## Test plan

- [x] `pnpm vitest run packages/` — all 1959 tests pass (109 files)
- [x] `pnpm typecheck` — clean
- [x] New reducer test cases (`grid-interaction-state.test.ts`) cover every new action including no-op short-circuit assertions
- [x] New causl contract assertions (`grid-interaction-causl.contract.test.tsx`) — one per new field — confirm `interaction:<action>` commits land on the host graph
- [x] New `e2e/issue-106-interaction-state-lifted.spec.ts` covers row drag with drop indicator, Excel filter menu open/Escape-close, and row-group collapse/expand on the Kitchen Sink stories — all 3 specs pass locally

Closes #106