### PR TITLE
feat(richtext): overflow-mode column config (truncate | wrap | fit)

### DIFF
--- a/e2e/issue-96-richtext-overflow-modes.spec.ts
+++ b/e2e/issue-96-richtext-overflow-modes.spec.ts
@@ -1,0 +1,182 @@
+/**
+ * End-to-end coverage for issue #96 — per-column rich-text overflow modes.
+ *
+ * Story: `examples-richtext--overflow-modes` (see
+ * `stories/RichText.stories.tsx#OverflowModes`).
+ *
+ * Three rich-text cells are rendered side-by-side in a 180px-wide Notes
+ * column, one per overflow mode (`truncate`, `wrap`, `fit`). The story
+ * seeds each cell with a long markdown string whose laid-out width
+ * exceeds the column width so each mode's behaviour is observable:
+ *
+ *   - `truncate` (default): the wrapper applies `text-overflow: ellipsis`
+ *     to clip the rendered markdown at a single line and trail with a
+ *     U+2026 character. The DOM exposes `data-richtext-overflow="truncate"`
+ *     on the wrapper so this spec can target the right element without
+ *     relying on grid-internal layout details.
+ *
+ *   - `wrap`: the wrapper switches to `white-space: normal` so the
+ *     rendered markdown wraps to multiple lines. The cell's natural
+ *     content height (as observed via `scrollHeight` on the
+ *     `[data-testid="richtext-rendered"]` content node) exceeds a
+ *     single-line height, proving the wrap actually engaged. (The
+ *     row-height growth itself is a body-layout concern tracked
+ *     separately; this assertion stays scoped to the rich-text cell's
+ *     own measurable surface.)
+ *
+ *   - `fit`: the `RichTextDisplay` shrink-to-fit hook scales the
+ *     wrapper's `font-size` down via `ResizeObserver` so the entire
+ *     single-line content stays visible. We assert that the computed
+ *     `font-size` on the wrapper falls below the base 13px, which is
+ *     only reachable when the shrink path engaged.
+ *
+ * The story renders three SEPARATE single-row grids so a per-row mode
+ * override is observable without leaking grid-internal per-row column
+ * machinery into the test.
+ */
+import { test, expect, type Page } from '@playwright/test';
+
+const STORY_URL =
+  '/iframe.html?viewMode=story&id=examples-richtext--overflow-modes';
+
+async function waitForStory(page: Page): Promise<void> {
+  await page
+    .locator('[data-testid="richtext-overflow-modes"]')
+    .waitFor({ state: 'visible' });
+  // The grids inside each section have to render at least one row each
+  // before assertions can read the cells — wait for every overflow-mode
+  // wrapper to appear so race-condition retries don't fire on the
+  // wrong-cell selector.
+  await page
+    .locator('[data-richtext-overflow="truncate"]')
+    .first()
+    .waitFor({ state: 'visible' });
+  await page
+    .locator('[data-richtext-overflow="wrap"]')
+    .first()
+    .waitFor({ state: 'visible' });
+  await page
+    .locator('[data-richtext-overflow="fit"]')
+    .first()
+    .waitFor({ state: 'visible' });
+}
+
+test.describe('Rich-text overflow modes — per-column richTextOverflow (#96)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(STORY_URL);
+    await waitForStory(page);
+  });
+
+  test('truncate mode clips at the cell width with an ellipsis', async ({ page }) => {
+    const wrapper = page
+      .locator('[data-testid="grid-truncate"] [data-richtext-overflow="truncate"]')
+      .first();
+    await expect(wrapper).toBeVisible();
+
+    // Computed style proves the truncation contract: `text-overflow:
+    // ellipsis` + `white-space: nowrap` is what produces the trailing
+    // U+2026 on overflow.
+    const computed = await wrapper.evaluate((el) => {
+      const cs = window.getComputedStyle(el as HTMLElement);
+      return {
+        textOverflow: cs.textOverflow,
+        whiteSpace: cs.whiteSpace,
+        overflow: cs.overflow,
+      };
+    });
+    expect(computed.textOverflow).toBe('ellipsis');
+    expect(computed.whiteSpace).toBe('nowrap');
+
+    // The content is wider than the wrapper — assert the content's
+    // intrinsic width (`scrollWidth`) exceeds the wrapper's box width.
+    const overflowed = await wrapper.evaluate((el) => {
+      const node = el as HTMLElement;
+      return node.scrollWidth > node.clientWidth;
+    });
+    expect(overflowed).toBe(true);
+  });
+
+  test('wrap mode lets the content reflow onto multiple lines', async ({ page }) => {
+    const wrapper = page
+      .locator('[data-testid="grid-wrap"] [data-richtext-overflow="wrap"]')
+      .first();
+    await expect(wrapper).toBeVisible();
+
+    const computed = await wrapper.evaluate((el) => {
+      const cs = window.getComputedStyle(el as HTMLElement);
+      return {
+        whiteSpace: cs.whiteSpace,
+        wordWrap: cs.wordWrap,
+      };
+    });
+    expect(computed.whiteSpace).toBe('normal');
+
+    // Multi-line proof: the content's natural height exceeds a single
+    // line. We compute against the wrapper's own line-height to keep the
+    // assertion robust against font-size tweaks.
+    const heights = await wrapper.evaluate((el) => {
+      const node = el as HTMLElement;
+      const cs = window.getComputedStyle(node);
+      const lineHeight =
+        parseFloat(cs.lineHeight) ||
+        parseFloat(cs.fontSize) * 1.2;
+      return {
+        scrollHeight: node.scrollHeight,
+        offsetHeight: node.offsetHeight,
+        lineHeight,
+      };
+    });
+    // At least two lines: `scrollHeight >= 1.5 * lineHeight` guards
+    // against sub-pixel rounding while still requiring real wrapping.
+    expect(heights.scrollHeight).toBeGreaterThan(heights.lineHeight * 1.5);
+  });
+
+  test('fit mode scales the rendered font-size down so content fits without truncation', async ({
+    page,
+  }) => {
+    const wrapper = page
+      .locator('[data-testid="grid-fit"] [data-richtext-overflow="fit"]')
+      .first();
+    await expect(wrapper).toBeVisible();
+
+    // The ResizeObserver-driven shrink-to-fit pass runs in a microtask
+    // after layout; wait one rAF tick so the computed style reflects the
+    // shrunk value before reading it. `expect.poll` keeps the assertion
+    // resilient on slow CI runners.
+    await expect
+      .poll(
+        async () =>
+          await wrapper.evaluate((el) =>
+            parseFloat(window.getComputedStyle(el as HTMLElement).fontSize),
+          ),
+        {
+          message: 'fit-mode wrapper should shrink font-size below 13px base',
+          timeout: 5000,
+        },
+      )
+      .toBeLessThan(13);
+
+    // And the shrink must respect the documented 9px floor — assertion
+    // is purely a sanity guard so an over-aggressive shrink regression
+    // surfaces in CI rather than at a customer site.
+    const fontPx = await wrapper.evaluate((el) =>
+      parseFloat(window.getComputedStyle(el as HTMLElement).fontSize),
+    );
+    expect(fontPx).toBeGreaterThanOrEqual(9);
+  });
+
+  test('every rendered wrapper exposes its mode via data-richtext-overflow', async ({
+    page,
+  }) => {
+    // Smoke check: the attribute is what the other three tests pivot on,
+    // so assert all three values are present somewhere in the document.
+    const modes = await page
+      .locator('[data-richtext-overflow]')
+      .evaluateAll((els) =>
+        els.map((el) => (el as HTMLElement).dataset.richtextOverflow),
+      );
+    expect(modes).toContain('truncate');
+    expect(modes).toContain('wrap');
+    expect(modes).toContain('fit');
+  });
+});

--- a/packages/core/src/__tests__/overflow.test.ts
+++ b/packages/core/src/__tests__/overflow.test.ts
@@ -27,6 +27,11 @@
  */
 // @ts-expect-error — Phase B will add `overflow.ts` and re-export these.
 import { truncateMiddle, getDefaultOverflowPolicy } from '@iasbuilt/datagrid-core';
+import {
+  resolveRichTextOverflow,
+  DEFAULT_RICH_TEXT_OVERFLOW,
+  RICH_TEXT_FIT_MIN_FONT_PX,
+} from '@iasbuilt/datagrid-core';
 
 describe('truncateMiddle', () => {
   it('returns the input untouched when it already fits within maxChars', () => {
@@ -98,5 +103,61 @@ describe('getDefaultOverflowPolicy', () => {
 
   it('falls back to truncate-end when called with no argument', () => {
     expect(getDefaultOverflowPolicy()).toBe('truncate-end');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveRichTextOverflow — issue #96
+//
+// Rich-text cells take a narrower overflow vocabulary than plain-text cells
+// (`truncate | wrap | fit`) because `truncate-middle` and the clamp-N
+// variants don't compose with marked-up content. The resolver maps a
+// column-like input onto one of those three modes, falling back to
+// `truncate` when the column omits the field.
+// ---------------------------------------------------------------------------
+
+describe('resolveRichTextOverflow (issue #96)', () => {
+  it('defaults to truncate when the source is undefined', () => {
+    expect(resolveRichTextOverflow(undefined)).toBe('truncate');
+  });
+
+  it('defaults to truncate when the source is null', () => {
+    expect(resolveRichTextOverflow(null)).toBe('truncate');
+  });
+
+  it('defaults to truncate when richTextOverflow is omitted', () => {
+    expect(resolveRichTextOverflow({})).toBe('truncate');
+  });
+
+  it('returns truncate when richTextOverflow is explicitly truncate', () => {
+    expect(resolveRichTextOverflow({ richTextOverflow: 'truncate' })).toBe(
+      'truncate',
+    );
+  });
+
+  it('returns wrap when richTextOverflow is wrap', () => {
+    expect(resolveRichTextOverflow({ richTextOverflow: 'wrap' })).toBe('wrap');
+  });
+
+  it('returns fit when richTextOverflow is fit', () => {
+    expect(resolveRichTextOverflow({ richTextOverflow: 'fit' })).toBe('fit');
+  });
+
+  it('ignores unknown string values and falls back to the default mode', () => {
+    // Cast through `unknown` so the test exercises the runtime guard even
+    // though the type system would normally reject the value.
+    expect(
+      resolveRichTextOverflow({
+        richTextOverflow: 'banana' as unknown as 'wrap',
+      }),
+    ).toBe('truncate');
+  });
+
+  it('exposes the documented DEFAULT_RICH_TEXT_OVERFLOW constant', () => {
+    expect(DEFAULT_RICH_TEXT_OVERFLOW).toBe('truncate');
+  });
+
+  it('keeps the fit-mode font-size floor at the documented minimum (9px)', () => {
+    expect(RICH_TEXT_FIT_MIN_FONT_PX).toBe(9);
   });
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -69,8 +69,15 @@ export * from './transposed';
 // Per-column search indexing: prefix trie, builders, and the IndexedDB persistence adapter.
 export * from './search-index';
 // Cell text overflow policy vocabulary + default policy resolver and middle-truncation helper.
-export type { OverflowPolicy, Density } from './overflow';
-export { truncateMiddle, truncateEnd, getDefaultOverflowPolicy } from './overflow';
+export type { OverflowPolicy, Density, RichTextOverflowMode } from './overflow';
+export {
+  truncateMiddle,
+  truncateEnd,
+  getDefaultOverflowPolicy,
+  resolveRichTextOverflow,
+  DEFAULT_RICH_TEXT_OVERFLOW,
+  RICH_TEXT_FIT_MIN_FONT_PX,
+} from './overflow';
 // Excel-style number-format presets + dual-unit sub-cell spec (issue #92).
 export type { NumberFormatSpec, SecondaryUnitSpec } from './number-format';
 export { formatNumber, isNumberFormatSpec } from './number-format';

--- a/packages/core/src/overflow.ts
+++ b/packages/core/src/overflow.ts
@@ -22,6 +22,62 @@ export type OverflowPolicy =
 /** Grid density mode controlling row height + clamp eligibility. */
 export type Density = 'compact' | 'comfortable';
 
+/**
+ * Rich-text-specific overflow modes (issue #96).
+ *
+ * Rich-text cells (`cellType: 'richText'`) render Markdown via
+ * `react-markdown` and so cannot reuse the plain-text `OverflowPolicy`
+ * vocabulary verbatim — clamping a markdown block by `-webkit-line-clamp`
+ * works, but `truncate-middle` doesn't compose with marked-up content.
+ * Issue #96 narrows the rich-text vocabulary to the three modes users
+ * actually asked for:
+ *
+ *   - `'truncate'` — current behaviour; clip the rendered markdown at the
+ *     cell width and render a trailing ellipsis. Single-line, fixed row
+ *     height.
+ *   - `'wrap'`    — let the rendered markdown wrap to multiple lines; the
+ *     cell grows vertically and the effective row height becomes
+ *     `max(rowHeight, contentHeight)`.
+ *   - `'fit'`     — scale the rendered font-size down (within a sensible
+ *     minimum) until the content fits the available width without
+ *     truncation. Driven by a `ResizeObserver` + a CSS variable so the
+ *     scaling re-runs whenever the cell width or content changes.
+ */
+export type RichTextOverflowMode = 'truncate' | 'wrap' | 'fit';
+
+/**
+ * The default rich-text overflow mode applied when a column omits
+ * `richTextOverflow`. Matches the pre-#96 behaviour so existing grids
+ * upgrade with zero visual diff.
+ */
+export const DEFAULT_RICH_TEXT_OVERFLOW: RichTextOverflowMode = 'truncate';
+
+/**
+ * Minimum font-size (px) that the `'fit'` mode will scale the rendered
+ * markdown down to. Below this floor the content is allowed to overflow /
+ * clip instead, so cells with extreme content never produce unreadable
+ * 4-pixel text.
+ */
+export const RICH_TEXT_FIT_MIN_FONT_PX = 9;
+
+/**
+ * Returns the effective rich-text overflow mode for a column-like value
+ * carrying an optional `richTextOverflow` field. Falls back to
+ * {@link DEFAULT_RICH_TEXT_OVERFLOW} when omitted.
+ *
+ * Accepts a structural argument (not the full `ColumnDef`) so the helper
+ * lives in `@iasbuilt/datagrid-core` without taking a circular dep on
+ * higher-level packages and so unit tests can exercise the resolution
+ * without constructing a full grid column.
+ */
+export function resolveRichTextOverflow(
+  source?: { richTextOverflow?: RichTextOverflowMode | undefined } | null,
+): RichTextOverflowMode {
+  const v = source?.richTextOverflow;
+  if (v === 'truncate' || v === 'wrap' || v === 'fit') return v;
+  return DEFAULT_RICH_TEXT_OVERFLOW;
+}
+
 const ELLIPSIS = '\u2026';
 
 /**

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,5 +1,5 @@
 import type { Validator } from './validators';
-import type { OverflowPolicy, Density } from './overflow';
+import type { OverflowPolicy, Density, RichTextOverflowMode } from './overflow';
 import type { NumberFormatSpec, SecondaryUnitSpec } from './number-format';
 
 /**
@@ -500,6 +500,23 @@ export interface ColumnDef<TData = Record<string, unknown>> {
    * Defaults to `true` when not set.
    */
   allowCustomColor?: boolean;
+
+  /**
+   * How a `cellType: 'richText'` cell fits its rendered Markdown into the
+   * column width (issue #96). The plain-text {@link OverflowPolicy} does
+   * not compose cleanly with marked-up content (a `truncate-middle` slice
+   * could land mid-`<strong>`), so rich-text cells take a narrower
+   * vocabulary:
+   *
+   * - `'truncate'` (default): single-line clip with a trailing ellipsis.
+   * - `'wrap'`              : multi-line wrap, row grows to fit content.
+   * - `'fit'`               : scale font-size down (within a minimum) so
+   *                           the content fits the available width without
+   *                           truncation.
+   *
+   * Ignored on non-rich-text cells.
+   */
+  richTextOverflow?: RichTextOverflowMode;
 
   // Sub-grid
 

--- a/packages/mui/src/cells/MuiRichTextCell/MuiRichTextCell.tsx
+++ b/packages/mui/src/cells/MuiRichTextCell/MuiRichTextCell.tsx
@@ -48,6 +48,7 @@ import ToggleButton from '@mui/material/ToggleButton';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import type { CellRendererProps } from '@iasbuilt/datagrid-react';
+import { resolveRichTextOverflow, RICH_TEXT_FIT_MIN_FONT_PX } from '@iasbuilt/datagrid-core';
 
 const useIsomorphicLayoutEffect =
   typeof window !== 'undefined' ? useLayoutEffect : useEffect;
@@ -247,6 +248,101 @@ const rawSurfaceStyle: React.CSSProperties = {
   minHeight: '1.4em',
   background: '#f8fafc',
 };
+
+/**
+ * Display-mode subcomponent honoring the column's `richTextOverflow` mode
+ * (issue #96). Mirrors the React-package equivalent so behaviour is
+ * identical across the two adapters; the shrink-to-fit pass observes the
+ * wrapper + content via `ResizeObserver` and writes the computed
+ * `font-size` to the wrapper's inline style.
+ */
+function MuiRichTextDisplay({
+  mode,
+  plainText,
+  markdown,
+  placeholder,
+}: {
+  mode: 'truncate' | 'wrap' | 'fit';
+  plainText: string;
+  markdown: string;
+  placeholder?: string;
+}): React.ReactElement {
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLSpanElement>(null);
+
+  useIsomorphicLayoutEffect(() => {
+    if (mode !== 'fit') return;
+    const wrapper = wrapperRef.current;
+    const content = contentRef.current;
+    if (!wrapper || !content || typeof ResizeObserver === 'undefined') return;
+    const BASE_FONT_PX = 13;
+    const rescale = () => {
+      wrapper.style.fontSize = `${BASE_FONT_PX}px`;
+      const available = wrapper.clientWidth;
+      if (available <= 0) return;
+      // Reading scrollWidth from both ensures we pick up the overflow even
+      // when react-markdown wraps the content in an inline element whose
+      // own scrollWidth would otherwise read 0.
+      const needed = Math.max(wrapper.scrollWidth, content.scrollWidth);
+      if (needed <= available) return;
+      const factor = available / needed;
+      const next = Math.max(RICH_TEXT_FIT_MIN_FONT_PX, BASE_FONT_PX * factor);
+      wrapper.style.fontSize = `${next}px`;
+    };
+    rescale();
+    const ro = new ResizeObserver(() => rescale());
+    ro.observe(wrapper);
+    ro.observe(content);
+    return () => ro.disconnect();
+  }, [mode, markdown]);
+
+  const wrapperSx =
+    mode === 'wrap'
+      ? {
+          width: '100%',
+          fontSize: 13,
+          lineHeight: 1.4,
+          whiteSpace: 'normal' as const,
+          wordWrap: 'break-word' as const,
+          overflowWrap: 'break-word' as const,
+        }
+      : mode === 'fit'
+        ? {
+            width: '100%',
+            fontSize: 13,
+            lineHeight: 1.4,
+            overflow: 'hidden',
+            whiteSpace: 'nowrap' as const,
+          }
+        : {
+            width: '100%',
+            overflow: 'hidden',
+            maxHeight: 40,
+            fontSize: 13,
+            lineHeight: 1.4,
+            whiteSpace: 'nowrap' as const,
+            textOverflow: 'ellipsis' as const,
+          };
+
+  return (
+    <Box
+      ref={wrapperRef}
+      sx={wrapperSx}
+      title={plainText}
+      data-richtext-overflow={mode}
+    >
+      {markdown ? (
+        <Box component="span" ref={contentRef} data-testid="richtext-rendered">
+          <ReactMarkdown remarkPlugins={[remarkGfm]}>{markdown}</ReactMarkdown>
+        </Box>
+      ) : (
+        <Box component="span" sx={{ color: 'text.secondary' }}>
+          {placeholder ?? 'No content'}
+        </Box>
+      )}
+    </Box>
+  );
+}
 
 /**
  * MUI-based markdown rich-text cell renderer.
@@ -572,21 +668,14 @@ export const MuiRichTextCell = React.memo(function MuiRichTextCell<TData = Recor
 
   if (!isEditing) {
     const plainText = markdownToPlainText(rawMarkdown);
+    const mode = resolveRichTextOverflow(column);
     return (
-      <Box
-        sx={{ overflow: 'hidden', maxHeight: 40, fontSize: 13, lineHeight: 1.4 }}
-        title={plainText}
-      >
-        {rawMarkdown ? (
-          <Box component="span" data-testid="richtext-rendered">
-            <ReactMarkdown remarkPlugins={[remarkGfm]}>{rawMarkdown}</ReactMarkdown>
-          </Box>
-        ) : (
-          <Box component="span" sx={{ color: 'text.secondary' }}>
-            {column.placeholder ?? 'No content'}
-          </Box>
-        )}
-      </Box>
+      <MuiRichTextDisplay
+        mode={mode}
+        plainText={plainText}
+        markdown={rawMarkdown}
+        placeholder={column.placeholder}
+      />
     );
   }
 

--- a/packages/react/src/cells/RichTextCell/RichTextCell.styles.ts
+++ b/packages/react/src/cells/RichTextCell/RichTextCell.styles.ts
@@ -1,10 +1,52 @@
 import type { CSSProperties } from 'react';
 
+/**
+ * Base wrapper for the display-mode rich-text content. Concrete sizing /
+ * overflow behaviour comes from the per-mode style spreads below
+ * (`displayTruncate`, `displayWrap`, `displayFit`) so the three issue-#96
+ * modes share a single layout primitive.
+ */
 export const displayContainer: CSSProperties = {
-  overflow: 'hidden',
-  maxHeight: 40,
   fontSize: 13,
   lineHeight: '1.4',
+  width: '100%',
+};
+
+/**
+ * Truncate mode (issue #96, default): single line, clip with ellipsis.
+ * Uses `whiteSpace: 'nowrap'` + `textOverflow: 'ellipsis'` on the wrapper
+ * so the markdown body inherits the clipping behaviour even though its
+ * own `display: 'inline'` would otherwise pass through.
+ */
+export const displayTruncate: CSSProperties = {
+  overflow: 'hidden',
+  maxHeight: 40,
+  whiteSpace: 'nowrap',
+  textOverflow: 'ellipsis',
+};
+
+/**
+ * Wrap mode (issue #96): allow the cell to grow vertically as the
+ * markdown wraps to multiple lines. The grid row's effective height is
+ * computed as `max(rowHeight, contentHeight)` by the body layout, so the
+ * wrapper just removes the height cap and switches to wrap-on-spaces.
+ */
+export const displayWrap: CSSProperties = {
+  whiteSpace: 'normal',
+  wordWrap: 'break-word',
+  overflowWrap: 'break-word',
+};
+
+/**
+ * Fit mode (issue #96): no truncation, no wrapping — the
+ * RichTextDisplay shrink-to-fit hook scales `font-size` down (within
+ * RICH_TEXT_FIT_MIN_FONT_PX) until the content fits the available width.
+ * The wrapper itself just provides the single-line layout the hook
+ * measures against.
+ */
+export const displayFit: CSSProperties = {
+  overflow: 'hidden',
+  whiteSpace: 'nowrap',
 };
 
 export const placeholderText: CSSProperties = {

--- a/packages/react/src/cells/RichTextCell/RichTextCell.tsx
+++ b/packages/react/src/cells/RichTextCell/RichTextCell.tsx
@@ -32,6 +32,7 @@ import { createPortal } from 'react-dom';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import type { CellValue, ColumnDef } from '@iasbuilt/datagrid-core';
+import { resolveRichTextOverflow, RICH_TEXT_FIT_MIN_FONT_PX } from '@iasbuilt/datagrid-core';
 import * as styles from './RichTextCell.styles';
 
 /**
@@ -175,6 +176,95 @@ const PLACEMENT_BUFFER = 8;
  * stays fully visible instead of overflowing the window.
  */
 const EDGE_ALIGN_MARGIN = 100;
+
+/**
+ * Display-mode subcomponent that renders the markdown body honoring the
+ * column's `richTextOverflow` mode (issue #96). Extracted out of the
+ * main {@link RichTextCell} so the `'fit'` mode can hang its own
+ * `ResizeObserver` off the wrapper ref without forcing a hook into the
+ * edit branch.
+ */
+function RichTextDisplay({
+  mode,
+  plainText,
+  markdown,
+  placeholder,
+}: {
+  mode: 'truncate' | 'wrap' | 'fit';
+  plainText: string;
+  markdown: string;
+  placeholder?: string;
+}): React.ReactElement {
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
+
+  // Shrink-to-fit: observe both the wrapper width AND the rendered content
+  // width and scale the font-size down (within RICH_TEXT_FIT_MIN_FONT_PX)
+  // until the content fits. The computed font-size is pushed onto the
+  // wrapper as an inline style so `getComputedStyle` reports the scaled
+  // value — the e2e test asserts this exact contract.
+  useIsomorphicLayoutEffect(() => {
+    if (mode !== 'fit') return;
+    const wrapper = wrapperRef.current;
+    const content = contentRef.current;
+    if (!wrapper || !content || typeof ResizeObserver === 'undefined') return;
+
+    const BASE_FONT_PX = 13;
+    const rescale = () => {
+      // Reset to base before measuring so a previously-shrunk size doesn't
+      // pin us in a too-small state when the cell grows back.
+      wrapper.style.fontSize = `${BASE_FONT_PX}px`;
+      const available = wrapper.clientWidth;
+      if (available <= 0) return;
+      // `scrollWidth` reports the laid-out width of the content at the
+      // currently-applied font-size, so we can compute the scaling factor
+      // directly without an iterative shrink loop. We read from BOTH the
+      // wrapper (whose `overflow: hidden` makes its own `scrollWidth`
+      // include the off-cell content) and the content node so we get a
+      // reliable value regardless of react-markdown's internal element
+      // structure (an inline span may report 0).
+      const needed = Math.max(wrapper.scrollWidth, content.scrollWidth);
+      if (needed <= available) return;
+      const factor = available / needed;
+      const next = Math.max(RICH_TEXT_FIT_MIN_FONT_PX, BASE_FONT_PX * factor);
+      wrapper.style.fontSize = `${next}px`;
+    };
+
+    rescale();
+    const ro = new ResizeObserver(() => rescale());
+    ro.observe(wrapper);
+    ro.observe(content);
+    return () => ro.disconnect();
+  }, [mode, markdown]);
+
+  const wrapperStyle: React.CSSProperties =
+    mode === 'wrap'
+      ? { ...styles.displayContainer, ...styles.displayWrap }
+      : mode === 'fit'
+        ? { ...styles.displayContainer, ...styles.displayFit }
+        : { ...styles.displayContainer, ...styles.displayTruncate };
+
+  return (
+    <div
+      ref={wrapperRef}
+      style={wrapperStyle}
+      title={plainText}
+      data-richtext-overflow={mode}
+    >
+      {markdown ? (
+        <div
+          ref={contentRef}
+          style={styles.markdownBody}
+          data-testid="richtext-rendered"
+        >
+          <ReactMarkdown remarkPlugins={[remarkGfm]}>{markdown}</ReactMarkdown>
+        </div>
+      ) : (
+        <span style={styles.placeholderText}>{placeholder ?? 'No content'}</span>
+      )}
+    </div>
+  );
+}
 
 /**
  * Datagrid cell renderer for Markdown rich-text content.
@@ -446,19 +536,20 @@ export const RichTextCell = React.memo(function RichTextCell<TData = Record<stri
     onCommit(draft);
   };
 
-  // Display mode: render markdown via react-markdown + remark-gfm.
+  // Display mode: render markdown via react-markdown + remark-gfm. The
+  // wrapper styles vary with the column's `richTextOverflow` mode (issue
+  // #96): `truncate` clips at a single line with ellipsis, `wrap` lets the
+  // cell grow vertically, `fit` engages the shrink-to-fit hook.
   if (!isEditing) {
     const plainText = markdownToPlainText(rawMarkdown);
+    const mode = resolveRichTextOverflow(column);
     return (
-      <div style={styles.displayContainer} title={plainText}>
-        {rawMarkdown ? (
-          <div style={styles.markdownBody} data-testid="richtext-rendered">
-            <ReactMarkdown remarkPlugins={[remarkGfm]}>{rawMarkdown}</ReactMarkdown>
-          </div>
-        ) : (
-          <span style={styles.placeholderText}>{column.placeholder ?? 'No content'}</span>
-        )}
-      </div>
+      <RichTextDisplay
+        mode={mode}
+        plainText={plainText}
+        markdown={rawMarkdown}
+        placeholder={column.placeholder}
+      />
     );
   }
 

--- a/stories/RichText.stories.tsx
+++ b/stories/RichText.stories.tsx
@@ -139,6 +139,124 @@ export const ViewportEdges: StoryObj = {
 };
 
 // ---------------------------------------------------------------------------
+// OverflowModes — issue #96 / Playwright target
+//
+// Renders a tight (180px) Notes column with one row per overflow mode so the
+// e2e spec at `e2e/issue-96-richtext-overflow-modes.spec.ts` can assert each
+// mode's visible behaviour against a fixed-width column. The rendered
+// markdown content (`LONG_LINE`) is wider than 180px when laid out on a
+// single line, which guarantees the mode-specific behaviours observably
+// trigger:
+//   - truncate row: text ends with a trailing ellipsis from the wrapper's
+//     `text-overflow: ellipsis` rule.
+//   - wrap row: cell height exceeds the default row height because the
+//     content wraps onto multiple lines.
+//   - fit row: computed font-size on the wrapper falls below the base
+//     13px so the entire single-line content remains visible.
+// ---------------------------------------------------------------------------
+
+interface OverflowRow {
+  id: string;
+  mode: string;
+  notes: string;
+}
+
+// One long markdown line — bold prefix + a long run of words so each mode's
+// effect is unambiguously visible at the column's 180px width.
+const LONG_LINE =
+  '**Quarterly audit complete** with extensive notes covering every single asset across all sites including the warehouse and the offsite storage facility.';
+
+const overflowRows: OverflowRow[] = [
+  { id: 'truncate', mode: 'truncate', notes: LONG_LINE },
+  { id: 'wrap', mode: 'wrap', notes: LONG_LINE },
+  { id: 'fit', mode: 'fit', notes: LONG_LINE },
+];
+
+const overflowColumns: ColumnDef<OverflowRow>[] = [
+  { id: 'mode', field: 'mode', title: 'Mode', width: 100 },
+  {
+    id: 'notes',
+    field: 'notes',
+    title: 'Notes',
+    width: 180,
+    cellType: 'richText',
+    richTextOverflow: 'truncate',
+  },
+];
+
+// Rebuild the columns with the per-row override applied. Each row uses a
+// column-def variant whose `richTextOverflow` matches its `mode`. The grid
+// itself doesn't natively support per-row column overrides, so we render
+// THREE single-row grids stacked vertically — one per mode — to keep the
+// fixture trivially deterministic for the Playwright assertions.
+function singleModeColumns(mode: 'truncate' | 'wrap' | 'fit'): ColumnDef<OverflowRow>[] {
+  return [
+    overflowColumns[0]!,
+    { ...overflowColumns[1]!, richTextOverflow: mode },
+  ];
+}
+
+const overflowSection: React.CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 16,
+};
+
+const overflowGridWrap: React.CSSProperties = {
+  height: 80,
+  width: 320,
+  border: '1px solid #e2e8f0',
+  borderRadius: 6,
+  overflow: 'hidden',
+};
+
+const overflowWrapGridWrap: React.CSSProperties = {
+  // Wrap mode grows vertically — give the host container enough room so
+  // the test can observe the cell exceeding the default row height.
+  height: 200,
+  width: 320,
+  border: '1px solid #e2e8f0',
+  borderRadius: 6,
+  overflow: 'hidden',
+};
+
+export const OverflowModes: StoryObj = {
+  render: () => (
+    <div style={storyContainer}>
+      <h2 style={styles.heading}>Rich-text overflow modes (#96)</h2>
+      <p style={styles.subtitle}>
+        Per-column <code>richTextOverflow</code> controls how a rich-text cell fits content wider
+        than the column. Three modes are supported: <code>truncate</code> (default),
+        <code> wrap</code>, and <code>fit</code>.
+      </p>
+      <div style={overflowSection} data-testid="richtext-overflow-modes">
+        <div data-testid="grid-truncate" style={overflowGridWrap}>
+          <MuiDataGrid
+            data={[overflowRows[0]!]}
+            columns={singleModeColumns('truncate') as any}
+            rowKey="id"
+          />
+        </div>
+        <div data-testid="grid-wrap" style={overflowWrapGridWrap}>
+          <MuiDataGrid
+            data={[overflowRows[1]!]}
+            columns={singleModeColumns('wrap') as any}
+            rowKey="id"
+          />
+        </div>
+        <div data-testid="grid-fit" style={overflowGridWrap}>
+          <MuiDataGrid
+            data={[overflowRows[2]!]}
+            columns={singleModeColumns('fit') as any}
+            rowKey="id"
+          />
+        </div>
+      </div>
+    </div>
+  ),
+};
+
+// ---------------------------------------------------------------------------
 // ShowFormattingDemo
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Adds per-column `richTextOverflow` config to rich-text cells, supporting `truncate` (default, single-line ellipsis), `wrap` (multi-line, content height grows), and `fit` (font-size scales down via `ResizeObserver` within a 9px floor so the content stays visible without truncation).
- Extends `OverflowPolicy`-side helpers in `packages/core/src/overflow.ts` with the rich-text-specific vocabulary (`RichTextOverflowMode`, `resolveRichTextOverflow`, `DEFAULT_RICH_TEXT_OVERFLOW`, `RICH_TEXT_FIT_MIN_FONT_PX`) — kept narrowly scoped so an inbound PR (#120) that touches the plain-text policy surface merges cleanly.
- Threads the resolver through both `RichTextCell` (React) and `MuiRichTextCell` (MUI) display branches via a new `RichTextDisplay` / `MuiRichTextDisplay` subcomponent that hangs the `ResizeObserver` off the wrapper ref so the `fit`-mode hook stays out of the edit branch.

## Test plan

- [x] Unit: `pnpm vitest run packages/` — 1950 tests pass, including the new `resolveRichTextOverflow` suite in `packages/core/src/__tests__/overflow.test.ts`.
- [x] Build/typecheck: `pnpm tsc -b` across all package `tsconfig.build.json`s — clean.
- [x] Playwright: `pnpm exec playwright test e2e/issue-96-richtext-overflow-modes.spec.ts` — 4/4 pass against the new `examples-richtext--overflow-modes` story.
- [x] Pre-commit hook gate (`typecheck + build + tests + tokens:check + test:scripts + actionlint`) — all green.

Closes #96.