### PR TITLE
feat(richtext): portaled floating toolbar + show-formatting toggle (closes #81)

### DIFF
--- a/e2e/issue-81-richtext-floating-toolbar.spec.ts
+++ b/e2e/issue-81-richtext-floating-toolbar.spec.ts
@@ -1,0 +1,163 @@
+/**
+ * End-to-end coverage for issue #81 — RichText cell: portaled floating
+ * formatting toolbar + "Show formatting" toggle + keyboard shortcuts.
+ *
+ * Companion to `rich-text-floating-menu.spec.ts` (the original spec authored
+ * with the issue), this file extends coverage to the additional surfaces
+ * called out in the implementation brief:
+ *
+ *   1. Portal placement — `[role="toolbar"][data-floating-menu]` lives at
+ *      `document.body`, not inside the cell. (Cross-checks the original.)
+ *   2. Show-formatting toggle — flipping the toggle ON surfaces raw markdown
+ *      delimiters in the editor's visible text.
+ *   3. Keyboard shortcuts — Ctrl/Cmd+B wraps the selection in `**...**` in
+ *      the underlying draft buffer (the canonical `<textarea>` mirror).
+ *   4. Right-edge alignment — when the cell sits near the viewport right
+ *      edge, the toolbar shifts left (`data-align="right"`).
+ *
+ * Drives the `Examples/Cell Types → AllCellTypes` story rendered by the
+ * MuiDataGrid (see `stories/CellTypes.stories.tsx`).
+ */
+import { test, expect, type Locator, type Page } from '@playwright/test';
+
+const CELL_TYPES_URL =
+  '/iframe.html?viewMode=story&id=examples-cell-types--all-cell-types';
+
+function richTextCell(page: Page, rowId: string): Locator {
+  return page.locator(
+    `[role="gridcell"][data-row-id="${rowId}"][data-field="richText"]`,
+  );
+}
+
+async function enterEditMode(cell: Locator): Promise<void> {
+  await cell.dblclick();
+  await cell
+    .locator('textarea, [contenteditable="true"]')
+    .first()
+    .waitFor({ state: 'visible' });
+}
+
+test.describe('issue #81 — RichText floating toolbar', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(CELL_TYPES_URL);
+    await page.locator('[role="grid"]').first().waitFor({ state: 'visible' });
+  });
+
+  test('floating toolbar mounts via portal at document.body (not inside the cell)', async ({
+    page,
+  }) => {
+    const cell = richTextCell(page, '2');
+    await enterEditMode(cell);
+
+    const menu = page.locator('[role="toolbar"][data-floating-menu]');
+    await expect(menu).toHaveCount(1);
+    await expect(menu).toBeVisible();
+
+    // Toolbar must not be a descendant of the cell, AND its closest fixed-
+    // position ancestor should be <body> — i.e. it was portaled out, not
+    // merely position:fixed inside the cell stacking context.
+    const result = await cell.evaluate((cellEl) => {
+      const toolbar = document.querySelector(
+        '[role="toolbar"][data-floating-menu]',
+      ) as HTMLElement | null;
+      return {
+        descendantOfCell: toolbar ? cellEl.contains(toolbar) : null,
+        parentTag: toolbar?.parentElement?.tagName?.toLowerCase() ?? null,
+      };
+    });
+    expect(result.descendantOfCell).toBe(false);
+    // Portal target is `document.body`, so the toolbar's parent is BODY.
+    expect(result.parentTag).toBe('body');
+  });
+
+  test('"Show formatting" toggle reveals raw markdown delimiters in the editor', async ({
+    page,
+  }) => {
+    const cell = richTextCell(page, '2');
+    await enterEditMode(cell);
+
+    const menu = page.locator('[role="toolbar"][data-floating-menu]');
+    const toggle = menu.getByRole('button', { name: /show formatting/i });
+    await expect(toggle).toHaveAttribute('aria-pressed', 'false');
+
+    const editor = cell.locator('[contenteditable="true"]').first();
+    // Seed a deterministic markdown payload — the textarea mirror is the
+    // canonical source of truth so we drive that and let the editor surface
+    // re-project the visible text.
+    const textarea = cell.locator('textarea').first();
+    await textarea.fill('**emphasis** check');
+
+    // Toggle OFF: delimiters NOT in visible text (default behaviour).
+    expect(((await editor.innerText()) ?? '').includes('**')).toBe(false);
+
+    await toggle.click();
+    await expect(toggle).toHaveAttribute('aria-pressed', 'true');
+
+    // Toggle ON: delimiters ARE in visible text.
+    const visibleAfter = (await editor.innerText()) ?? '';
+    expect(
+      visibleAfter.includes('**'),
+      `editor must show raw ** delimiters when toggle is ON; got ${JSON.stringify(visibleAfter)}`,
+    ).toBe(true);
+    expect(visibleAfter).toContain('emphasis');
+  });
+
+  test('Ctrl+B wraps the selection in ** in the textarea buffer', async ({
+    page,
+  }) => {
+    const cell = richTextCell(page, '1');
+    await enterEditMode(cell);
+
+    // The keyboard shortcut handler is bound to BOTH the contenteditable and
+    // the textarea (`onKeyDown={handleKeyDown}` on each surface in
+    // `MuiRichTextCell.tsx`). Drive the textarea directly — it's the
+    // canonical raw-markdown source and has a stable text-selection API.
+    const textarea = cell.locator('textarea').first();
+    await textarea.fill('emphasis');
+    // Force a deterministic selection range over the full draft. Pressing
+    // `Control+a` in a textarea is the more idiomatic gesture, but on
+    // platforms where the menu shortcut is `Cmd+a` the selection can fail
+    // to land — set the range explicitly to keep this assertion focused on
+    // the transform behaviour, not the platform-specific select-all hotkey.
+    await textarea.evaluate((el: HTMLTextAreaElement) => {
+      el.focus();
+      el.setSelectionRange(0, el.value.length);
+    });
+    await textarea.press('Control+b');
+
+    // After Ctrl+B the textarea draft must be wrapped in `**...**`.
+    await expect(textarea).toHaveValue('**emphasis**');
+  });
+
+  test('cell near right viewport edge anchors the toolbar to the right', async ({
+    page,
+  }) => {
+    // The story renders a horizontally-scrolling grid; the richText column
+    // sits near the right. Pick a cell, scroll its right edge close to the
+    // viewport's right edge, and confirm the toolbar flips alignment.
+    const cell = richTextCell(page, '1');
+    await cell.scrollIntoViewIfNeeded();
+    // Pin the cell's right edge close to the viewport's right edge so the
+    // alignment heuristic (EDGE_ALIGN_MARGIN px in the component) fires.
+    await cell.evaluate((el) => {
+      // Anchor the cell's right edge against the viewport right edge.
+      el.scrollIntoView({ inline: 'end', block: 'center' });
+    });
+
+    await enterEditMode(cell);
+
+    const menu = page.locator('[role="toolbar"][data-floating-menu]');
+    await expect(menu).toBeVisible();
+    // Alignment surfaces as data-align="right" when the cell is close to
+    // the viewport's right edge.
+    await expect(menu).toHaveAttribute('data-align', 'right');
+
+    // Sanity: confirm the toolbar's right-edge sits within the viewport
+    // (it wouldn't if alignment hadn't flipped).
+    const overflow = await menu.evaluate((el) => {
+      const r = el.getBoundingClientRect();
+      return r.right - window.innerWidth;
+    });
+    expect(overflow).toBeLessThanOrEqual(2);
+  });
+});

--- a/packages/mui/src/cells/MuiRichTextCell/MuiRichTextCell.tsx
+++ b/packages/mui/src/cells/MuiRichTextCell/MuiRichTextCell.tsx
@@ -381,6 +381,19 @@ export const MuiRichTextCell = React.memo(function MuiRichTextCell<TData = Recor
     }
   }, [visibleText, isEditing]);
 
+  /**
+   * Applies a markdown-wrapping transform against whichever editing surface
+   * is currently active. Toolbar clicks and shortcuts fired from the
+   * contenteditable read its caret position via {@link getEditableSelection};
+   * shortcuts fired from the textarea use its native `selectionStart` /
+   * `selectionEnd`. Both paths write back to the shared `draft` state so the
+   * two surfaces stay in lock-step.
+   *
+   * `sourceEl` is the optional surface the transform should target. When
+   * omitted (toolbar clicks), the contenteditable is preferred and we fall
+   * back to the textarea — the toolbar's `onMouseDown` preventDefault keeps
+   * the prior surface focused so this preference matches user expectations.
+   */
   const applyTransform = useCallback(
     (
       transform: (
@@ -388,17 +401,45 @@ export const MuiRichTextCell = React.memo(function MuiRichTextCell<TData = Recor
         selStart: number,
         selEnd: number,
       ) => TextSelection,
+      sourceEl?: HTMLElement | null,
     ) => {
-      const el = editableRef.current;
-      if (!el) return;
-      const { start, end } = getEditableSelection(el);
+      const textarea = textareaRef.current;
+      const editable = editableRef.current;
+      const target =
+        sourceEl === textarea
+          ? 'textarea'
+          : sourceEl === editable
+            ? 'editable'
+            : editable
+              ? 'editable'
+              : textarea
+                ? 'textarea'
+                : null;
+      if (!target) return;
+
+      let start = 0;
+      let end = 0;
+      if (target === 'textarea' && textarea) {
+        start = textarea.selectionStart ?? 0;
+        end = textarea.selectionEnd ?? 0;
+      } else if (target === 'editable' && editable) {
+        const sel = getEditableSelection(editable);
+        start = sel.start;
+        end = sel.end;
+      }
       const next = transform(draftRef.current, start, end);
       setDraft(next.value);
       draftRef.current = next.value;
-      // Restore selection after React commits — the sync effect above runs
-      // first and replaces the text nodes, so we schedule the caret update
-      // one microtask later so it resolves against the fresh DOM.
+      // Restore selection after React commits — the surface's DOM is replaced
+      // by the projection effect above, so we schedule the caret update one
+      // frame later so it resolves against the fresh DOM.
       requestAnimationFrame(() => {
+        if (target === 'textarea' && textareaRef.current) {
+          const ta = textareaRef.current;
+          ta.focus();
+          ta.setSelectionRange(next.selectionStart, next.selectionEnd);
+          return;
+        }
         const surface = editableRef.current;
         if (!surface) return;
         surface.focus();
@@ -417,19 +458,22 @@ export const MuiRichTextCell = React.memo(function MuiRichTextCell<TData = Recor
     const mod = e.ctrlKey || e.metaKey;
     if (!mod) return;
     const key = e.key.toLowerCase();
+    const source = e.currentTarget as HTMLElement;
     if (key === 'b') {
       e.preventDefault();
-      applyTransform((value, s, end) =>
-        wrapSelection(value, s, end, '**', '**', 'bold text'),
+      applyTransform(
+        (value, s, end) => wrapSelection(value, s, end, '**', '**', 'bold text'),
+        source,
       );
     } else if (key === 'i') {
       e.preventDefault();
-      applyTransform((value, s, end) =>
-        wrapSelection(value, s, end, '*', '*', 'italic text'),
+      applyTransform(
+        (value, s, end) => wrapSelection(value, s, end, '*', '*', 'italic text'),
+        source,
       );
     } else if (key === 'k') {
       e.preventDefault();
-      applyTransform(insertLink);
+      applyTransform(insertLink, source);
     }
   };
 


### PR DESCRIPTION
Closes #81.

## Summary

- Extends MuiRichTextCell so Ctrl/Cmd+B / I / K shortcuts also work when fired from the raw-markdown textarea mirror. `applyTransform` now resolves the selection from whichever surface dispatched the keydown, so the handler bound to the textarea no longer silently reads a stale selection from the contenteditable.
- Adds `e2e/issue-81-richtext-floating-toolbar.spec.ts` covering the implementation brief: portal mount at `document.body`, "Show formatting" toggle reveals raw delimiters, Ctrl+B wraps the selection in `**...**`, and right-edge alignment via `data-align="right"`.

## Test plan

- [x] `pnpm vitest run packages/` — 1941 tests pass
- [x] `pnpm exec playwright test e2e/issue-81-richtext-floating-toolbar.spec.ts e2e/rich-text-floating-menu.spec.ts` — 8/8 green
- [x] `pnpm exec tsc -b packages/*/tsconfig.build.json` — clean