### PR TITLE
feat(validation): tooltip severity icon + colored portal background (#78)

### DIFF
--- a/e2e/issue-78-validation-tooltip-severity.spec.ts
+++ b/e2e/issue-78-validation-tooltip-severity.spec.ts
@@ -1,0 +1,173 @@
+/**
+ * End-to-end coverage for issue #78 — "Validation tooltip: severity icon +
+ * red/yellow portal background".
+ *
+ * The companion spec `e2e/validation-tooltip.spec.ts` guards the broader
+ * portal-rendering contract (target attributes, no-inline-alert, error-first
+ * ordering). This file zeroes in on the issue-#78 visual contract:
+ *
+ *   - The tooltip portal has a **severity-keyed background colour** —
+ *     red for `error`, yellow for `warning`, blue for `info` — sourced from
+ *     the `--dg-validation-{error,warning,info}-bg` design token so the
+ *     hue can be retinted without code changes. We assert against the
+ *     hue family of the computed colour rather than a hex literal so the
+ *     test stays valid through token-pack swaps.
+ *   - The tooltip contains an **inline SVG severity icon** under
+ *     `[data-icon="<severity>"] > svg`. The wrapping `data-icon`
+ *     attribute is the load-bearing selector contract; the inner `<svg>`
+ *     is what swaps in for the legacy unicode glyph per the issue.
+ *
+ * The `Default` story under `examples-validation-tooltip` already exposes a
+ * cell wired to:
+ *   - an error-severity validator on `email` (regex format check)
+ *   - a warning-severity validator on `name` (`lettersOnly` rule)
+ * The story does NOT include an info-severity validator, so this spec
+ * exercises error + warning. Info coverage is exercised at the unit level
+ * via `packages/react/src/__tests__/validation-tooltip.test.tsx`; adding an
+ * info-severity validator to the shared story would have rippled into the
+ * existing "two validators" contract assertion in the sibling spec, so we
+ * deliberately keep the story shape stable here.
+ */
+import { test, expect, type Page } from '@playwright/test';
+
+const STORY_URL =
+  '/iframe.html?viewMode=story&id=examples-validation-tooltip--default';
+
+async function waitForGrid(page: Page): Promise<void> {
+  // First-hit storybook compilation can stretch past the 7.5s default expect
+  // window; mirror the timeout used by the sibling validation-tooltip spec.
+  await page
+    .locator('[role="grid"]')
+    .first()
+    .waitFor({ state: 'visible', timeout: 30_000 });
+}
+
+function parseRgb(s: string): [number, number, number] | null {
+  const m = s.match(/rgba?\s*\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)/);
+  if (!m) return null;
+  return [Number(m[1]), Number(m[2]), Number(m[3])];
+}
+
+// Hue-family probes — these intentionally match the same heuristics used by
+// `e2e/validation-tooltip.spec.ts` so a token-pack swap that satisfies one
+// spec satisfies the other too.
+function isRedFamily([r, g, b]: [number, number, number]): boolean {
+  return r > 180 && r > g + 40 && r > b + 40;
+}
+function isYellowFamily([r, g, b]: [number, number, number]): boolean {
+  return r > 180 && g > 140 && b < 120;
+}
+
+async function commit(
+  page: Page,
+  rowId: string,
+  field: string,
+  value: string,
+): Promise<void> {
+  const cell = page
+    .locator(`[role="gridcell"][data-row-id="${rowId}"][data-field="${field}"]`)
+    .first();
+  await cell.dblclick();
+  const input = page.locator('input:focus, textarea:focus').first();
+  await input.fill(value);
+  await input.press('Enter');
+}
+
+function tooltipFor(page: Page, rowId: string, field: string) {
+  return page
+    .locator(`[role="tooltip"][data-validation-target="${rowId}:${field}"]`)
+    .first();
+}
+
+test.describe('Issue #78 — validation tooltip severity icon + portal bg', () => {
+  // Bump the per-test budget so a cold Storybook (lazy story compile on
+  // first navigation, can stretch past the default 30s for a fresh worker)
+  // does not flake out the visual-contract assertions.
+  test.setTimeout(90_000);
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto(STORY_URL, { timeout: 60_000 });
+    await waitForGrid(page);
+  });
+
+  test('error severity: red portal background + inline SVG error icon', async ({
+    page,
+  }) => {
+    // Email column is wired with an error-severity regex validator in the
+    // shared story; entering a non-email value triggers it.
+    await commit(page, '1', 'email', 'not-an-email');
+
+    const tip = tooltipFor(page, '1', 'email');
+    await expect(tip).toBeVisible();
+    await expect(tip).toHaveAttribute('data-validation-severity', 'error');
+
+    // Background lives in the red family (issue-#78 contract — token-driven,
+    // so we probe the resolved colour rather than a hex literal).
+    const bg = await tip.evaluate(
+      (el) => getComputedStyle(el).backgroundColor,
+    );
+    const rgb = parseRgb(bg);
+    expect(rgb, `expected an rgb-ish background, got "${bg}"`).not.toBeNull();
+    expect(
+      isRedFamily(rgb!),
+      `expected red-family background, got rgb(${rgb!.join(', ')})`,
+    ).toBe(true);
+
+    // Inline SVG severity icon, wrapped in the load-bearing data-icon span.
+    const icon = tip.locator('[data-icon="error"]');
+    await expect(icon).toHaveCount(1);
+    await expect(icon.locator('svg')).toHaveCount(1);
+  });
+
+  test('warning severity: yellow portal background + inline SVG warning icon', async ({
+    page,
+  }) => {
+    // The `name` column has a warning-severity letters-only rule; committing
+    // digits triggers warning without tripping the minLength error rule.
+    await commit(page, '1', 'name', 'Alice99');
+
+    const tip = tooltipFor(page, '1', 'name');
+    await expect(tip).toBeVisible();
+    await expect(tip).toHaveAttribute('data-validation-severity', 'warning');
+
+    const bg = await tip.evaluate(
+      (el) => getComputedStyle(el).backgroundColor,
+    );
+    const rgb = parseRgb(bg);
+    expect(rgb, `expected an rgb-ish background, got "${bg}"`).not.toBeNull();
+    expect(
+      isYellowFamily(rgb!),
+      `expected yellow-family background, got rgb(${rgb!.join(', ')})`,
+    ).toBe(true);
+
+    const icon = tip.locator('[data-icon="warning"]');
+    await expect(icon).toHaveCount(1);
+    await expect(icon.locator('svg')).toHaveCount(1);
+  });
+
+  test('icon swaps to error when both error + warning fire on the same cell', async ({
+    page,
+  }) => {
+    // The story's `name` column carries both a minLength (error) and a
+    // letters-only (warning) validator. The digits-only short value "1"
+    // fails both — the icon must render as `error` (most-severe wins) so the
+    // visual badge matches the colour-coded surface.
+    await commit(page, '1', 'name', '1');
+
+    const tip = tooltipFor(page, '1', 'name');
+    await expect(tip).toBeVisible();
+    await expect(tip).toHaveAttribute('data-validation-severity', 'error');
+
+    const bg = await tip.evaluate(
+      (el) => getComputedStyle(el).backgroundColor,
+    );
+    const rgb = parseRgb(bg);
+    expect(rgb).not.toBeNull();
+    expect(isRedFamily(rgb!)).toBe(true);
+
+    await expect(tip.locator('[data-icon="error"]')).toHaveCount(1);
+    await expect(tip.locator('[data-icon="error"] svg')).toHaveCount(1);
+    // No warning icon should be present alongside — the top-severity wins.
+    await expect(tip.locator('[data-icon="warning"]')).toHaveCount(0);
+  });
+});

--- a/e2e/validation-tooltip.spec.ts
+++ b/e2e/validation-tooltip.spec.ts
@@ -37,7 +37,14 @@ const STORY_URL =
   '/iframe.html?viewMode=story&id=examples-validation-tooltip--default';
 
 async function waitForGrid(page: Page): Promise<void> {
-  await page.locator('[role="grid"]').first().waitFor({ state: 'visible' });
+  // Storybook in `--ci` mode lazy-compiles stories on first navigation, so
+  // the first hit to a given iframe URL can take noticeably longer than the
+  // default 7.5s expect timeout. Give the grid a generous 30s window so the
+  // suite is not flaky when run in isolation against a cold Storybook.
+  await page
+    .locator('[role="grid"]')
+    .first()
+    .waitFor({ state: 'visible', timeout: 30_000 });
 }
 
 // RGB parser: getComputedStyle emits colours as `rgb(r, g, b)` or
@@ -81,8 +88,12 @@ async function tooltipFor(page: Page, rowId: string, field: string) {
 }
 
 test.describe('Validation tooltip — portal + severity styling', () => {
+  // Bump the per-test budget so first-hit Storybook compile + the 30s grid
+  // wait above do not bust through the default 30s test timeout.
+  test.setTimeout(90_000);
+
   test.beforeEach(async ({ page }) => {
-    await page.goto(STORY_URL);
+    await page.goto(STORY_URL, { timeout: 60_000 });
     await waitForGrid(page);
   });
 

--- a/packages/react/src/ValidationTooltip.tsx
+++ b/packages/react/src/ValidationTooltip.tsx
@@ -2,7 +2,9 @@
  * Per-cell validation tooltip rendered via a React portal into `document.body`.
  *
  * Rendering contract (enforced by
- * `packages/react/src/__tests__/validation-tooltip.test.tsx`):
+ * `packages/react/src/__tests__/validation-tooltip.test.tsx` and the e2e
+ * suites `e2e/validation-tooltip.spec.ts` /
+ * `e2e/issue-78-validation-tooltip-severity.spec.ts`):
  *
  *   - The tooltip node lives on `document.body`, never inside the grid
  *     container. Portal target is the document body so the overlay can escape
@@ -14,18 +16,25 @@
  *     lookup even when the tooltip is visually dismissed.
  *   - Each result renders as a `<div data-validation-message>{message}</div>`
  *     child. The caller is responsible for ordering the results the way the
- *     UI wants — errors first, then warnings, then infos — so this component
+ *     UI wants (errors first, then warnings, then infos) so this component
  *     stays a pure renderer.
  *   - `data-validation-severity` reflects the most-severe entry so callers
- *     can style by severity (e.g. red border for `error`, yellow for
- *     `warning`). Paired with `data-validation-target` it lets tests and
- *     consumers address a specific cell's tooltip without relying on the
- *     React tree.
+ *     can style by severity (e.g. red background for `error`, yellow for
+ *     `warning`, blue for `info`). Paired with `data-validation-target` it
+ *     lets tests and consumers address a specific cell's tooltip without
+ *     relying on the React tree.
  *   - A single `<span data-icon="<severity>">` glyph is rendered before the
- *     messages block, reflecting the most-severe entry. Consumers can target
- *     `[data-icon="error" | "warning" | "info"]` to swap in a bespoke SVG;
- *     the built-in glyph is a unicode fallback so the tooltip still reads
- *     as severity-tagged without any icon-font dependency.
+ *     messages block, reflecting the most-severe entry. Issue #78 swapped
+ *     the legacy Unicode fallback for an inline SVG glyph (circle-X /
+ *     triangle-! / circle-i) so the tooltip reads as a true severity badge
+ *     even when the host application has not loaded an icon-font sprite.
+ *     The wrapping `[data-icon="..."]` selector is preserved so existing
+ *     consumers (CSS overrides, Playwright assertions) keep working.
+ *   - The portal background is driven by the severity-keyed token chain
+ *     `--dg-validation-{error,warning,info}-bg`, falling back to the
+ *     legacy `--dg-{error,warning,info}-color` aliases and finally to
+ *     Tailwind-style red-500 / amber-500 / blue-500 literals so the tooltip
+ *     stays in the right hue family even when no theme preset is wired up.
  *
  * @module ValidationTooltip
  */
@@ -46,24 +55,78 @@ export interface ValidationTooltipProps {
   severity: ValidationSeverity | null;
 }
 
-// Severity → background colour token. Consumers can override by supplying
-// their own CSS for `[data-validation-severity="error"]` / `="warning"` /
-// `="info"` — these fallbacks match the existing `--dg-*-color` tokens.
+// Severity to portal-surface colour. Layered fallback chain so consumers can
+// either set the issue-78-aligned tokens directly OR keep using the legacy
+// `--dg-{error,warning,info}-color` aliases without breakage; the literal
+// hex anchors the hue family when no theme is wired up at all (matching the
+// hue-family probes in `e2e/validation-tooltip.spec.ts`).
 const SEVERITY_BG: Record<ValidationSeverity, string> = {
-  error: 'var(--dg-error-color, #ef4444)',
-  warning: 'var(--dg-warning-color, #f59e0b)',
-  info: 'var(--dg-info-color, #3b82f6)',
+  error: 'var(--dg-validation-error-bg, var(--dg-error-color, #ef4444))',
+  warning: 'var(--dg-validation-warning-bg, var(--dg-warning-color, #f59e0b))',
+  info: 'var(--dg-validation-info-bg, var(--dg-info-color, #3b82f6))',
 };
 
-// Severity → unicode glyph used as the default icon. Consumers can override
-// by styling/replacing `[data-icon="<severity>"]` via portal CSS; the
-// `data-icon` attribute is the load-bearing contract so tests and external
-// icon swaps keep working either way.
-const SEVERITY_ICON: Record<ValidationSeverity, string> = {
-  error: '\u2716', // HEAVY MULTIPLICATION X — reads as "error" without an icon font.
-  warning: '\u26A0', // WARNING SIGN.
-  info: '\u2139', // INFORMATION SOURCE.
+// Severity to icon foreground colour. Defaults to white so the SVG glyph
+// stays legible against the saturated severity surface; consumers can
+// override via `--dg-validation-{error,warning,info}-icon`.
+const SEVERITY_ICON_COLOUR: Record<ValidationSeverity, string> = {
+  error: 'var(--dg-validation-error-icon, #ffffff)',
+  warning: 'var(--dg-validation-warning-icon, #ffffff)',
+  info: 'var(--dg-validation-info-icon, #ffffff)',
 };
+
+/**
+ * Inline-SVG severity glyph rendered inside `[data-icon="<severity>"]`.
+ *
+ * Issue #78 calls for a real iconographic glyph (circle-X / triangle-! /
+ * circle-i) rather than the previous Unicode fallback so the tooltip reads
+ * as a true severity badge even when the host application has not loaded an
+ * icon-font sprite. The wrapping `<span data-icon="...">` stays in place so
+ * the load-bearing CSS / test selector contract is preserved; consumers
+ * swapping in a bespoke icon can target `[data-icon="..."] > svg` without
+ * losing the data-attribute hook.
+ */
+function SeverityGlyph({ severity }: { severity: ValidationSeverity }): React.JSX.Element {
+  const stroke = SEVERITY_ICON_COLOUR[severity];
+  const common = {
+    width: 12,
+    height: 12,
+    viewBox: '0 0 16 16',
+    fill: 'none',
+    stroke,
+    strokeWidth: 2,
+    strokeLinecap: 'round' as const,
+    strokeLinejoin: 'round' as const,
+    'aria-hidden': true,
+    focusable: false,
+  };
+  if (severity === 'error') {
+    return (
+      <svg {...common}>
+        <circle cx="8" cy="8" r="6.5" />
+        <line x1="5.5" y1="5.5" x2="10.5" y2="10.5" />
+        <line x1="10.5" y1="5.5" x2="5.5" y2="10.5" />
+      </svg>
+    );
+  }
+  if (severity === 'warning') {
+    return (
+      <svg {...common}>
+        <path d="M8 2 L14.5 13.5 L1.5 13.5 Z" />
+        <line x1="8" y1="6" x2="8" y2="9.5" />
+        <line x1="8" y1="11.5" x2="8.01" y2="11.5" />
+      </svg>
+    );
+  }
+  // info
+  return (
+    <svg {...common}>
+      <circle cx="8" cy="8" r="6.5" />
+      <line x1="8" y1="7" x2="8" y2="11.5" />
+      <line x1="8" y1="4.6" x2="8.01" y2="4.6" />
+    </svg>
+  );
+}
 
 /**
  * Renders a single portal tooltip for a validated cell.
@@ -103,16 +166,22 @@ export function ValidationTooltip(props: ValidationTooltipProps): React.ReactPor
         lineHeight: 1.4,
         maxWidth: 260,
         display: 'flex',
-        alignItems: 'flex-start',
+        alignItems: 'center',
         gap: 6,
       }}
     >
       <span
         data-icon={iconSeverity}
         aria-hidden="true"
-        style={{ flexShrink: 0, lineHeight: 1, fontSize: 14 }}
+        style={{
+          flexShrink: 0,
+          lineHeight: 0,
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
       >
-        {SEVERITY_ICON[iconSeverity]}
+        <SeverityGlyph severity={iconSeverity} />
       </span>
       <div style={{ flex: 1, minWidth: 0 }}>
         {results.map((r, i) => (

--- a/packages/react/src/styles/tokens/index.ts
+++ b/packages/react/src/styles/tokens/index.ts
@@ -113,6 +113,21 @@ export function toDatagridThemeTokens(
   const primary = get('global.brand.primary.default');
   const selectionBg = get('global.selection.bg.default');
 
+  // Validation severity tokens consumed by the portal validation tooltip
+  // (`packages/react/src/ValidationTooltip.tsx`). Issue #78 requires a
+  // severity-keyed background + matching icon foreground for the tooltip;
+  // these tokens slot into the existing feedback.{danger,warning,info}
+  // surface scale so a single token-pack swap retints the tooltip without
+  // a code change. `bg.strong` is the saturated severity hue (red / yellow
+  // / blue), and the icon glyph is drawn in white so it stays legible
+  // against that surface in both light and dark themes.
+  const validationErrorBg = get('feedback.danger.bg.strong');
+  const validationErrorIcon = '#ffffff';
+  const validationWarningBg = get('feedback.warning.bg.strong');
+  const validationWarningIcon = '#ffffff';
+  const validationInfoBg = get('feedback.info.bg.strong');
+  const validationInfoIcon = '#ffffff';
+
   return {
     // Primary / semantic
     '--dg-primary-color': primary,
@@ -120,6 +135,16 @@ export function toDatagridThemeTokens(
     '--dg-text-color': cellTextDefault,
     '--dg-border-color': gridBorder,
     '--dg-error-color': cellBorderInvalid,
+
+    // Validation tooltip severity tokens (see issue #78). Surfaces use the
+    // saturated severity hue; icon foreground is white so the inline SVG
+    // glyph reads clearly against the surface in both themes.
+    '--dg-validation-error-bg': validationErrorBg,
+    '--dg-validation-error-icon': validationErrorIcon,
+    '--dg-validation-warning-bg': validationWarningBg,
+    '--dg-validation-warning-icon': validationWarningIcon,
+    '--dg-validation-info-bg': validationInfoBg,
+    '--dg-validation-info-icon': validationInfoIcon,
 
     // Header
     '--dg-header-bg': headerBg,


### PR DESCRIPTION
## Summary

- Closes #78. The portal validation tooltip now renders an inline-SVG severity badge (circle-X for error, triangle-! for warning, circle-i for info) and a saturated severity-keyed background (red / yellow / blue) instead of the plain white surface + unicode glyph it shipped with previously.
- New `--dg-validation-{error,warning,info}-{bg,icon}` design tokens flow through the existing token mapper so the surfaces resolve from `feedback.{danger,warning,info}.bg.strong` in both light and dark token packs, while a fallback chain to the legacy `--dg-{error,warning,info}-color` aliases keeps existing themes working.
- Extended `e2e/validation-tooltip.spec.ts` with a longer first-hit Storybook compile budget and added `e2e/issue-78-validation-tooltip-severity.spec.ts` covering the icon SVG + hue-family contract for error and warning severities, plus the error-wins case when both severities fire on the same cell.

## Test plan

- [x] `pnpm vitest run packages/` — 1941/1941 passing
- [x] `pnpm exec playwright test e2e/issue-78-validation-tooltip-severity.spec.ts e2e/validation-tooltip.spec.ts` — 7/7 passing
- [x] Full `pnpm exec playwright test` — 100/100 passing locally (pre-push hook green)