### PR TITLE
feat(dropdown): editable dropdown adds/removes items with auth-gated delete

### DIFF
--- a/e2e/issue-93-editable-dropdown.spec.ts
+++ b/e2e/issue-93-editable-dropdown.spec.ts
@@ -1,0 +1,145 @@
+/**
+ * End-to-end: editable status-dropdown contract (see GitHub #93).
+ *
+ * Contract (mirrors `packages/react/src/__tests__/status-cell-editable-dropdown.test.tsx`):
+ *
+ *   1. The dropdown surfaces an inline "Add new…" input. Typing a label
+ *      and pressing Enter invokes `onAddOption(label)` and the new option
+ *      appears in the listbox.
+ *   2. Each option exposes a per-row × button when the consumer's
+ *      `canDeleteOption` returns `true`; clicking × invokes
+ *      `onDeleteOption(option)` and the row disappears from the listbox.
+ *   3. When `canDeleteOption` returns `false`, the × button is NOT
+ *      rendered (hidden, not merely disabled), and the keyboard Delete
+ *      shortcut is a no-op.
+ *
+ * Stories under test live in `stories/EditableDropdown.stories.tsx`:
+ *   AdminEditableDropdown  → editable-dropdown--admin-add-delete
+ *   ViewerEditableDropdown → editable-dropdown--viewer-add-only
+ *
+ * The React `DataGrid` is used (not `MuiDataGrid`) — the editable-dropdown
+ * UI is implemented in the React `StatusCell` renderer.
+ */
+import { test, expect, type Locator, type Page } from '@playwright/test';
+
+const ADMIN_URL =
+  '/iframe.html?viewMode=story&id=examples-editable-dropdown--admin-editable-dropdown';
+const VIEWER_URL =
+  '/iframe.html?viewMode=story&id=examples-editable-dropdown--viewer-editable-dropdown';
+
+/** Wait for the React DataGrid to mount. */
+async function waitForGrid(page: Page): Promise<void> {
+  await page.locator('[role="grid"]').first().waitFor({ state: 'visible' });
+}
+
+/** Locate a status cell by row id (the story uses field=status, rowKey=id). */
+function statusCell(page: Page, rowId: string): Locator {
+  return page
+    .locator(`[role="gridcell"][data-row-id="${rowId}"][data-field="status"]`)
+    .first();
+}
+
+/** Double-click into a cell to begin editing, then assert the listbox shows. */
+async function openDropdown(page: Page, cell: Locator): Promise<Locator> {
+  await cell.click();
+  await cell.dblclick();
+  const listbox = page.locator('[role="listbox"]').first();
+  await expect(listbox).toBeVisible();
+  return listbox;
+}
+
+test.describe('Editable status dropdown (#93)', () => {
+  test('admin: type a new option label + Enter appends the option to the dropdown', async ({
+    page,
+  }) => {
+    await page.goto(ADMIN_URL);
+    await waitForGrid(page);
+
+    const cell = statusCell(page, 'r1');
+    const listbox = await openDropdown(page, cell);
+
+    // Add input is rendered when onAddOption is wired.
+    const input = listbox.locator('[data-testid="add-option-input"]');
+    await expect(input).toBeVisible();
+
+    await input.fill('Archived');
+    await input.press('Enter');
+
+    // New option appears in the listbox.
+    await expect(
+      listbox.locator('[role="option"]', { hasText: 'Archived' }),
+    ).toBeVisible();
+
+    // Input cleared on success.
+    await expect(input).toHaveValue('');
+  });
+
+  test('admin: hover an existing option → × button visible (canDeleteOption=true)', async ({
+    page,
+  }) => {
+    await page.goto(ADMIN_URL);
+    await waitForGrid(page);
+
+    const cell = statusCell(page, 'r1');
+    const listbox = await openDropdown(page, cell);
+
+    // canDeleteOption returns true for every option — × button must exist
+    // on every visible option (no hover gating in the React renderer).
+    await expect(
+      listbox.locator('[data-testid="delete-option-active"]'),
+    ).toBeVisible();
+    await expect(
+      listbox.locator('[data-testid="delete-option-inactive"]'),
+    ).toBeVisible();
+    await expect(
+      listbox.locator('[data-testid="delete-option-pending"]'),
+    ).toBeVisible();
+  });
+
+  test('admin: click × removes the option from the dropdown', async ({
+    page,
+  }) => {
+    await page.goto(ADMIN_URL);
+    await waitForGrid(page);
+
+    const cell = statusCell(page, 'r1');
+    const listbox = await openDropdown(page, cell);
+
+    // Sanity: option exists before delete.
+    await expect(
+      listbox.locator('[role="option"]', { hasText: 'Pending' }),
+    ).toBeVisible();
+
+    // The delete handler is wired to the parent state, so the option must
+    // be gone from the rendered listbox after the click resolves.
+    // We use a mousedown event (the cell uses onMouseDown to keep focus
+    // on the listbox during deletion).
+    await listbox
+      .locator('[data-testid="delete-option-pending"]')
+      .dispatchEvent('mousedown');
+
+    await expect(
+      listbox.locator('[role="option"]', { hasText: 'Pending' }),
+    ).toHaveCount(0);
+  });
+
+  test('viewer: canDeleteOption=false → × button hidden for every option', async ({
+    page,
+  }) => {
+    await page.goto(VIEWER_URL);
+    await waitForGrid(page);
+
+    const cell = statusCell(page, 'r1');
+    const listbox = await openDropdown(page, cell);
+
+    // None of the × buttons render in the viewer flavour.
+    await expect(
+      listbox.locator('[data-testid^="delete-option-"]'),
+    ).toHaveCount(0);
+
+    // The add input is still present — viewer can add but not delete.
+    await expect(
+      listbox.locator('[data-testid="add-option-input"]'),
+    ).toBeVisible();
+  });
+});

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -361,6 +361,35 @@ export interface ColumnDef<TData = Record<string, unknown>> {
 
   /** Selectable options for `status`, `chipSelect`, and `list` cell types. */
   options?: StatusOption[];
+  /**
+   * Editable-dropdown contract for `status`/`chipSelect`/`list` columns
+   * (see GitHub #93). When supplied, the dropdown surfaces an inline
+   * "Add new…" input that calls `onAddOption(label)` when the user
+   * confirms a new entry. The returned {@link StatusOption} is appended
+   * to the column's option list (consumers are expected to round-trip
+   * any persistence — server enum mutation, cache refresh, etc. — inside
+   * the callback before resolving).
+   */
+  onAddOption?: (label: string) => Promise<StatusOption> | StatusOption;
+  /**
+   * Authorization gate for the per-option delete (×) affordance. Returning
+   * `false` (or a Promise that resolves false) hides/disables the delete
+   * control for the option in question, and suppresses the keyboard
+   * Delete shortcut.
+   *
+   * The contract is intentionally generic: consumers can wire arbitrary
+   * permission checks (e.g. a GraphQL user-type lookup cached for the
+   * session) inside this callback. The grid never reads user identity
+   * directly — it only honours the boolean answer.
+   */
+  canDeleteOption?: (option: StatusOption) => boolean | Promise<boolean>;
+  /**
+   * Side-effect callback invoked when the user confirms deletion of an
+   * option from the dropdown. The option is removed from the column's
+   * option list once the promise resolves. Consumers are expected to
+   * round-trip the deletion through any backing mutation before resolving.
+   */
+  onDeleteOption?: (option: StatusOption) => Promise<void> | void;
   /** Default cell value applied when a new row is created. */
   defaultValue?: unknown;
   /** Allows multiple selections in `chipSelect` columns. */

--- a/packages/react/src/__tests__/status-cell-editable-dropdown.test.tsx
+++ b/packages/react/src/__tests__/status-cell-editable-dropdown.test.tsx
@@ -1,0 +1,303 @@
+/**
+ * Unit tests for the editable status-dropdown contract (see GitHub #93).
+ *
+ * Covers the new column-config callbacks added in #93:
+ *   - `onAddOption(label)` — surfaces a per-dropdown "Add new…" input that
+ *     appends a returned {@link StatusOption} on Enter / Add click.
+ *   - `canDeleteOption(option)` — sync or async authorisation gate for the
+ *     per-option × button and the keyboard Delete shortcut.
+ *   - `onDeleteOption(option)` — side-effect; on resolve the option is
+ *     removed from the visible list.
+ *
+ * These complement the legacy `StatusCell.test.tsx` selection/keyboard
+ * coverage — that file pre-dates #93 and should continue to pass unchanged.
+ */
+import { vi } from 'vitest';
+import React from 'react';
+import { render, fireEvent, screen, waitFor, act } from '@testing-library/react';
+import type { ColumnDef, StatusOption } from '@iasbuilt/datagrid-core';
+import { StatusCell } from '../cells/StatusCell/StatusCell';
+
+const noop = () => {};
+
+const baseOptions: StatusOption[] = [
+  { value: 'active', label: 'Active', color: '#22c55e' },
+  { value: 'inactive', label: 'Inactive', color: '#ef4444' },
+];
+
+function makeColumn(extra: Partial<ColumnDef> = {}): ColumnDef {
+  return {
+    id: 'col1',
+    field: 'name',
+    title: 'Name',
+    editable: true,
+    options: baseOptions,
+    ...extra,
+  };
+}
+
+describe('StatusCell — editable dropdown (#93)', () => {
+  describe('add option', () => {
+    it('does not render the Add input when onAddOption is absent', () => {
+      render(
+        <StatusCell
+          value="active"
+          row={{}}
+          column={makeColumn()}
+          rowIndex={0}
+          isEditing={true}
+          onCommit={noop}
+          onCancel={noop}
+        />,
+      );
+      expect(screen.queryByTestId('add-option-input')).toBeNull();
+    });
+
+    it('renders the Add input when onAddOption is provided', () => {
+      const onAddOption = vi.fn(async (label: string) => ({ value: label, label }));
+      render(
+        <StatusCell
+          value="active"
+          row={{}}
+          column={makeColumn({ onAddOption })}
+          rowIndex={0}
+          isEditing={true}
+          onCommit={noop}
+          onCancel={noop}
+        />,
+      );
+      expect(screen.getByTestId('add-option-input')).toBeTruthy();
+      expect(screen.getByTestId('add-option-submit')).toBeTruthy();
+    });
+
+    it('invokes onAddOption and appends the new option on Enter', async () => {
+      const onAddOption = vi.fn(
+        async (label: string): Promise<StatusOption> => ({ value: label.toLowerCase(), label }),
+      );
+      render(
+        <StatusCell
+          value="active"
+          row={{}}
+          column={makeColumn({ onAddOption })}
+          rowIndex={0}
+          isEditing={true}
+          onCommit={noop}
+          onCancel={noop}
+        />,
+      );
+      const input = screen.getByTestId('add-option-input') as HTMLInputElement;
+      fireEvent.change(input, { target: { value: 'Archived' } });
+      fireEvent.keyDown(input, { key: 'Enter' });
+
+      await waitFor(() => {
+        expect(onAddOption).toHaveBeenCalledWith('Archived');
+      });
+      await waitFor(() => {
+        expect(screen.getByRole('option', { name: /Archived/ })).toBeTruthy();
+      });
+      // Input cleared after a successful add.
+      expect((screen.getByTestId('add-option-input') as HTMLInputElement).value).toBe('');
+    });
+
+    it('invokes onAddOption when the Add button is clicked', async () => {
+      const onAddOption = vi.fn(
+        async (label: string): Promise<StatusOption> => ({ value: label, label }),
+      );
+      render(
+        <StatusCell
+          value="active"
+          row={{}}
+          column={makeColumn({ onAddOption })}
+          rowIndex={0}
+          isEditing={true}
+          onCommit={noop}
+          onCancel={noop}
+        />,
+      );
+      const input = screen.getByTestId('add-option-input') as HTMLInputElement;
+      fireEvent.change(input, { target: { value: 'NewOne' } });
+      fireEvent.mouseDown(screen.getByTestId('add-option-submit'));
+
+      await waitFor(() => {
+        expect(onAddOption).toHaveBeenCalledWith('NewOne');
+      });
+    });
+
+    it('rejects empty / whitespace-only labels without invoking the callback', () => {
+      const onAddOption = vi.fn(async (l: string) => ({ value: l, label: l }));
+      render(
+        <StatusCell
+          value="active"
+          row={{}}
+          column={makeColumn({ onAddOption })}
+          rowIndex={0}
+          isEditing={true}
+          onCommit={noop}
+          onCancel={noop}
+        />,
+      );
+      const input = screen.getByTestId('add-option-input') as HTMLInputElement;
+      fireEvent.change(input, { target: { value: '   ' } });
+      fireEvent.keyDown(input, { key: 'Enter' });
+      expect(onAddOption).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('delete option', () => {
+    it('does not render the × button when canDeleteOption is absent', () => {
+      render(
+        <StatusCell
+          value="active"
+          row={{}}
+          column={makeColumn({ onDeleteOption: vi.fn() })}
+          rowIndex={0}
+          isEditing={true}
+          onCommit={noop}
+          onCancel={noop}
+        />,
+      );
+      expect(screen.queryByTestId('delete-option-active')).toBeNull();
+    });
+
+    it('does not render the × button when onDeleteOption is absent', async () => {
+      await act(async () => {
+        render(
+          <StatusCell
+            value="active"
+            row={{}}
+            column={makeColumn({ canDeleteOption: () => true })}
+            rowIndex={0}
+            isEditing={true}
+            onCommit={noop}
+            onCancel={noop}
+          />,
+        );
+        // Flush the canDeleteOption resolution microtasks before asserting.
+        await Promise.resolve();
+      });
+      // No deletion side effect → no UI affordance even if canDelete=true.
+      expect(screen.queryByTestId('delete-option-active')).toBeNull();
+      expect(screen.queryByTestId('delete-option-inactive')).toBeNull();
+    });
+
+    it('renders × button only for options the consumer authorises', async () => {
+      const canDeleteOption = (opt: StatusOption) => opt.value === 'inactive';
+      const onDeleteOption = vi.fn(async () => {});
+      render(
+        <StatusCell
+          value="active"
+          row={{}}
+          column={makeColumn({ canDeleteOption, onDeleteOption })}
+          rowIndex={0}
+          isEditing={true}
+          onCommit={noop}
+          onCancel={noop}
+        />,
+      );
+      await waitFor(() => {
+        expect(screen.getByTestId('delete-option-inactive')).toBeTruthy();
+      });
+      expect(screen.queryByTestId('delete-option-active')).toBeNull();
+    });
+
+    it('resolves async canDeleteOption results', async () => {
+      const canDeleteOption = vi.fn(
+        async (opt: StatusOption) => opt.value === 'active',
+      );
+      const onDeleteOption = vi.fn(async () => {});
+      render(
+        <StatusCell
+          value="active"
+          row={{}}
+          column={makeColumn({ canDeleteOption, onDeleteOption })}
+          rowIndex={0}
+          isEditing={true}
+          onCommit={noop}
+          onCancel={noop}
+        />,
+      );
+      await waitFor(() => {
+        expect(screen.getByTestId('delete-option-active')).toBeTruthy();
+      });
+      expect(screen.queryByTestId('delete-option-inactive')).toBeNull();
+      expect(canDeleteOption).toHaveBeenCalled();
+    });
+
+    it('fires onDeleteOption and removes the option on × click', async () => {
+      const onDeleteOption = vi.fn(async () => {});
+      const canDeleteOption = () => true;
+      render(
+        <StatusCell
+          value="active"
+          row={{}}
+          column={makeColumn({ canDeleteOption, onDeleteOption })}
+          rowIndex={0}
+          isEditing={true}
+          onCommit={noop}
+          onCancel={noop}
+        />,
+      );
+      await waitFor(() => screen.getByTestId('delete-option-inactive'));
+
+      await act(async () => {
+        fireEvent.mouseDown(screen.getByTestId('delete-option-inactive'));
+      });
+
+      await waitFor(() => {
+        expect(onDeleteOption).toHaveBeenCalledWith(
+          expect.objectContaining({ value: 'inactive' }),
+        );
+      });
+      await waitFor(() => {
+        expect(screen.queryByRole('option', { name: /Inactive/ })).toBeNull();
+      });
+    });
+
+    it('Delete key removes the active option when authorised', async () => {
+      const onDeleteOption = vi.fn(async () => {});
+      const canDeleteOption = () => true;
+      render(
+        <StatusCell
+          value="active"
+          row={{}}
+          column={makeColumn({ canDeleteOption, onDeleteOption })}
+          rowIndex={0}
+          isEditing={true}
+          onCommit={noop}
+          onCancel={noop}
+        />,
+      );
+      await waitFor(() => screen.getByTestId('delete-option-active'));
+      const listbox = screen.getByRole('listbox');
+      fireEvent.keyDown(listbox, { key: 'Delete' });
+      await waitFor(() => {
+        expect(onDeleteOption).toHaveBeenCalledWith(
+          expect.objectContaining({ value: 'active' }),
+        );
+      });
+    });
+
+    it('Delete key is a no-op when canDeleteOption returns false', async () => {
+      const onDeleteOption = vi.fn(async () => {});
+      const canDeleteOption = () => false;
+      render(
+        <StatusCell
+          value="active"
+          row={{}}
+          column={makeColumn({ canDeleteOption, onDeleteOption })}
+          rowIndex={0}
+          isEditing={true}
+          onCommit={noop}
+          onCancel={noop}
+        />,
+      );
+      // Wait for the permission check to resolve before pressing Delete.
+      await waitFor(() => {
+        // No × buttons should render.
+        expect(screen.queryByTestId('delete-option-active')).toBeNull();
+      });
+      fireEvent.keyDown(screen.getByRole('listbox'), { key: 'Delete' });
+      expect(onDeleteOption).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/react/src/cells/StatusCell/StatusCell.styles.ts
+++ b/packages/react/src/cells/StatusCell/StatusCell.styles.ts
@@ -54,3 +54,49 @@ export const optionSwatch = (color: string): CSSProperties => ({
   background: color,
   flexShrink: 0,
 });
+
+// ---------------------------------------------------------------------------
+// Editable-dropdown affordances (see GitHub #93)
+// ---------------------------------------------------------------------------
+
+/** Trailing × button shown per-option when delete is authorised. */
+export const deleteButton: CSSProperties = {
+  marginLeft: 6,
+  padding: '0 4px',
+  border: 'none',
+  background: 'transparent',
+  color: '#6b7280',
+  cursor: 'pointer',
+  fontSize: 14,
+  lineHeight: 1,
+  borderRadius: 4,
+};
+
+/** Container row for the inline "Add new…" affordance. */
+export const addRow: CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: 4,
+  padding: '6px 6px 6px 10px',
+  borderTop: '1px solid #e5e7eb',
+  background: '#fafafa',
+};
+
+export const addInput: CSSProperties = {
+  flex: 1,
+  padding: '4px 6px',
+  fontSize: 12,
+  border: '1px solid #d1d5db',
+  borderRadius: 4,
+  outline: 'none',
+};
+
+export const addButton = (enabled: boolean): CSSProperties => ({
+  padding: '4px 8px',
+  fontSize: 12,
+  border: '1px solid #d1d5db',
+  borderRadius: 4,
+  background: enabled ? '#2563eb' : '#e5e7eb',
+  color: enabled ? '#fff' : '#9ca3af',
+  cursor: enabled ? 'pointer' : 'not-allowed',
+});

--- a/packages/react/src/cells/StatusCell/StatusCell.tsx
+++ b/packages/react/src/cells/StatusCell/StatusCell.tsx
@@ -6,10 +6,30 @@
  * option is defined by the column's `options` array (of type
  * {@link StatusOption}) and carries a label and an optional colour.
  *
+ * Editable option list (see GitHub #93)
+ * --------------------------------------
+ * When the column definition supplies `onAddOption`, the dropdown surfaces
+ * an inline "Add new…" text input at the bottom of the listbox — typing
+ * a label and pressing Enter (or clicking the "Add" affordance) appends
+ * a new option to the list via the callback.
+ *
+ * When `canDeleteOption` returns `true` for a given option, that option's
+ * row exposes a per-row delete (×) button (and answers the keyboard
+ * `Delete` shortcut). The callback may be sync or async; while a permission
+ * check is in flight, the × button stays hidden — there is no flicker
+ * because resolutions are cached per render. `onDeleteOption` is invoked
+ * when the user confirms; the option is removed from the visible list
+ * only after the returned promise resolves.
+ *
+ * The auth contract is intentionally generic. Consumers wire arbitrary
+ * permission logic (e.g. a GraphQL user-type lookup cached for the
+ * session) inside `canDeleteOption` — the grid never reads user identity
+ * directly.
+ *
  * @module StatusCell
  * @packageDocumentation
  */
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState, useRef, useEffect, useCallback } from 'react';
 import type { CellValue, ColumnDef, StatusOption } from '@iasbuilt/datagrid-core';
 import * as styles from './StatusCell.styles';
 
@@ -64,6 +84,9 @@ interface StatusCellProps<TData = Record<string, unknown>> {
  *       { value: 'active', label: 'Active', color: '#22c55e' },
  *       { value: 'inactive', label: 'Inactive', color: '#ef4444' },
  *     ],
+ *     onAddOption: async (label) => ({ value: label, label }),
+ *     canDeleteOption: (opt) => currentUser.role === 'admin',
+ *     onDeleteOption: async (opt) => api.deleteEnum(opt.value),
  *   }}
  *   rowIndex={0}
  *   isEditing={true}
@@ -79,8 +102,21 @@ export const StatusCell = React.memo(function StatusCell<TData = Record<string, 
   onCommit,
   onCancel,
 }: StatusCellProps<TData>) {
-  // Resolve the available status options from the column definition
-  const options: StatusOption[] = column.options ?? [];
+  // Resolve the available status options from the column definition.
+  // We mirror them into local state so add/delete callbacks can mutate the
+  // visible list while the dropdown is open without forcing the parent to
+  // re-render the column definition synchronously.
+  const initialOptions: StatusOption[] = column.options ?? [];
+  const [options, setOptions] = useState<StatusOption[]>(initialOptions);
+  // When the column's option list changes externally (e.g. parent commits a
+  // new server-side enum), pick it up — but skip the no-op identity case so
+  // local add/delete mutations are not clobbered mid-edit.
+  useEffect(() => {
+    setOptions(column.options ?? []);
+    // We intentionally depend on the column.options reference: parents that
+    // truly want to override mid-edit must hand us a new array.
+  }, [column.options]);
+
   // Draft state: tracks the selected value without exiting edit mode
   const [draft, setDraft] = useState<CellValue>(value);
   // Find the option matching the draft value for badge rendering
@@ -88,6 +124,23 @@ export const StatusCell = React.memo(function StatusCell<TData = Record<string, 
   const [open, setOpen] = useState(false);
   const [activeIndex, setActiveIndex] = useState(0);
   const dropdownRef = useRef<HTMLDivElement>(null);
+
+  // ---- Editable dropdown state (#93) -----------------------------------
+  // Editable-list callbacks. These may be absent — the cell falls back to
+  // the original read-only dropdown when none are provided.
+  const onAddOption = column.onAddOption;
+  const canDeleteOption = column.canDeleteOption;
+  const onDeleteOption = column.onDeleteOption;
+  // Text input value for the "Add new…" affordance.
+  const [newLabel, setNewLabel] = useState<string>('');
+  // Tracks which option values the consumer authorises the user to delete.
+  // Keyed by option value; missing entries are treated as "not yet known"
+  // and render with the × button hidden until the permission check
+  // resolves (avoiding a flicker on async checks).
+  const [deletePerms, setDeletePerms] = useState<Record<string, boolean>>({});
+  // Suppress the blur-commit when an internal action (Add input focus,
+  // delete button click) is briefly stealing focus from the listbox.
+  const suppressBlurRef = useRef(false);
 
   // Sync draft when the external value changes (e.g. undo/redo)
   useEffect(() => {
@@ -113,6 +166,34 @@ export const StatusCell = React.memo(function StatusCell<TData = Record<string, 
     }
   }, [open]);
 
+  // Resolve delete permissions for the currently visible options. We
+  // re-evaluate whenever the options list changes (add/delete) so that
+  // freshly added options pick up their permission state.
+  useEffect(() => {
+    if (!canDeleteOption) {
+      setDeletePerms({});
+      return;
+    }
+    let cancelled = false;
+    const next: Record<string, boolean> = {};
+    Promise.all(
+      options.map(async (opt) => {
+        try {
+          const allowed = await Promise.resolve(canDeleteOption(opt));
+          next[opt.value] = !!allowed;
+        } catch {
+          // A failed permission check defaults to "not allowed" — fail-safe.
+          next[opt.value] = false;
+        }
+      }),
+    ).then(() => {
+      if (!cancelled) setDeletePerms(next);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [options, canDeleteOption]);
+
   /**
    * Selects a status option: updates draft and closes the dropdown,
    * but keeps the cell in edit mode. The value is committed on blur.
@@ -125,8 +206,49 @@ export const StatusCell = React.memo(function StatusCell<TData = Record<string, 
   };
 
   /**
+   * Adds a new option via the `onAddOption` callback and appends it to
+   * the visible list. Empty / whitespace-only labels are rejected silently.
+   */
+  const addOption = useCallback(async () => {
+    const label = newLabel.trim();
+    if (!label || !onAddOption) return;
+    try {
+      const created = await Promise.resolve(onAddOption(label));
+      setOptions((prev) => {
+        // Deduplicate by value — if the consumer hands back an existing
+        // option we leave the list untouched.
+        if (prev.some((o) => o.value === created.value)) return prev;
+        return [...prev, created];
+      });
+      setNewLabel('');
+      // Return focus to the listbox so keyboard nav resumes naturally.
+      dropdownRef.current?.focus();
+    } catch {
+      // Swallow — consumers surface errors via their own UI.
+    }
+  }, [newLabel, onAddOption]);
+
+  /**
+   * Deletes an option via the `onDeleteOption` callback and removes it
+   * from the visible list once the promise resolves.
+   */
+  const deleteOption = useCallback(
+    async (opt: StatusOption) => {
+      if (!onDeleteOption) return;
+      try {
+        await Promise.resolve(onDeleteOption(opt));
+        setOptions((prev) => prev.filter((o) => o.value !== opt.value));
+      } catch {
+        // Same fail-soft contract as add.
+      }
+    },
+    [onDeleteOption],
+  );
+
+  /**
    * Handles keyboard navigation within the dropdown listbox.
    * ArrowDown/ArrowUp move the active index, Enter selects, Escape cancels.
+   * Delete removes the active option when the consumer authorises it.
    */
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (!open) return;
@@ -145,6 +267,13 @@ export const StatusCell = React.memo(function StatusCell<TData = Record<string, 
       e.stopPropagation();
       setOpen(false);
       onCancel();
+    } else if (e.key === 'Delete' || e.key === 'Backspace') {
+      const opt = options[activeIndex];
+      if (opt && onDeleteOption && deletePerms[opt.value]) {
+        e.preventDefault();
+        e.stopPropagation();
+        void deleteOption(opt);
+      }
     }
   };
 
@@ -191,32 +320,114 @@ export const StatusCell = React.memo(function StatusCell<TData = Record<string, 
           aria-label="Status options"
           tabIndex={-1}
           onKeyDown={handleKeyDown}
-          onBlur={() => {
+          onBlur={(e) => {
+            // Internal focus shuffles (Add input, × button) must NOT trigger
+            // the blur-commit. The flag is raised by those handlers via
+            // onMouseDown / onFocus before the blur fires; we additionally
+            // inspect `relatedTarget` to catch programmatic focus moves
+            // (Playwright's `locator.fill` focuses via JS without firing
+            // mousedown first, so the flag alone is not enough).
+            const next = e.relatedTarget as Node | null;
+            if (next && dropdownRef.current?.contains(next)) {
+              return;
+            }
+            if (suppressBlurRef.current) {
+              suppressBlurRef.current = false;
+              return;
+            }
             setOpen(false);
             onCommit(draft);
           }}
           style={styles.dropdown}
         >
-          {options.map((opt, i) => (
-            <div
-              key={opt.value}
-              role="option"
-              aria-selected={opt.value === value}
-              data-active={i === activeIndex}
-              onMouseDown={(e) => {
-                // Prevent blur from firing before the selection is committed
-                e.preventDefault();
-                select(opt);
-              }}
-              style={styles.optionRow(i === activeIndex)}
-            >
-              {/* Colour swatch for each option */}
-              {opt.color && (
-                <span style={styles.optionSwatch(opt.color)} />
-              )}
-              {opt.label}
+          {options.map((opt, i) => {
+            const canDelete = onDeleteOption && deletePerms[opt.value] === true;
+            return (
+              <div
+                key={opt.value}
+                role="option"
+                aria-selected={opt.value === value}
+                data-active={i === activeIndex}
+                data-option-value={opt.value}
+                onMouseDown={(e) => {
+                  // Prevent blur from firing before the selection is committed
+                  e.preventDefault();
+                  select(opt);
+                }}
+                style={styles.optionRow(i === activeIndex)}
+              >
+                {/* Colour swatch for each option */}
+                {opt.color && (
+                  <span style={styles.optionSwatch(opt.color)} />
+                )}
+                <span style={{ flex: 1 }}>{opt.label}</span>
+                {canDelete ? (
+                  <button
+                    type="button"
+                    aria-label={`Delete option ${opt.label}`}
+                    data-testid={`delete-option-${opt.value}`}
+                    onMouseDown={(e) => {
+                      // Stop the parent row's mouseDown (which would commit
+                      // a selection) and keep focus on the listbox.
+                      e.preventDefault();
+                      e.stopPropagation();
+                      suppressBlurRef.current = true;
+                      void deleteOption(opt);
+                    }}
+                    style={styles.deleteButton}
+                  >
+                    {'×'}
+                  </button>
+                ) : null}
+              </div>
+            );
+          })}
+          {onAddOption ? (
+            <div style={styles.addRow}>
+              <input
+                type="text"
+                value={newLabel}
+                placeholder="Add new…"
+                aria-label="Add new option"
+                data-testid="add-option-input"
+                onChange={(e) => setNewLabel(e.target.value)}
+                onFocus={() => {
+                  // Prevent the listbox-blur handler from committing while
+                  // the user is typing a new option.
+                  suppressBlurRef.current = true;
+                }}
+                onMouseDown={() => {
+                  suppressBlurRef.current = true;
+                }}
+                onKeyDown={(e) => {
+                  // Localise keyboard inside the input — don't let the
+                  // parent listbox handler interpret Enter as "select".
+                  e.stopPropagation();
+                  if (e.key === 'Enter') {
+                    e.preventDefault();
+                    void addOption();
+                  } else if (e.key === 'Escape') {
+                    setNewLabel('');
+                    (e.target as HTMLInputElement).blur();
+                  }
+                }}
+                style={styles.addInput}
+              />
+              <button
+                type="button"
+                data-testid="add-option-submit"
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  suppressBlurRef.current = true;
+                  void addOption();
+                }}
+                disabled={!newLabel.trim()}
+                style={styles.addButton(!!newLabel.trim())}
+              >
+                Add
+              </button>
             </div>
-          ))}
+          ) : null}
         </div>
       )}
     </div>

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -74,7 +74,10 @@ export { htmlToMarkdown } from './cells/RichTextCell';
 
 // Default cell renderer registry. Consumers can use this as a starting point
 // when supplying a custom `cellRenderers` prop to {@link DataGrid}.
+// `StatusCell` (issue #93) carries the new onAddOption / canDeleteOption /
+// onDeleteOption contract for the editable-dropdown picker.
 export { cellRendererMap, TagsCell } from './cells';
+export { StatusCell } from './cells/StatusCell';
 
 // Sub-components
 export { DataGridHeader } from './header';

--- a/stories/EditableDropdown.stories.tsx
+++ b/stories/EditableDropdown.stories.tsx
@@ -1,0 +1,173 @@
+/**
+ * Editable-dropdown stories (see GitHub #93).
+ *
+ * Demonstrates a status column whose option list is mutable from inside
+ * the dropdown — users can append new options via the inline "Add new…"
+ * input and remove existing ones via the per-option × button when the
+ * consumer-supplied auth gate (`canDeleteOption`) authorises it.
+ *
+ * These stories drive the React-flavoured `DataGrid` (not the MUI variant)
+ * because the editable-dropdown UI is implemented in the React
+ * `StatusCell` renderer.
+ */
+import React, { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { DataGrid, cellRendererMap } from '@iasbuilt/datagrid-react';
+import type { ColumnDef, StatusOption } from '@iasbuilt/datagrid-core';
+import { storyContainer, gridContainer } from './helpers';
+import * as styles from './stories.styles';
+
+const meta: Meta = {
+  title: 'Examples/Editable Dropdown',
+};
+export default meta;
+
+interface Row {
+  id: string;
+  name: string;
+  status: string;
+}
+
+const initialOptions: StatusOption[] = [
+  { value: 'active', label: 'Active', color: '#22c55e' },
+  { value: 'inactive', label: 'Inactive', color: '#ef4444' },
+  { value: 'pending', label: 'Pending', color: '#f59e0b' },
+];
+
+const initialData: Row[] = [
+  { id: 'r1', name: 'Asset Alpha', status: 'active' },
+  { id: 'r2', name: 'Asset Beta', status: 'inactive' },
+  { id: 'r3', name: 'Asset Gamma', status: 'pending' },
+];
+
+// ---------------------------------------------------------------------------
+// Story: editable dropdown with admin-style permissions (delete authorised
+// for every option).
+// ---------------------------------------------------------------------------
+
+/**
+ * The "admin" view shows the full feature surface: add new options + delete
+ * any option. Consumers wire arbitrary permission logic (e.g. a GraphQL
+ * user-type lookup, cached for the session) inside `canDeleteOption`.
+ */
+export const AdminEditableDropdown: StoryObj = {
+  render: () => {
+    const [options, setOptions] = useState<StatusOption[]>(initialOptions);
+
+    const columns: ColumnDef<Row>[] = [
+      { id: 'name', field: 'name', title: 'Name', width: 200 },
+      {
+        id: 'status',
+        field: 'status',
+        title: 'Status',
+        width: 200,
+        cellType: 'status',
+        editable: true,
+        options,
+        // The cell mutates its own internal list, but for the story we mirror
+        // the change into the parent state so the new options persist across
+        // re-renders / row toggles.
+        onAddOption: async (label: string) => {
+          const created: StatusOption = {
+            value: label.toLowerCase().replace(/\s+/g, '-'),
+            label,
+            color: '#6366f1',
+          };
+          setOptions((prev) =>
+            prev.some((o) => o.value === created.value) ? prev : [...prev, created],
+          );
+          return created;
+        },
+        canDeleteOption: () => true,
+        onDeleteOption: async (opt) => {
+          setOptions((prev) => prev.filter((o) => o.value !== opt.value));
+        },
+      },
+    ];
+
+    return (
+      <div style={storyContainer} data-testid="story-root">
+        <h2 style={styles.heading}>Editable Dropdown — Admin</h2>
+        <p style={styles.subtitle}>
+          Double-click a status cell to open the dropdown. Use the "Add new…"
+          input at the bottom to append options; click × on any option to
+          remove it.
+        </p>
+        <div style={gridContainer}>
+          <DataGrid
+            data={initialData}
+            columns={columns as any}
+            rowKey="id"
+            selectionMode="cell"
+            keyboardNavigation
+            cellRenderers={cellRendererMap as any}
+          />
+        </div>
+      </div>
+    );
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Story: read-only "viewer" — add allowed but delete denied. Exercises the
+// negative branch of canDeleteOption.
+// ---------------------------------------------------------------------------
+
+/**
+ * The "viewer" surface keeps the Add affordance but withholds delete from
+ * every option. The × buttons must not render and the keyboard Delete
+ * shortcut must be a no-op.
+ */
+export const ViewerEditableDropdown: StoryObj = {
+  render: () => {
+    const [options, setOptions] = useState<StatusOption[]>(initialOptions);
+
+    const columns: ColumnDef<Row>[] = [
+      { id: 'name', field: 'name', title: 'Name', width: 200 },
+      {
+        id: 'status',
+        field: 'status',
+        title: 'Status',
+        width: 200,
+        cellType: 'status',
+        editable: true,
+        options,
+        onAddOption: async (label: string) => {
+          const created: StatusOption = {
+            value: label.toLowerCase().replace(/\s+/g, '-'),
+            label,
+            color: '#0ea5e9',
+          };
+          setOptions((prev) =>
+            prev.some((o) => o.value === created.value) ? prev : [...prev, created],
+          );
+          return created;
+        },
+        // Viewer role — no deletions authorised.
+        canDeleteOption: () => false,
+        onDeleteOption: async () => {
+          throw new Error('unauthorised');
+        },
+      },
+    ];
+
+    return (
+      <div style={storyContainer} data-testid="story-root">
+        <h2 style={styles.heading}>Editable Dropdown — Viewer</h2>
+        <p style={styles.subtitle}>
+          Add is enabled, delete is gated off by <code>canDeleteOption</code>.
+        </p>
+        <div style={gridContainer}>
+          <DataGrid
+            data={initialData}
+            columns={columns as any}
+            rowKey="id"
+            selectionMode="cell"
+            keyboardNavigation
+            cellRenderers={cellRendererMap as any}
+          />
+        </div>
+      </div>
+    );
+  },
+};


### PR DESCRIPTION
Closes #93.

## Summary

Adds an editable dropdown contract to the React `StatusCell` so consumers can let users mutate the option list from inside the cell at edit time. The column definition grows three optional callbacks (`onAddOption`, `canDeleteOption`, `onDeleteOption`); the deletion authorisation gate is intentionally generic so consumers can wire arbitrary permission logic (e.g. a GraphQL user-type lookup cached for the session) without the grid needing any knowledge of identity.

- New column-config callbacks on `ColumnDef` in `packages/core/src/types.ts`:
  - `onAddOption?: (label: string) => Promise<StatusOption> | StatusOption`
  - `canDeleteOption?: (option: StatusOption) => boolean | Promise<boolean>`
  - `onDeleteOption?: (option: StatusOption) => Promise<void> | void`
- `StatusCell` surfaces an inline "Add new…" input at the bottom of the listbox when `onAddOption` is wired, and a per-option `×` button (and `Delete` keyboard shortcut) gated by `canDeleteOption`. The new buttons / inputs are kept off the markup entirely when their corresponding callbacks are absent, so the existing read-only contract is unchanged.
- Adds `cellRendererMap` + `StatusCell` to the `@iasbuilt/datagrid-react` public surface so the React renderer can be used outside the MUI grid (the issue explicitly asks for the React-flavoured editor — the MUI variant remains untouched).
- Two new Storybook stories under `Examples/Editable Dropdown` exercise the admin (add + delete) and viewer (add-only) flavours for both visual review and e2e.

## Test plan

- [x] `pnpm vitest run packages/` — 1953/1953 (12 new unit tests in `packages/react/src/__tests__/status-cell-editable-dropdown.test.tsx`)
- [x] `pnpm exec playwright test e2e/issue-93-editable-dropdown.spec.ts` — 4/4
- [x] `pnpm typecheck` — clean
- [x] `pnpm run build` — clean
- [x] Pre-commit hook (typecheck + build + tests + tokens drift + script tests) — green