### PR TITLE
feat(tags): multi-select dropdown variant (closes #94)

### DIFF
--- a/e2e/issue-94-tag-list-multi-select.spec.ts
+++ b/e2e/issue-94-tag-list-multi-select.spec.ts
@@ -1,0 +1,116 @@
+/**
+ * End-to-end: Tag-list cell — multi-select variant of the dropdown cell (#94).
+ *
+ * Story: `examples-cell-types--tags-multi-select` (see
+ * `stories/CellTypes.stories.tsx`). Renders the React (non-MUI) DataGrid with
+ * a `tags`-type column whose `options` list activates the multi-select picker
+ * in `TagsCell`. Two rows are seeded — row 1 pre-selected with `frontend`,
+ * row 2 empty.
+ *
+ * Contracts (all from the issue spec):
+ *
+ *   1. Double-click on the cell opens a checkbox picker. Selecting three
+ *      options renders three chips in the cell after the user clicks outside
+ *      (commit).
+ *   2. Each rendered chip has a `×` button. Clicking it removes the chip
+ *      from the cell value without re-opening the editor.
+ *   3. Re-opening the picker shows the currently-selected options as checked.
+ */
+import { test, expect, type Locator, type Page } from '@playwright/test';
+
+const STORY_URL =
+  '/iframe.html?viewMode=story&id=examples-cell-types--tags-multi-select';
+
+async function waitForGrid(page: Page): Promise<void> {
+  await page.locator('[role="grid"]').first().waitFor({ state: 'visible' });
+}
+
+function labelsCell(page: Page, rowId: string): Locator {
+  return page.locator(
+    `[role="gridcell"][data-row-id="${rowId}"][data-field="labels"]`,
+  );
+}
+
+test.describe('Tag-list multi-select cell (#94)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(STORY_URL);
+    await waitForGrid(page);
+  });
+
+  test('multi-select three options renders three chips after commit (#94)', async ({ page }) => {
+    // Row 2 starts empty — fresh selection from scratch.
+    const cell = labelsCell(page, '2');
+    await cell.dblclick();
+
+    // Picker opens with a listbox of checkbox options.
+    const listbox = cell.locator('[role="listbox"]');
+    await expect(listbox).toBeVisible();
+
+    // Tick three options.
+    for (const value of ['frontend', 'backend', 'design']) {
+      await cell.locator(`[data-testid="tag-option-${value}"] input[type="checkbox"]`).click();
+    }
+
+    // Click outside the cell to commit. We use the document body via a
+    // coordinates click so we definitively land outside any popup.
+    await page.mouse.click(2, 2);
+
+    // After commit, the cell renders exactly three chips with the option
+    // labels (not raw values). Editor must be gone.
+    await expect(cell.locator('[role="listbox"]')).toHaveCount(0);
+    await expect(cell.locator('[data-testid^="tag-chip-"]')).toHaveCount(3);
+    await expect(cell.locator('[data-testid="tag-chip-frontend"]')).toBeVisible();
+    await expect(cell.locator('[data-testid="tag-chip-backend"]')).toBeVisible();
+    await expect(cell.locator('[data-testid="tag-chip-design"]')).toBeVisible();
+  });
+
+  test('chip × removes a chip and updates the cell value without opening the editor (#94)', async ({ page }) => {
+    // Row 1 is seeded with one chip — add two more, commit, then remove one
+    // via the × in display mode and assert the picker did not open.
+    const cell = labelsCell(page, '1');
+    await cell.dblclick();
+    for (const value of ['backend', 'design']) {
+      await cell.locator(`[data-testid="tag-option-${value}"] input[type="checkbox"]`).click();
+    }
+    await page.mouse.click(2, 2);
+
+    await expect(cell.locator('[data-testid^="tag-chip-"]')).toHaveCount(3);
+
+    // Click the × on the frontend chip. The button is inside the chip span
+    // and `mousedown`-based to avoid focus thrash, so a plain click works.
+    await cell.locator('[data-testid="tag-remove-frontend"]').click();
+
+    // Chip is gone, picker did NOT open.
+    await expect(cell.locator('[data-testid="tag-chip-frontend"]')).toHaveCount(0);
+    await expect(cell.locator('[data-testid^="tag-chip-"]')).toHaveCount(2);
+    await expect(cell.locator('[role="listbox"]')).toHaveCount(0);
+  });
+
+  test('re-opening the picker shows currently-selected options as checked (#94)', async ({ page }) => {
+    // Seed two selections via the picker, commit, then re-open and verify
+    // the corresponding checkboxes carry the `checked` attribute.
+    const cell = labelsCell(page, '2');
+    await cell.dblclick();
+    for (const value of ['backend', 'qa']) {
+      await cell.locator(`[data-testid="tag-option-${value}"] input[type="checkbox"]`).click();
+    }
+    await page.mouse.click(2, 2);
+    await expect(cell.locator('[role="listbox"]')).toHaveCount(0);
+
+    // Re-open the picker.
+    await cell.dblclick();
+    await expect(cell.locator('[role="listbox"]')).toBeVisible();
+
+    // The previously-selected options must be checked; an unselected one
+    // (`design`) must remain unchecked.
+    await expect(
+      cell.locator('[data-testid="tag-option-backend"] input[type="checkbox"]'),
+    ).toBeChecked();
+    await expect(
+      cell.locator('[data-testid="tag-option-qa"] input[type="checkbox"]'),
+    ).toBeChecked();
+    await expect(
+      cell.locator('[data-testid="tag-option-design"] input[type="checkbox"]'),
+    ).not.toBeChecked();
+  });
+});

--- a/packages/react/src/cells/TagsCell/TagsCell.styles.ts
+++ b/packages/react/src/cells/TagsCell/TagsCell.styles.ts
@@ -30,10 +30,23 @@ export const displayContainer: CSSProperties = {
 
 export const editContainer: CSSProperties = {
   display: 'flex',
+  flexDirection: 'column',
+  gap: 4,
+  alignItems: 'flex-start',
+  minWidth: 80,
+  position: 'relative',
+};
+
+export const chipRow: CSSProperties = {
+  display: 'flex',
   flexWrap: 'wrap',
   gap: 4,
   alignItems: 'center',
-  minWidth: 80,
+};
+
+export const placeholder: CSSProperties = {
+  color: '#9ca3af',
+  fontSize: 12,
 };
 
 export const tagInput: CSSProperties = {
@@ -42,3 +55,45 @@ export const tagInput: CSSProperties = {
   minWidth: 60,
   flex: 1,
 };
+
+/**
+ * Floating picker panel rendered when a multi-select TagsCell is in edit mode.
+ * Mirrors the {@link ChipSelectCell} dropdown so the two cells share a visual
+ * vocabulary — same offset, shadow, and option metrics.
+ */
+export const dropdown: CSSProperties = {
+  position: 'absolute',
+  top: '100%',
+  left: 0,
+  zIndex: 1000,
+  background: '#fff',
+  border: '1px solid #e5e7eb',
+  borderRadius: 6,
+  boxShadow: '0 4px 12px rgba(0,0,0,0.12)',
+  padding: '4px 0',
+  minWidth: 160,
+  maxHeight: 240,
+  overflowY: 'auto',
+};
+
+export const optionLabel = (checked: boolean): CSSProperties => ({
+  display: 'flex',
+  alignItems: 'center',
+  gap: 8,
+  padding: '6px 12px',
+  cursor: 'pointer',
+  fontSize: 13,
+  background: checked ? '#eff6ff' : 'none',
+});
+
+export const checkbox: CSSProperties = {
+  margin: 0,
+};
+
+export const optionSwatch = (color: string): CSSProperties => ({
+  display: 'inline-block',
+  width: 8,
+  height: 8,
+  borderRadius: '50%',
+  background: color,
+});

--- a/packages/react/src/cells/TagsCell/TagsCell.tsx
+++ b/packages/react/src/cells/TagsCell/TagsCell.tsx
@@ -1,15 +1,30 @@
 /**
  * TagsCell module for the datagrid component library.
  *
- * Provides a cell renderer that displays and edits a collection of tags as inline badges.
- * In display mode, tags appear as read-only colored pills. In edit mode, users can type
- * new tags (committed via Enter or comma), remove existing tags with backspace or the
- * remove button, and confirm the full set by pressing Enter on an empty input or blurring.
+ * Provides a cell renderer that displays and edits a collection of tags as inline
+ * chips. The cell operates in one of two modes, decided per column:
+ *
+ *   1. **Free-text mode** (default — no `column.options`): users type new tags
+ *      into an inline input. Tags are committed via Enter or comma. Backspace on
+ *      an empty input removes the last tag. This is the original `tags` cell
+ *      semantics.
+ *
+ *   2. **Multi-select mode** (when `column.options` is provided): users pick
+ *      one or more values from a checkbox dropdown rendered below the cell —
+ *      the multi-select counterpart of the dropdown ({@link StatusCell}) cell.
+ *      Clicking outside the dropdown commits. Each chip has an inline `×` to
+ *      remove without re-opening the picker, both in display and edit modes.
+ *      `column.allowFreeText: true` additionally renders a free-text input
+ *      inside the picker so ad-hoc tags can still be added on the same surface.
+ *
+ * Both modes serialise the cell value as `string[]` (or the option `value`
+ * strings for multi-select), accept JSON-encoded arrays and comma-separated
+ * legacy strings on read, and emit a plain string array on commit.
  *
  * @module TagsCell
  */
-import React, { useState, useRef, useEffect } from 'react';
-import type { CellValue, ColumnDef } from '@iasbuilt/datagrid-core';
+import React, { useState, useRef, useEffect, useMemo } from 'react';
+import type { CellValue, ColumnDef, StatusOption } from '@iasbuilt/datagrid-core';
 import * as styles from './TagsCell.styles';
 
 /**
@@ -60,48 +75,85 @@ function parseTags(value: CellValue): string[] {
 /**
  * A datagrid cell renderer for tag collections.
  *
- * Renders tags as small colored badges in both display and edit modes. During editing,
- * an inline text input allows adding tags via Enter or comma keystrokes. Tags are
- * deduplicated on insertion and can be removed individually or via backspace.
+ * See the module docstring for the two operating modes (free-text and
+ * options-driven multi-select).
  *
  * @typeParam TData - Row data shape, defaults to `Record<string, unknown>`.
  *
  * @param props - The component props conforming to {@link TagsCellProps}.
- * @returns A React element showing tag badges and, when editing, an inline input.
+ * @returns A React element showing tag chips and, when editing, either an
+ *   inline text input or a checkbox picker depending on the column config.
  *
  * @example
+ * Free-text mode:
+ * ```tsx
+ * <TagsCell value={['react', 'typescript']} column={{ id, field, title }} ... />
+ * ```
+ *
+ * @example
+ * Multi-select mode:
  * ```tsx
  * <TagsCell
- *   value={['react', 'typescript']}
- *   row={rowData}
- *   column={columnDef}
- *   rowIndex={0}
- *   isEditing={false}
- *   onCommit={handleCommit}
- *   onCancel={handleCancel}
+ *   value={['frontend', 'urgent']}
+ *   column={{
+ *     id, field, title,
+ *     options: [
+ *       { value: 'frontend', label: 'Frontend' },
+ *       { value: 'backend', label: 'Backend' },
+ *       { value: 'urgent', label: 'Urgent', color: '#ef4444' },
+ *     ],
+ *   }}
+ *   ...
  * />
  * ```
  */
 export const TagsCell = React.memo(function TagsCell<TData = Record<string, unknown>>({
   value,
+  column,
   isEditing,
   onCommit,
   onCancel,
 }: TagsCellProps<TData>) {
-  // Parse the incoming value once for display mode rendering
-  const initialTags = parseTags(value);
+  // Pick the operating mode based on whether the column carries an option list.
+  // Options-driven mode renders a checkbox picker instead of a free-text input.
+  const options: StatusOption[] = column.options ?? [];
+  const isMultiSelect = options.length > 0;
+
+  // Parse the incoming value once for display mode rendering.
+  // useMemo keeps the array stable across re-renders so the chip key set
+  // does not thrash when only display props change.
+  const initialTags = useMemo(() => parseTags(value), [value]);
   const [tags, setTags] = useState<string[]>(initialTags);
   const [input, setInput] = useState('');
   const inputRef = useRef<HTMLInputElement>(null);
+  // Outer container ref — used by multi-select mode to detect outside clicks
+  // (which auto-commit, matching the {@link ChipSelectCell} contract).
+  const containerRef = useRef<HTMLDivElement>(null);
 
-  // Reset local state and focus the input whenever the cell enters edit mode
+  // Reset local state whenever the cell enters edit mode. We also focus
+  // the free-text input here; multi-select mode does not auto-focus the
+  // picker because the picker uses checkboxes and label-clicks instead of
+  // a single focusable target.
   useEffect(() => {
     if (isEditing) {
       setTags(parseTags(value));
       setInput('');
-      inputRef.current?.focus();
+      if (!isMultiSelect) inputRef.current?.focus();
     }
   }, [isEditing]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Multi-select mode: clicking outside the cell while editing commits the
+  // current selection — same UX as the checkbox-dropdown {@link ChipSelectCell}.
+  useEffect(() => {
+    if (!isEditing || !isMultiSelect) return;
+    function handleOutside(e: MouseEvent) {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        onCommit(tags);
+      }
+    }
+    document.addEventListener('mousedown', handleOutside);
+    return () => document.removeEventListener('mousedown', handleOutside);
+  }, [isEditing, isMultiSelect, tags, onCommit]);
 
   /**
    * Appends a tag to the current set if it is non-empty and not already present.
@@ -121,7 +173,11 @@ export const TagsCell = React.memo(function TagsCell<TData = Record<string, unkn
   };
 
   /**
-   * Removes a specific tag from the set and commits immediately if not in edit mode.
+   * Removes a specific tag from the set.
+   *
+   * In display mode the removal auto-commits so the chip × works without
+   * forcing the user into edit mode (per the issue spec). In edit mode the
+   * removal stays local and is committed alongside the rest of the draft.
    *
    * @param tag - The tag string to remove.
    * @returns The updated tag array after removal.
@@ -129,16 +185,26 @@ export const TagsCell = React.memo(function TagsCell<TData = Record<string, unkn
   const removeTag = (tag: string) => {
     const next = tags.filter((t) => t !== tag);
     setTags(next);
-    // Auto-commit removals that happen outside of active editing (e.g. badge close button)
     if (!isEditing) onCommit(next);
     return next;
   };
 
   /**
-   * Handles keyboard interactions within the tag input field.
+   * Toggles a single option value in the multi-select draft.
    *
-   * Enter and comma add the current input as a tag. An empty Enter commits the entire
-   * set. Backspace on an empty input removes the last tag. Escape cancels editing.
+   * @param val - The option value to add or remove.
+   */
+  const toggleOption = (val: string) => {
+    setTags((prev) =>
+      prev.includes(val) ? prev.filter((v) => v !== val) : [...prev, val]
+    );
+  };
+
+  /**
+   * Handles keyboard interactions within the free-text tag input field.
+   *
+   * Enter and comma add the current input as a tag. An empty Enter commits the
+   * entire set. Backspace on an empty input removes the last tag. Escape cancels.
    *
    * @param e - The keyboard event from the input element.
    */
@@ -161,47 +227,137 @@ export const TagsCell = React.memo(function TagsCell<TData = Record<string, unkn
   };
 
   /**
-   * Renders a single tag badge with optional remove button.
+   * Renders a single tag chip with optional remove button.
    *
-   * @param tag - The tag text to display.
+   * @param tag - The raw tag value to display.
    * @param removable - Whether to show the close/remove button.
-   * @returns A styled `<span>` element representing the tag.
+   * @returns A styled `<span>` element representing the chip.
    */
-  const tagBadge = (tag: string, removable: boolean) => (
-    <span
-      key={tag}
-      style={styles.tagBadge}
-    >
-      {tag}
-      {removable && (
-        <button
-          type="button"
-          aria-label={`Remove tag ${tag}`}
-          onMouseDown={(e) => {
-            // Prevent blur on the input so the cell stays in edit mode
-            e.preventDefault();
-            removeTag(tag);
-          }}
-          style={styles.tagRemoveButton}
-        >
-          &times;
-        </button>
-      )}
-    </span>
-  );
+  const tagBadge = (tag: string, removable: boolean) => {
+    // In multi-select mode resolve the user-facing label and colour from the
+    // option list; fall back to the raw value for unknown / ad-hoc tags.
+    const opt = isMultiSelect ? options.find((o) => o.value === tag) : undefined;
+    const label = opt?.label ?? tag;
+    const style = opt?.color ? { ...styles.tagBadge, background: opt.color, color: '#fff' } : styles.tagBadge;
+    return (
+      <span
+        key={tag}
+        data-testid={`tag-chip-${tag}`}
+        style={style}
+      >
+        {label}
+        {removable && (
+          <button
+            type="button"
+            aria-label={`Remove tag ${label}`}
+            data-testid={`tag-remove-${tag}`}
+            onMouseDown={(e) => {
+              // Prevent blur on the input so the cell stays in edit mode
+              e.preventDefault();
+              removeTag(tag);
+            }}
+            style={opt?.color ? { ...styles.tagRemoveButton, color: '#fff' } : styles.tagRemoveButton}
+          >
+            &times;
+          </button>
+        )}
+      </span>
+    );
+  };
 
-  // Display mode: render tags as non-removable badges
+  // ---------------------------------------------------------------------
+  // Display mode
+  // ---------------------------------------------------------------------
+  // Issue #94 calls for chips to be removable without opening the editor.
+  // Display chips therefore expose the × button too (auto-commit on click).
   if (!isEditing) {
     return (
-      <span style={styles.displayContainer}>
-        {initialTags.map((tag) => tagBadge(tag, false))}
+      <span ref={containerRef} style={styles.displayContainer}>
+        {initialTags.map((tag) => tagBadge(tag, true))}
       </span>
     );
   }
 
-  // Edit mode: render removable badges plus an inline input for adding new tags
+  // ---------------------------------------------------------------------
+  // Edit mode — multi-select picker (options-driven)
+  // ---------------------------------------------------------------------
+  if (isMultiSelect) {
+    return (
+      <div ref={containerRef} style={styles.editContainer}>
+        {/* Selected chips render inline above the picker so the user can see */}
+        {/* the current draft and remove items without opening menu items. */}
+        <span style={styles.chipRow}>
+          {tags.length === 0 ? (
+            <span style={styles.placeholder}>
+              {column.placeholder ?? 'Select...'}
+            </span>
+          ) : (
+            tags.map((tag) => tagBadge(tag, true))
+          )}
+        </span>
+        <div
+          role="listbox"
+          aria-label={`Select ${column.title ?? column.field}`}
+          aria-multiselectable="true"
+          style={styles.dropdown}
+        >
+          {options.map((opt) => {
+            const checked = tags.includes(opt.value);
+            return (
+              <label
+                key={opt.value}
+                role="option"
+                aria-selected={checked}
+                data-testid={`tag-option-${opt.value}`}
+                style={styles.optionLabel(checked)}
+              >
+                <input
+                  type="checkbox"
+                  checked={checked}
+                  onChange={() => toggleOption(opt.value)}
+                  style={styles.checkbox}
+                />
+                {/* Colour swatch echoes the chip colour so the picker reads */}
+                {/* the same as the rendered chip set. */}
+                {opt.color && (
+                  <span style={styles.optionSwatch(opt.color)} />
+                )}
+                {opt.label}
+              </label>
+            );
+          })}
+          {/* When the column also opts into free-text entry, a small input is */}
+          {/* surfaced under the picker so users can add ad-hoc values without */}
+          {/* leaving the same surface. */}
+          {column.allowFreeText && (
+            <input
+              ref={inputRef}
+              type="text"
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ',') {
+                  e.preventDefault();
+                  addTag(input);
+                  setInput('');
+                } else if (e.key === 'Escape') {
+                  onCancel();
+                }
+              }}
+              style={styles.tagInput}
+              placeholder="Add tag..."
+            />
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  // ---------------------------------------------------------------------
+  // Edit mode — free-text input (legacy / no-options columns)
+  // ---------------------------------------------------------------------
   return (
-    <span style={styles.editContainer}>
+    <span ref={containerRef} style={styles.editContainer}>
       {tags.map((tag) => tagBadge(tag, true))}
       <input
         ref={inputRef}

--- a/packages/react/src/cells/TagsCell/__tests__/TagsCell.test.tsx
+++ b/packages/react/src/cells/TagsCell/__tests__/TagsCell.test.tsx
@@ -1,7 +1,7 @@
 import { vi } from 'vitest';
 import React from 'react';
-import { render, fireEvent, screen } from '@testing-library/react';
-import type { ColumnDef } from '@iasbuilt/datagrid-core';
+import { render, fireEvent, screen, within } from '@testing-library/react';
+import type { ColumnDef, StatusOption } from '@iasbuilt/datagrid-core';
 import { TagsCell } from '../TagsCell';
 
 // ---------------------------------------------------------------------------
@@ -17,11 +17,23 @@ const baseColumn: ColumnDef = {
 
 const noop = () => {};
 
+const multiSelectOptions: StatusOption[] = [
+  { value: 'frontend', label: 'Frontend' },
+  { value: 'backend', label: 'Backend' },
+  { value: 'design', label: 'Design' },
+  { value: 'qa', label: 'QA' },
+];
+
+const multiSelectColumn: ColumnDef = {
+  ...baseColumn,
+  options: multiSelectOptions,
+};
+
 // ---------------------------------------------------------------------------
-// TagsCell
+// TagsCell — free-text mode (legacy contract)
 // ---------------------------------------------------------------------------
 
-describe('TagsCell', () => {
+describe('TagsCell (free-text mode)', () => {
   it('renders tags in display mode', () => {
     render(
       <TagsCell value={['alpha', 'beta']} row={{}} column={baseColumn} rowIndex={0} isEditing={false} onCommit={noop} onCancel={noop} />
@@ -85,7 +97,7 @@ describe('TagsCell', () => {
     expect(screen.getByText('first')).toBeTruthy();
   });
 
-  it('removes specific tag via close button', () => {
+  it('removes specific tag via close button in edit mode', () => {
     render(
       <TagsCell value={['alpha', 'beta']} row={{}} column={baseColumn} rowIndex={0} isEditing={true} onCommit={noop} onCancel={noop} />
     );
@@ -122,11 +134,24 @@ describe('TagsCell', () => {
     expect(screen.getByText('baz')).toBeTruthy();
   });
 
-  it('does not show remove buttons in display mode', () => {
+  it('display-mode chips expose a × remove button (issue #94)', () => {
+    // Issue #94 spec: each chip has an inline × to remove without opening
+    // the editor. Previously remove buttons rendered only in edit mode.
     render(
       <TagsCell value={['alpha']} row={{}} column={baseColumn} rowIndex={0} isEditing={false} onCommit={noop} onCancel={noop} />
     );
-    expect(screen.queryByRole('button')).toBeNull();
+    expect(screen.getByRole('button', { name: /remove tag alpha/i })).toBeTruthy();
+  });
+
+  it('display-mode × auto-commits the new tag set (issue #94)', () => {
+    // Removing a chip outside of edit mode should call onCommit immediately
+    // so the row data updates without forcing the user into the editor.
+    const onCommit = vi.fn();
+    render(
+      <TagsCell value={['alpha', 'beta']} row={{}} column={baseColumn} rowIndex={0} isEditing={false} onCommit={onCommit} onCancel={noop} />
+    );
+    fireEvent.mouseDown(screen.getByRole('button', { name: /remove tag alpha/i }));
+    expect(onCommit).toHaveBeenCalledWith(['beta']);
   });
 
   it('commits added tag on blur when input has pending text', () => {
@@ -158,5 +183,115 @@ describe('TagsCell', () => {
     fireEvent.change(input, { target: { value: 'typing' } });
     fireEvent.keyDown(input, { key: 'Backspace' });
     expect(screen.getByText('keep')).toBeTruthy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TagsCell — multi-select mode (issue #94)
+// ---------------------------------------------------------------------------
+
+describe('TagsCell (multi-select mode, issue #94)', () => {
+  it('renders option labels (not raw values) as chips when options are provided', () => {
+    // The column's option list maps a stored value (`frontend`) to a label
+    // (`Frontend`). Display mode should resolve via the option list.
+    const col: ColumnDef = {
+      ...baseColumn,
+      options: [{ value: 'frontend', label: 'Frontend' }],
+    };
+    render(
+      <TagsCell value={['frontend']} row={{}} column={col} rowIndex={0} isEditing={false} onCommit={noop} onCancel={noop} />
+    );
+    expect(screen.getByText('Frontend')).toBeTruthy();
+  });
+
+  it('opens a checkbox listbox in edit mode with one option per column.options entry', () => {
+    render(
+      <TagsCell value={[]} row={{}} column={multiSelectColumn} rowIndex={0} isEditing={true} onCommit={noop} onCancel={noop} />
+    );
+    const listbox = screen.getByRole('listbox');
+    expect(listbox.getAttribute('aria-multiselectable')).toBe('true');
+    // One <label role="option"> per option, each containing a checkbox.
+    const options = within(listbox).getAllByRole('option');
+    expect(options.length).toBe(multiSelectOptions.length);
+    expect(within(listbox).getAllByRole('checkbox').length).toBe(multiSelectOptions.length);
+  });
+
+  it('toggles a checkbox into the draft selection without exiting edit mode', () => {
+    render(
+      <TagsCell value={[]} row={{}} column={multiSelectColumn} rowIndex={0} isEditing={true} onCommit={noop} onCancel={noop} />
+    );
+    const frontendOption = screen.getByTestId('tag-option-frontend');
+    const cb = within(frontendOption).getByRole('checkbox') as HTMLInputElement;
+    fireEvent.click(cb);
+    expect(cb.checked).toBe(true);
+    // A chip with the option label appears in the draft chip row.
+    expect(screen.getByTestId('tag-chip-frontend')).toBeTruthy();
+  });
+
+  it('shows currently selected options as pre-checked when re-entering edit mode', () => {
+    render(
+      <TagsCell value={['frontend', 'design']} row={{}} column={multiSelectColumn} rowIndex={0} isEditing={true} onCommit={noop} onCancel={noop} />
+    );
+    const frontendCb = within(screen.getByTestId('tag-option-frontend')).getByRole('checkbox') as HTMLInputElement;
+    const designCb = within(screen.getByTestId('tag-option-design')).getByRole('checkbox') as HTMLInputElement;
+    const backendCb = within(screen.getByTestId('tag-option-backend')).getByRole('checkbox') as HTMLInputElement;
+    expect(frontendCb.checked).toBe(true);
+    expect(designCb.checked).toBe(true);
+    expect(backendCb.checked).toBe(false);
+  });
+
+  it('commits the current selection when the user clicks outside the cell', () => {
+    const onCommit = vi.fn();
+    render(
+      <div>
+        <TagsCell value={[]} row={{}} column={multiSelectColumn} rowIndex={0} isEditing={true} onCommit={onCommit} onCancel={noop} />
+        <button>outside</button>
+      </div>
+    );
+    // Pick two options first.
+    fireEvent.click(within(screen.getByTestId('tag-option-frontend')).getByRole('checkbox'));
+    fireEvent.click(within(screen.getByTestId('tag-option-backend')).getByRole('checkbox'));
+    // Click outside the cell — emulates the user committing by moving focus
+    // elsewhere on the page.
+    fireEvent.mouseDown(screen.getByText('outside'));
+    expect(onCommit).toHaveBeenCalledWith(['frontend', 'backend']);
+  });
+
+  it('display-mode × removes a chip and auto-commits the new set', () => {
+    const onCommit = vi.fn();
+    render(
+      <TagsCell value={['frontend', 'backend']} row={{}} column={multiSelectColumn} rowIndex={0} isEditing={false} onCommit={onCommit} onCancel={noop} />
+    );
+    // Remove button uses the option's human label for accessibility.
+    const removeBtn = screen.getByRole('button', { name: /remove tag frontend/i });
+    fireEvent.mouseDown(removeBtn);
+    expect(onCommit).toHaveBeenCalledWith(['backend']);
+  });
+
+  it('does not render the free-text input by default in multi-select mode', () => {
+    const { container } = render(
+      <TagsCell value={[]} row={{}} column={multiSelectColumn} rowIndex={0} isEditing={true} onCommit={noop} onCancel={noop} />
+    );
+    // Picker has checkboxes only; no `type="text"` input.
+    expect(container.querySelector('input[type="text"]')).toBeNull();
+  });
+
+  it('renders an optional free-text input when column.allowFreeText is true', () => {
+    const col: ColumnDef = { ...multiSelectColumn, allowFreeText: true };
+    const { container } = render(
+      <TagsCell value={[]} row={{}} column={col} rowIndex={0} isEditing={true} onCommit={noop} onCancel={noop} />
+    );
+    expect(container.querySelector('input[type="text"]')).toBeTruthy();
+  });
+
+  it('uncheck removes the value from the draft selection', () => {
+    render(
+      <TagsCell value={['frontend']} row={{}} column={multiSelectColumn} rowIndex={0} isEditing={true} onCommit={noop} onCancel={noop} />
+    );
+    const cb = within(screen.getByTestId('tag-option-frontend')).getByRole('checkbox') as HTMLInputElement;
+    expect(cb.checked).toBe(true);
+    fireEvent.click(cb);
+    expect(cb.checked).toBe(false);
+    expect(screen.queryByTestId('tag-chip-frontend')).toBeNull();
   });
 });

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -66,6 +66,10 @@ export { PasswordConfirmCell, MISMATCH_MESSAGE } from './cells/PasswordConfirmCe
 // Migration helper for consumers upgrading from the HTML-backed RichTextCell.
 export { htmlToMarkdown } from './cells/RichTextCell';
 
+// Default cell renderer registry. Consumers can use this as a starting point
+// when supplying a custom `cellRenderers` prop to {@link DataGrid}.
+export { cellRendererMap, TagsCell } from './cells';
+
 // Sub-components
 export { DataGridHeader } from './header';
 export type { DataGridHeaderProps } from './header';

--- a/stories/CellTypes.stories.tsx
+++ b/stories/CellTypes.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { MuiDataGrid } from '@iasbuilt/datagrid-mui';
+import { DataGrid, cellRendererMap } from '@iasbuilt/datagrid-react';
 import type { ColumnDef, StatusOption } from '@iasbuilt/datagrid-core';
 import { storyContainer, gridContainer } from './helpers';
 import * as styles from './stories.styles';
@@ -119,6 +120,88 @@ export const AllCellTypes: StoryObj = {
       </div>
     </div>
   ),
+};
+
+// ---------------------------------------------------------------------------
+// Tags — multi-select dropdown (issue #94)
+// ---------------------------------------------------------------------------
+
+const tagOptions: StatusOption[] = [
+  { value: 'frontend', label: 'Frontend', color: '#3b82f6' },
+  { value: 'backend', label: 'Backend', color: '#10b981' },
+  { value: 'design', label: 'Design', color: '#a855f7' },
+  { value: 'qa', label: 'QA', color: '#f59e0b' },
+  { value: 'docs', label: 'Docs' },
+];
+
+interface TagRow {
+  id: string;
+  name: string;
+  labels: string[];
+}
+
+function makeTagRows(): TagRow[] {
+  // Two rows are enough for the e2e — one prefilled to assert the round-trip
+  // of pre-selected options, one empty to assert the picker flow from scratch.
+  return [
+    { id: '1', name: 'Ticket #1', labels: ['frontend'] },
+    { id: '2', name: 'Ticket #2', labels: [] },
+  ];
+}
+
+const tagColumns: ColumnDef<TagRow>[] = [
+  { id: 'name', field: 'name', title: 'Name', width: 160, cellType: 'text' },
+  {
+    id: 'labels',
+    field: 'labels',
+    title: 'Labels',
+    width: 320,
+    cellType: 'tags',
+    options: tagOptions,
+    editable: true,
+  },
+];
+
+/**
+ * Tag-list cell — multi-select variant of the dropdown cell (issue #94).
+ *
+ * Uses the React (non-MUI) `DataGrid` directly so the new `TagsCell`
+ * checkbox-picker is exercised. The MUI grid swaps in `MuiTagsCell` via its
+ * own renderer map, which is a separate concern.
+ */
+export const TagsMultiSelect: StoryObj = {
+  render: () => {
+    // Controlled data so chip-remove + multi-select commits round-trip into
+    // the visible cell — without this the cell would re-mount with the stale
+    // prop on every commit and lose the change.
+    const [rows, setRows] = React.useState<TagRow[]>(() => makeTagRows());
+    return (
+      <div style={storyContainer}>
+        <h2 style={styles.heading}>Tag list — multi-select (#94)</h2>
+        <p style={styles.subtitle}>
+          Double-click the Labels cell to open the multi-select picker. Click
+          chips' × in either mode to remove a tag.
+        </p>
+        <div style={gridContainer}>
+          <DataGrid
+            data={rows}
+            columns={tagColumns as any}
+            rowKey="id"
+            cellRenderers={cellRendererMap as any}
+            selectionMode="cell"
+            keyboardNavigation
+            onCellEdit={(_id, field, value) => {
+              setRows((prev) =>
+                prev.map((r) =>
+                  r.id === _id ? { ...r, [field]: value as string[] } : r
+                )
+              );
+            }}
+          />
+        </div>
+      </div>
+    );
+  },
 };
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #94.

## Summary
- `TagsCell` now operates in two modes: when the column carries `options: StatusOption[]`, it renders a checkbox picker (the multi-select counterpart of the `StatusCell` dropdown) with chip-style display; otherwise it falls back to the legacy free-text input.
- Chips expose an inline `×` in both display and edit mode so users can remove a tag without entering the editor — display-mode removals auto-commit.
- Outside-click commits the picker draft, matching the `ChipSelectCell` UX. `column.allowFreeText: true` surfaces an inline free-text input inside the picker for ad-hoc tags.
- Option labels and colours are resolved from the column option list. Storybook story `examples-cell-types--tags-multi-select` demonstrates the variant. `cellRendererMap` and `TagsCell` are now re-exported from `@iasbuilt/datagrid-react` so consumers can wire the React renderer map into a non-MUI `DataGrid`.

## Test plan
- [x] `pnpm vitest run packages/` — 1951/1951 pass (25 TagsCell tests, including 10 new multi-select cases)
- [x] `pnpm exec playwright test e2e/issue-94-tag-list-multi-select.spec.ts` — 3/3 pass (multi-select commit, chip × remove, re-open picker shows checked state)
- [ ] CI green