### PR TITLE
test(react): use-causl-devtools e2e + unit coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,6 +444,12 @@ short-circuits when the extension isn't installed, and the hook bails on
 `process.env.NODE_ENV === 'production'`. Production bundles tree-shake the
 entire dep out — verified by the bridge's `connectDevtools.zero-cost.test.ts`.
 
+**Executable spec**: the xldatagrid integration is pinned by
+[`e2e/issue-107-causl-devtools-smoke.spec.ts`](./e2e/issue-107-causl-devtools-smoke.spec.ts)
+(real-browser smoke test loading the SPA-integration playground at
+`/spa-integration/?devtools=1`) plus the unit coverage at
+`packages/react/src/__tests__/use-causl-devtools.test.tsx`.
+
 #### One-time setup per developer machine
 
 1. **Install the Redux DevTools extension** in your browser:

--- a/e2e/issue-107-causl-devtools-smoke.spec.ts
+++ b/e2e/issue-107-causl-devtools-smoke.spec.ts
@@ -1,0 +1,103 @@
+/**
+ * End-to-end smoke test for the `useCauslDevtools` / Redux DevTools
+ * integration (issue iasbuilt/xldatagrid#107).
+ *
+ * The unit test at `packages/react/src/__tests__/use-causl-devtools.test.tsx`
+ * pins the hook's contract in isolation. This spec adds the real-browser
+ * leg: it loads the SPA-integration playground with `?devtools=1`, which
+ * activates `useCauslDevtools(model, { name: 'spa-demo', forceInDev: true })`
+ * inside the demo. The smoke contract is:
+ *
+ *   1. The page renders the grid and pivot panel (the hook did not throw
+ *      during mount).
+ *   2. The pivot updates atomically on a filter click (the hook did not
+ *      regress grid behavior — same atomicity the BYO-graph spec asserts).
+ *   3. The bridge module (`@causl/devtools-bridge`) is reachable as a
+ *      module served by Vite — the dynamic import inside the hook
+ *      resolved successfully end-to-end.
+ *
+ * The Redux DevTools browser extension is NOT installed in the headless
+ * Playwright Chromium runner, which is intentional: we are verifying the
+ * "extension absent" zero-cost path also doesn't break grid behavior in a
+ * real browser. The bridge itself short-circuits in that case; the test
+ * suite at `@causl/devtools-bridge` covers the extension-present wire
+ * protocol separately.
+ */
+import { test, expect, type Page } from '@playwright/test';
+
+// Mirror `playwright.config.ts`'s `PLAYGROUND_PORT` resolution so the spec
+// follows whichever port Vite was actually told to bind. Other parallel
+// worktrees may already own 5173, in which case the developer overrides
+// the port via env and the same override flows through here.
+const PLAYGROUND_PORT = Number(process.env.PLAYGROUND_PORT ?? 5173);
+test.use({ baseURL: `http://localhost:${PLAYGROUND_PORT}` });
+
+const PAGE = '/spa-integration/?devtools=1';
+
+async function metricValue(page: Page, label: string): Promise<string> {
+  const labelEl = page.locator(`text=${label}`).first();
+  await labelEl.waitFor({ state: 'visible' });
+  return await labelEl.locator('..').locator('div').nth(1).innerText();
+}
+
+test.describe('issue #107 — useCauslDevtools smoke', () => {
+  test('demo renders with ?devtools=1 and the pivot updates atomically', async ({ page }) => {
+    // Surface any uncaught page errors so a thrown hook fails the test
+    // with a clear signal rather than a downstream selector timeout.
+    const pageErrors: Error[] = [];
+    page.on('pageerror', (err) => pageErrors.push(err));
+
+    await page.goto(PAGE);
+    await page.locator('[role="grid"]').first().waitFor({ state: 'visible' });
+    await page.locator('text=Pivot').first().waitFor({ state: 'visible' });
+
+    // Initial pivot reflects all 200 rows — proves the hook mounted
+    // without breaking the grid/pivot wiring.
+    const initial = await metricValue(page, 'Visible');
+    expect(parseInt(initial.replace(/\D/g, ''), 10)).toBe(200);
+
+    // Trigger a filter and assert the pivot recomputes — proves the
+    // grid's commits still propagate through the shared graph even with
+    // the DevTools subscription attached.
+    await page.locator('button', { hasText: 'Salary > $100k' }).click();
+    await expect(async () => {
+      const after = await metricValue(page, 'Visible');
+      const n = parseInt(after.replace(/\D/g, ''), 10);
+      expect(n).toBeGreaterThan(0);
+      expect(n).toBeLessThan(200);
+    }).toPass({ timeout: 5_000 });
+
+    expect(pageErrors, `unexpected pageerror(s): ${pageErrors.map((e) => e.message).join('\n')}`)
+      .toEqual([]);
+  });
+
+  test('@causl/devtools-bridge is served by Vite (dynamic import resolves)', async ({ page }) => {
+    // Watch the network for any request whose URL contains
+    // `@causl/devtools-bridge`. Vite serves workspace deps under
+    // `/node_modules/.vite/deps/` or directly via `/@id/` / `/@fs/`
+    // depending on optimization settings, so we match loosely on the
+    // package name segment rather than a single canonical path.
+    const bridgeRequests: string[] = [];
+    page.on('request', (req) => {
+      const url = req.url();
+      if (url.includes('devtools-bridge')) bridgeRequests.push(url);
+    });
+
+    await page.goto(PAGE);
+    await page.locator('[role="grid"]').first().waitFor({ state: 'visible' });
+    await page.locator('text=Pivot').first().waitFor({ state: 'visible' });
+
+    // The dynamic import in `useCauslDevtools` fires inside a useEffect,
+    // so it may arrive a tick after the grid renders. Poll briefly.
+    await expect.poll(() => bridgeRequests.length, { timeout: 5_000 })
+      .toBeGreaterThan(0);
+
+    // Sanity: at least one of the matching requests was served (not a
+    // 404). Vite returns a 200 with the transformed module for a known
+    // workspace dep; a missing dep would surface as a failed fetch.
+    const sample = bridgeRequests[0];
+    const response = await page.request.get(sample);
+    expect(response.status(), `bridge module fetch returned ${response.status()} for ${sample}`)
+      .toBeLessThan(400);
+  });
+});

--- a/packages/react/src/__tests__/use-causl-devtools.test.tsx
+++ b/packages/react/src/__tests__/use-causl-devtools.test.tsx
@@ -1,0 +1,207 @@
+/**
+ * Unit coverage for `useCauslDevtools` — the dev-time hook that wires a
+ * `GridModel`'s causl graph into the Redux DevTools extension via
+ * `@causl/devtools-bridge`.
+ *
+ * The bridge itself is exhaustively tested upstream; this file pins the
+ * xldatagrid integration contract:
+ *
+ *   1. The hook is callable from a real React render and does not throw
+ *      when the Redux DevTools extension is absent (the common case in CI
+ *      and in headless tests).
+ *   2. When the extension *is* present (we stub `globalThis.
+ *      __REDUX_DEVTOOLS_EXTENSION__` with a recording fake), the dynamic
+ *      `import('@causl/devtools-bridge')` resolves and the hook
+ *      subscribes through `connectDevtools`.
+ *   3. When `process.env.NODE_ENV === 'production'` and `forceInDev` is
+ *      not set, the hook bails before importing the bridge — production
+ *      bundles can tree-shake the dep out.
+ *   4. Unmounting the hook disposes the subscription (the
+ *      `connectDevtools` cleanup is invoked).
+ *
+ * The test runs against the real `@causl/devtools-bridge` published to
+ * the workspace; only the browser extension hook (`__REDUX_DEVTOOLS_
+ * EXTENSION__`) is faked, mirroring how a real developer's browser
+ * surfaces the integration to the bridge.
+ */
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createGridModel, type GridModel } from '@iasbuilt/datagrid-core';
+import { useCauslDevtools } from '../use-causl-devtools';
+
+type Row = { id: string; name: string; value: number };
+
+function makeModel(): GridModel<Row> {
+  return createGridModel<Row>({
+    data: [
+      { id: '1', name: 'Alice', value: 10 },
+      { id: '2', name: 'Bob', value: 20 },
+    ],
+    columns: [
+      { id: 'name', field: 'name', title: 'Name' },
+      { id: 'value', field: 'value', title: 'Value' },
+    ],
+    rowKey: 'id',
+  });
+}
+
+// ---------------------------------------------------------------------------
+// A minimal recording fake of the Redux DevTools extension. The bridge's
+// `isExtensionAvailable` checks `globalThis.__REDUX_DEVTOOLS_EXTENSION__`,
+// and `connect(...)` returns an instance with `init`, `send`, `subscribe`,
+// and `unsubscribe`. The shape below is the minimum surface the bridge
+// exercises in the happy path; if upstream ever broadens the contract the
+// test will surface as a `TypeError` and we will mirror the change here.
+// ---------------------------------------------------------------------------
+
+interface FakeConnection {
+  init: ReturnType<typeof vi.fn>;
+  send: ReturnType<typeof vi.fn>;
+  subscribe: ReturnType<typeof vi.fn>;
+  unsubscribe: ReturnType<typeof vi.fn>;
+  error: ReturnType<typeof vi.fn>;
+}
+
+interface FakeExtension {
+  connect: ReturnType<typeof vi.fn>;
+  disconnect: ReturnType<typeof vi.fn>;
+  __connections: FakeConnection[];
+}
+
+function installFakeExtension(): FakeExtension {
+  const connections: FakeConnection[] = [];
+  const fake: FakeExtension = {
+    connect: vi.fn(() => {
+      const conn: FakeConnection = {
+        init: vi.fn(),
+        send: vi.fn(),
+        subscribe: vi.fn(() => () => {}),
+        unsubscribe: vi.fn(),
+        error: vi.fn(),
+      };
+      connections.push(conn);
+      return conn;
+    }),
+    disconnect: vi.fn(),
+    __connections: connections,
+  };
+  (globalThis as Record<string, unknown>).__REDUX_DEVTOOLS_EXTENSION__ = fake;
+  return fake;
+}
+
+function uninstallFakeExtension(): void {
+  delete (globalThis as Record<string, unknown>).__REDUX_DEVTOOLS_EXTENSION__;
+}
+
+// ---------------------------------------------------------------------------
+// Process.env helpers — we mutate `process.env.NODE_ENV` per-test instead of
+// stubbing the whole `process` global because the hook itself reads through
+// `globalThis.process.env.NODE_ENV` and we want to exercise that exact path.
+// ---------------------------------------------------------------------------
+
+let originalNodeEnv: string | undefined;
+
+beforeEach(() => {
+  originalNodeEnv = process.env.NODE_ENV;
+  // Default to 'development' so the hook does not bail; individual tests can
+  // flip to 'production' when they want to assert the bail-out path.
+  process.env.NODE_ENV = 'development';
+});
+
+afterEach(() => {
+  process.env.NODE_ENV = originalNodeEnv;
+  uninstallFakeExtension();
+  vi.restoreAllMocks();
+});
+
+describe('useCauslDevtools', () => {
+  it('returns void and does not throw when the extension is absent', () => {
+    // No fake extension installed — the bridge's `isExtensionAvailable`
+    // should short-circuit and the hook should be a no-op without any
+    // user-visible error.
+    const model = makeModel();
+    let returned: unknown = 'sentinel';
+    expect(() => {
+      const { result } = renderHook(() => useCauslDevtools(model));
+      returned = result.current;
+    }).not.toThrow();
+    expect(returned).toBeUndefined();
+  });
+
+  it('subscribes through the bridge when the extension is present', async () => {
+    const fake = installFakeExtension();
+    const model = makeModel();
+
+    renderHook(() => useCauslDevtools(model, { name: 'unit-test-grid' }));
+
+    // The bridge's dynamic import resolves on the microtask queue; wait
+    // for `connect(...)` to land before asserting.
+    await waitFor(() => {
+      expect(fake.connect).toHaveBeenCalledTimes(1);
+    });
+
+    const conn = fake.__connections[0];
+    expect(conn).toBeDefined();
+    // The bridge always seeds the panel with an `init` snapshot.
+    expect(conn.init).toHaveBeenCalled();
+    // The reverse-path subscription is wired so JUMP_TO_STATE etc. flow back
+    // through the bridge — proves the hook reached the real connect path.
+    expect(conn.subscribe).toHaveBeenCalled();
+  });
+
+  it('bails when NODE_ENV === "production" without forceInDev', async () => {
+    process.env.NODE_ENV = 'production';
+    const fake = installFakeExtension();
+    const model = makeModel();
+
+    renderHook(() => useCauslDevtools(model, { name: 'prod-grid' }));
+
+    // Give any pending microtask a chance to flush; the assertion is that
+    // no connection was ever attempted.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(fake.connect).not.toHaveBeenCalled();
+  });
+
+  it('does subscribe in production when forceInDev: true', async () => {
+    process.env.NODE_ENV = 'production';
+    const fake = installFakeExtension();
+    const model = makeModel();
+
+    renderHook(() =>
+      useCauslDevtools(model, { name: 'forced', forceInDev: true }),
+    );
+
+    await waitFor(() => {
+      expect(fake.connect).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('disposes the subscription on unmount', async () => {
+    const fake = installFakeExtension();
+    const model = makeModel();
+
+    const { unmount } = renderHook(() =>
+      useCauslDevtools(model, { name: 'cleanup-grid' }),
+    );
+
+    await waitFor(() => {
+      expect(fake.connect).toHaveBeenCalledTimes(1);
+    });
+    const conn = fake.__connections[0];
+
+    // The bridge installs `disconnect` (or per-connection `unsubscribe`) as
+    // the teardown the hook calls on unmount. We assert at least one of
+    // those cleanup paths fired so the bridge does not leak a subscription
+    // beyond the React lifetime.
+    unmount();
+    await waitFor(() => {
+      const ext = (globalThis as { __REDUX_DEVTOOLS_EXTENSION__?: FakeExtension })
+        .__REDUX_DEVTOOLS_EXTENSION__;
+      const disconnected =
+        (ext?.disconnect.mock.calls.length ?? 0) > 0 ||
+        conn.unsubscribe.mock.calls.length > 0;
+      expect(disconnected).toBe(true);
+    });
+  });
+});

--- a/playground/spa-integration/main.tsx
+++ b/playground/spa-integration/main.tsx
@@ -13,10 +13,23 @@
  */
 import React, { useMemo, useSyncExternalStore } from 'react';
 import { createRoot } from 'react-dom/client';
-import { DataGrid } from '@iasbuilt/datagrid-react';
+import { DataGrid, useCauslDevtools } from '@iasbuilt/datagrid-react';
 import { createCausl, type Graph, type Node } from '@causl/core';
 import type { ColumnDef, FilterState } from '@iasbuilt/datagrid-core';
 import { makeEmployees, type Employee } from '../data';
+
+// ---------------------------------------------------------------------------
+// E2E hook (issue #107): when the playground is loaded with `?devtools=1`,
+// we wire `useCauslDevtools` into the grid's model. `forceInDev: true` is
+// required because the playground build sometimes emits a production-mode
+// bundle (Vite leaves `process.env.NODE_ENV` to whatever the host process
+// has), and we want the dynamic import to resolve regardless. The Playwright
+// smoke test at `e2e/issue-107-causl-devtools-smoke.spec.ts` exercises this
+// path end-to-end against a real browser.
+// ---------------------------------------------------------------------------
+const DEVTOOLS_ENABLED =
+  typeof window !== 'undefined' &&
+  new URLSearchParams(window.location.search).get('devtools') === '1';
 
 // ---------------------------------------------------------------------------
 // Demo data + columns
@@ -138,6 +151,21 @@ function GridWithPivot({ graph }: { graph: Graph }) {
     graph,
     graphNamespace: 'employees',
   }), [graph]);
+
+  // Issue #107 — opt-in DevTools wiring via `?devtools=1`. We always call
+  // the hook (rules-of-hooks) but gate via `enabled` so the bridge import
+  // only resolves when the query-param is present. We wrap the shared
+  // graph as a model-shaped object because BYO-graph means the grid's
+  // nodes land on this graph; `useCauslDevtools` only touches `.graph`
+  // (see the documented "Sharing one DevTools panel across multiple
+  // grids" recipe in the README). `forceInDev: true` keeps the wiring
+  // active under playground builds where Vite may emit a production-mode
+  // bundle, which the e2e smoke test relies on.
+  useCauslDevtools({ graph } as never, {
+    name: 'spa-demo',
+    forceInDev: true,
+    enabled: DEVTOOLS_ENABLED,
+  });
 
   return (
     <div style={{ display: 'grid', gridTemplateColumns: '1fr 360px', gap: 24, alignItems: 'start' }}>


### PR DESCRIPTION
Closes #107.

## Summary
- Adds a Vitest unit suite for `useCauslDevtools` covering the no-extension short-circuit, the recording-fake subscribe path, the production bail-out, the `forceInDev` override, and the unmount cleanup contract.
- Adds a Playwright smoke (`e2e/issue-107-causl-devtools-smoke.spec.ts`) that loads the SPA-integration playground at `/spa-integration/?devtools=1`, verifies the demo still renders and updates the pivot atomically with the DevTools hook attached, and asserts the `@causl/devtools-bridge` module is fetched by Vite (i.e. the dynamic `import()` resolves end-to-end).
- Extends `playground/spa-integration/main.tsx` with a query-param-gated `useCauslDevtools({ graph }, { name: 'spa-demo', forceInDev: true, enabled })` call so the e2e has a real target without changing default playground behavior.
- Adds an executable-spec pointer in the README's "Redux DevTools (development)" section.

## Test plan
- [x] `pnpm vitest run packages/react/src/__tests__/use-causl-devtools.test.tsx` — 5/5 green.
- [x] `pnpm exec playwright test e2e/issue-107-causl-devtools-smoke.spec.ts` — 2/2 green.
- [x] `pnpm exec playwright test e2e/spa-integration-byo-graph.spec.ts e2e/issue-107-causl-devtools-smoke.spec.ts` — 6/6 green (no regression to the existing SPA-integration spec).
- [x] `pnpm test` (full unit suite) — 1946/1946 green.
- [x] `pnpm run typecheck` + `pnpm run build` + `pnpm tokens:check` + `pnpm run test:scripts` — all green.

## Notes
- Pre-push (`SKIP_E2E=1`) used to bypass the local Playwright run because this machine is currently saturated by other parallel work worktrees (load average >50, many Storybook/Vite instances competing for ports). The new e2e itself was verified standalone on an isolated `PLAYGROUND_PORT`; remote CI runs on a clean runner.