### PR TITLE
feat(numeric): Excel-style format presets + dual-unit sub-cell

### DIFF
--- a/e2e/issue-92-number-format-presets.spec.ts
+++ b/e2e/issue-92-number-format-presets.spec.ts
@@ -1,0 +1,125 @@
+/**
+ * End-to-end coverage for issue #92 — Excel-style number-format presets and
+ * the optional dual-unit sub-cell on the numeric cell type.
+ *
+ * Stories:
+ *   - `examples-number-format--presets`        (Excel-style presets)
+ *   - `examples-number-format--secondary-unit` (dual-unit weight column)
+ *
+ * Each formatted cell is cross-checked against the expected
+ * `Intl.NumberFormat` output computed in-test so the spec is robust to
+ * locale drift in the host environment while still pinning the structural
+ * shape of every preset.
+ */
+import { test, expect, type Page } from '@playwright/test';
+
+const PRESETS_URL = '/iframe.html?viewMode=story&id=examples-number-format--presets';
+const SECONDARY_UNIT_URL = '/iframe.html?viewMode=story&id=examples-number-format--secondary-unit';
+
+async function waitForGrid(page: Page): Promise<void> {
+  await page.locator('[role="grid"]').first().waitFor({ state: 'visible' });
+}
+
+function cell(page: Page, field: string, rowId: string) {
+  return page.locator(`[role="gridcell"][data-field="${field}"][data-row-id="${rowId}"]`).first();
+}
+
+test.describe('Issue #92 — Excel-style number-format presets', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(PRESETS_URL);
+    await waitForGrid(page);
+  });
+
+  test('thousands preset matches Intl.NumberFormat output', async ({ page }) => {
+    const expected = new Intl.NumberFormat().format(1234567);
+    await expect(cell(page, 'thousands', '1')).toHaveText(expected);
+  });
+
+  test('currency preset renders the expected USD string', async ({ page }) => {
+    const expected = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(1234.5);
+    await expect(cell(page, 'currency', '1')).toHaveText(expected);
+  });
+
+  test('percent preset honours the 1-decimal config and treats value as a ratio', async ({ page }) => {
+    const expected = new Intl.NumberFormat('en-US', {
+      style: 'percent',
+      minimumFractionDigits: 1,
+      maximumFractionDigits: 1,
+    }).format(0.25);
+    await expect(cell(page, 'percent', '1')).toHaveText(expected);
+  });
+
+  test('accounting preset wraps negatives in parentheses', async ({ page }) => {
+    const text = (await cell(page, 'accounting', '1').innerText()).trim();
+    // -1000 USD in accounting style ⇒ parens around a USD amount.
+    expect(text).toMatch(/^\(.*1,000.*\)$/);
+    expect(text).toContain('$');
+  });
+
+  test('scientific preset uses uppercase E exponent', async ({ page }) => {
+    await expect(cell(page, 'scientific', '1')).toHaveText('1.23E5');
+  });
+
+  test('fixed preset honours the requested decimal count with no grouping', async ({ page }) => {
+    await expect(cell(page, 'fixed', '1')).toHaveText('3.142');
+  });
+
+  test('editing a preset cell reformats display after commit', async ({ page }) => {
+    const target = cell(page, 'thousands', '2');
+    await target.scrollIntoViewIfNeeded();
+    await target.dblclick();
+    const input = page.locator('[role="gridcell"][data-field="thousands"][data-row-id="2"] input').first();
+    await input.waitFor({ state: 'visible' });
+    // Wait for the deferred `select()` to run so the first keystroke replaces
+    // the existing text rather than racing the focus/select effect.
+    await input.focus();
+    await page.keyboard.press('ControlOrMeta+A');
+    await page.keyboard.type('9876543');
+    await page.keyboard.press('Enter');
+    const expected = new Intl.NumberFormat().format(9876543);
+    await expect(target).toHaveText(expected);
+  });
+});
+
+test.describe('Issue #92 — Dual-unit sub-cell', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(SECONDARY_UNIT_URL);
+    await waitForGrid(page);
+  });
+
+  test('renders both primary and secondary unit lines with the converted value', async ({ page }) => {
+    const target = cell(page, 'weight_kg', '1');
+    const primary = target.locator('[data-testid="numeric-primary"]');
+    const secondary = target.locator('[data-testid="numeric-secondary"]');
+
+    // Primary: fixed(1 dp) of 100 → "100.0"
+    await expect(primary).toHaveText('100.0');
+    // Secondary: 100 kg * 2.20462 = 220.462 → fixed(2 dp) "220.46 lb"
+    await expect(secondary).toHaveText('220.46 lb');
+  });
+
+  test('secondary line updates after a primary-value edit', async ({ page }) => {
+    const target = cell(page, 'weight_kg', '2');
+    await target.scrollIntoViewIfNeeded();
+    await target.dblclick();
+    const input = page.locator('[role="gridcell"][data-field="weight_kg"][data-row-id="2"] input').first();
+    await input.waitFor({ state: 'visible' });
+    await page.keyboard.type('10');
+    await page.keyboard.press('Enter');
+
+    const primary = target.locator('[data-testid="numeric-primary"]');
+    const secondary = target.locator('[data-testid="numeric-secondary"]');
+    await expect(primary).toHaveText('10.0');
+    // 10 kg * 2.20462 = 22.0462 → fixed(2 dp) ⇒ "22.05 lb"
+    await expect(secondary).toHaveText('22.05 lb');
+  });
+
+  test('edit mode shows a single input (no secondary line in the editor)', async ({ page }) => {
+    const target = cell(page, 'weight_kg', '1');
+    await target.dblclick();
+    const input = page.locator('[role="gridcell"][data-field="weight_kg"][data-row-id="1"] input').first();
+    await input.waitFor({ state: 'visible' });
+    // While editing, the dual-unit wrapper is replaced by the bare editor.
+    await expect(target.locator('[data-testid="numeric-secondary"]')).toHaveCount(0);
+  });
+});

--- a/packages/core/src/__tests__/number-format.test.ts
+++ b/packages/core/src/__tests__/number-format.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Unit tests for the Excel-style number-format helpers introduced for
+ * issue #92. The helpers in `packages/core/src/number-format.ts` are pure
+ * — they take a value + spec and return a string — so we cover the entire
+ * preset matrix here without React, DOM, or grid state.
+ *
+ * Locale-formatted strings vary by host environment. Each assertion is
+ * cross-checked against a freshly constructed `Intl.NumberFormat` instance
+ * configured with the same options so the test is robust across Node /
+ * browser locales, while still pinning the structural expectations
+ * (sign placement, decimals, grouping, exponent separator).
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  formatNumber,
+  isNumberFormatSpec,
+  type NumberFormatSpec,
+} from '../number-format';
+
+describe('isNumberFormatSpec', () => {
+  it('recognises the "thousands" shorthand', () => {
+    expect(isNumberFormatSpec('thousands')).toBe(true);
+  });
+  it('recognises every preset kind object', () => {
+    expect(isNumberFormatSpec({ kind: 'currency', currency: 'USD' })).toBe(true);
+    expect(isNumberFormatSpec({ kind: 'percent' })).toBe(true);
+    expect(isNumberFormatSpec({ kind: 'accounting' })).toBe(true);
+    expect(isNumberFormatSpec({ kind: 'scientific' })).toBe(true);
+    expect(isNumberFormatSpec({ kind: 'fixed', decimals: 2 })).toBe(true);
+  });
+  it('rejects unrelated strings and arbitrary objects', () => {
+    expect(isNumberFormatSpec('USD')).toBe(false);
+    expect(isNumberFormatSpec('YYYY-MM-DD')).toBe(false);
+    expect(isNumberFormatSpec({ foo: 'bar' })).toBe(false);
+    expect(isNumberFormatSpec(null)).toBe(false);
+    expect(isNumberFormatSpec(undefined)).toBe(false);
+    expect(isNumberFormatSpec(42)).toBe(false);
+  });
+});
+
+describe('formatNumber', () => {
+  describe('empty / non-numeric inputs', () => {
+    it('returns "" for null, undefined, empty string, and NaN', () => {
+      expect(formatNumber(null, 'thousands')).toBe('');
+      expect(formatNumber(undefined, 'thousands')).toBe('');
+      expect(formatNumber('', 'thousands')).toBe('');
+      expect(formatNumber(NaN, 'thousands')).toBe('');
+      expect(formatNumber('not-a-number', 'thousands')).toBe('');
+    });
+    it('returns "" for infinities', () => {
+      expect(formatNumber(Infinity, 'thousands')).toBe('');
+      expect(formatNumber(-Infinity, 'thousands')).toBe('');
+    });
+  });
+
+  describe('no spec', () => {
+    it('falls back to plain String() conversion', () => {
+      expect(formatNumber(1234567, undefined)).toBe('1234567');
+      expect(formatNumber(-12.5, undefined)).toBe('-12.5');
+    });
+  });
+
+  describe('thousands shorthand', () => {
+    it('matches the default Intl.NumberFormat output', () => {
+      const expected = new Intl.NumberFormat().format(1234567);
+      expect(formatNumber(1234567, 'thousands')).toBe(expected);
+    });
+  });
+
+  describe('currency', () => {
+    it('matches Intl.NumberFormat currency output (USD)', () => {
+      const spec: NumberFormatSpec = { kind: 'currency', currency: 'USD', locale: 'en-US' };
+      const expected = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(1234.5);
+      expect(formatNumber(1234.5, spec)).toBe(expected);
+    });
+    it('matches Intl.NumberFormat currency output (EUR / de-DE)', () => {
+      const spec: NumberFormatSpec = { kind: 'currency', currency: 'EUR', locale: 'de-DE' };
+      const expected = new Intl.NumberFormat('de-DE', { style: 'currency', currency: 'EUR' }).format(1234.5);
+      expect(formatNumber(1234.5, spec)).toBe(expected);
+    });
+  });
+
+  describe('percent', () => {
+    it('treats the value as a ratio (0.25 → 25%)', () => {
+      const expected = new Intl.NumberFormat('en-US', {
+        style: 'percent',
+        minimumFractionDigits: 0,
+        maximumFractionDigits: 0,
+      }).format(0.25);
+      expect(formatNumber(0.25, { kind: 'percent', locale: 'en-US' })).toBe(expected);
+    });
+    it('honours the `decimals` option', () => {
+      const expected = new Intl.NumberFormat('en-US', {
+        style: 'percent',
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+      }).format(0.12345);
+      expect(formatNumber(0.12345, { kind: 'percent', decimals: 2, locale: 'en-US' })).toBe(expected);
+    });
+  });
+
+  describe('accounting', () => {
+    it('wraps negatives in accounting parens', () => {
+      const out = formatNumber(-1000, { kind: 'accounting', currency: 'USD', locale: 'en-US' });
+      expect(out).toMatch(/\(.*1,000.*\)/);
+    });
+    it('formats positives like a regular currency', () => {
+      const expected = new Intl.NumberFormat('en-US', {
+        style: 'currency',
+        currency: 'USD',
+        currencySign: 'accounting',
+      }).format(1000);
+      expect(formatNumber(1000, { kind: 'accounting', currency: 'USD', locale: 'en-US' })).toBe(expected);
+    });
+    it('defaults to USD when currency is omitted', () => {
+      const out = formatNumber(1000, { kind: 'accounting', locale: 'en-US' });
+      expect(out).toContain('$');
+    });
+  });
+
+  describe('scientific', () => {
+    it('uses uppercase E exponent separator', () => {
+      const out = formatNumber(123456, { kind: 'scientific', decimals: 2 });
+      expect(out).toMatch(/^1\.23E5$/);
+    });
+    it('honours the decimals option', () => {
+      expect(formatNumber(0.000123, { kind: 'scientific', decimals: 3 })).toBe('1.230E-4');
+    });
+    it('defaults to 2 decimals', () => {
+      expect(formatNumber(50000, { kind: 'scientific' })).toBe('5.00E4');
+    });
+  });
+
+  describe('fixed', () => {
+    it('renders the requested decimal count with no grouping', () => {
+      expect(formatNumber(3.14159, { kind: 'fixed', decimals: 2, locale: 'en-US' })).toBe('3.14');
+      expect(formatNumber(1234.5, { kind: 'fixed', decimals: 0, locale: 'en-US' })).toBe('1235');
+    });
+    it('pads with trailing zeros when needed', () => {
+      expect(formatNumber(5, { kind: 'fixed', decimals: 3, locale: 'en-US' })).toBe('5.000');
+    });
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -71,6 +71,9 @@ export * from './search-index';
 // Cell text overflow policy vocabulary + default policy resolver and middle-truncation helper.
 export type { OverflowPolicy, Density } from './overflow';
 export { truncateMiddle, truncateEnd, getDefaultOverflowPolicy } from './overflow';
+// Excel-style number-format presets + dual-unit sub-cell spec (issue #92).
+export type { NumberFormatSpec, SecondaryUnitSpec } from './number-format';
+export { formatNumber, isNumberFormatSpec } from './number-format';
 
 // Re-exports of the causl primitives core depends on, so SPA integrators
 // who want BYO-graph composition (`createGridModel({ graph })` +

--- a/packages/core/src/number-format.ts
+++ b/packages/core/src/number-format.ts
@@ -1,0 +1,172 @@
+/**
+ * Excel-style number formatting primitives for the datagrid.
+ *
+ * Provides a small discriminated union — {@link NumberFormatSpec} — that
+ * encodes the most common Excel format presets (currency, percentage,
+ * accounting, scientific, thousands-separator, fixed-decimals) along with a
+ * single entry point, {@link formatNumber}, that resolves a raw value into a
+ * locale-aware display string via `Intl.NumberFormat`.
+ *
+ * The functions are pure: they take a value + spec and return a string.
+ * They never touch React, never read column state, and are exhaustively
+ * testable in isolation.
+ *
+ * @module number-format
+ */
+
+/**
+ * Discriminated union of the supported Excel-style format presets.
+ *
+ * - `'thousands'` — locale-grouped integer/decimal (e.g. `1,234,567`).
+ *   This shorthand string is preserved for backwards compatibility with the
+ *   pre-discriminated `format: 'thousands'` API surface.
+ * - `{ kind: 'currency'; currency: string; locale?: string }` — currency
+ *   formatting via `Intl.NumberFormat` (e.g. `$1,234.56`, `€1.234,56`).
+ * - `{ kind: 'percent'; decimals?: number }` — percent formatting.
+ *   The value is treated as a ratio (`0.25` → `25%`) per the Excel convention.
+ * - `{ kind: 'accounting' }` — accounting format: currency-style with parens
+ *   around negatives (defaults to USD if `currency` is omitted).
+ * - `{ kind: 'scientific' }` — scientific notation (e.g. `1.23E+5`).
+ * - `{ kind: 'fixed'; decimals: number }` — fixed decimal count, no grouping.
+ *
+ * An optional `locale` field is honoured on every object form; when omitted
+ * the runtime's default locale is used.
+ */
+export type NumberFormatSpec =
+  | 'thousands'
+  | { kind: 'currency'; currency: string; locale?: string }
+  | { kind: 'percent'; decimals?: number; locale?: string }
+  | { kind: 'accounting'; currency?: string; locale?: string }
+  | { kind: 'scientific'; decimals?: number; locale?: string }
+  | { kind: 'fixed'; decimals: number; locale?: string };
+
+/**
+ * Type-guard distinguishing a {@link NumberFormatSpec} object from a plain
+ * format string (e.g. legacy `'YYYY-MM-DD'` masks on calendar columns).
+ *
+ * Returns `true` for the shorthand `'thousands'` literal and for any object
+ * carrying a recognised `kind`.
+ */
+export function isNumberFormatSpec(value: unknown): value is NumberFormatSpec {
+  if (value === 'thousands') return true;
+  if (typeof value !== 'object' || value === null) return false;
+  const kind = (value as { kind?: unknown }).kind;
+  return (
+    kind === 'currency' ||
+    kind === 'percent' ||
+    kind === 'accounting' ||
+    kind === 'scientific' ||
+    kind === 'fixed'
+  );
+}
+
+/**
+ * Coerces an arbitrary cell value to a finite number.
+ *
+ * Returns `null` for nullish / empty-string / non-finite inputs so the caller
+ * can short-circuit to a friendly empty-cell display.
+ */
+function toFiniteNumber(value: unknown): number | null {
+  if (value === null || value === undefined || value === '') return null;
+  const n = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(n) ? n : null;
+}
+
+/**
+ * Formats a numeric value into a display string using the given spec.
+ *
+ * Returns `''` for nullish, empty-string, or non-finite inputs so cells render
+ * blank rather than showing `NaN`. When `spec` is `undefined`, the value is
+ * rendered with a plain `String()` conversion (no grouping, no decimals
+ * coercion) — matching the pre-existing default for numeric columns.
+ *
+ * @param value - The raw cell value to format.
+ * @param spec  - The format spec; see {@link NumberFormatSpec}.
+ * @returns The formatted string, or `''` when the value is empty/not numeric.
+ *
+ * @example
+ * ```ts
+ * formatNumber(1234567, 'thousands');                        // → "1,234,567"
+ * formatNumber(19.99, { kind: 'currency', currency: 'USD' }); // → "$19.99"
+ * formatNumber(0.25, { kind: 'percent', decimals: 1 });       // → "25.0%"
+ * formatNumber(-1000, { kind: 'accounting' });               // → "($1,000.00)"
+ * formatNumber(123_456, { kind: 'scientific', decimals: 2 }); // → "1.23E5"
+ * formatNumber(3.14159, { kind: 'fixed', decimals: 2 });      // → "3.14"
+ * ```
+ */
+export function formatNumber(value: unknown, spec: NumberFormatSpec | undefined): string {
+  const num = toFiniteNumber(value);
+  if (num === null) return '';
+
+  if (spec === undefined) return String(num);
+
+  if (spec === 'thousands') {
+    return new Intl.NumberFormat().format(num);
+  }
+
+  switch (spec.kind) {
+    case 'currency':
+      return new Intl.NumberFormat(spec.locale, {
+        style: 'currency',
+        currency: spec.currency,
+      }).format(num);
+
+    case 'percent': {
+      const decimals = spec.decimals ?? 0;
+      return new Intl.NumberFormat(spec.locale, {
+        style: 'percent',
+        minimumFractionDigits: decimals,
+        maximumFractionDigits: decimals,
+      }).format(num);
+    }
+
+    case 'accounting': {
+      const currency = spec.currency ?? 'USD';
+      return new Intl.NumberFormat(spec.locale, {
+        style: 'currency',
+        currency,
+        currencySign: 'accounting',
+      }).format(num);
+    }
+
+    case 'scientific': {
+      const decimals = spec.decimals ?? 2;
+      // `Intl.NumberFormat` does not expose a native `style: 'scientific'`;
+      // `Number.prototype.toExponential` is the cross-engine canonical path.
+      // Normalise the exponent separator to upper-case `E` to match Excel.
+      return num.toExponential(decimals).replace('e', 'E').replace('E+', 'E');
+    }
+
+    case 'fixed':
+      return new Intl.NumberFormat(spec.locale, {
+        useGrouping: false,
+        minimumFractionDigits: spec.decimals,
+        maximumFractionDigits: spec.decimals,
+      }).format(num);
+  }
+}
+
+/**
+ * Describes a dual-unit sub-cell rendered below the primary value.
+ *
+ * When set on a numeric column, the cell renders the primary (stored) value
+ * on the first line and a smaller, derived secondary line below it (e.g.
+ * `"100 kg / 220.46 lb"`). Edit mode shows only the primary input; the
+ * secondary line is presentation-only and recomputes on every render.
+ *
+ * - `label`      — short unit label appended to the converted value
+ *                  (e.g. `"lb"`, `"°F"`, `"mi"`).
+ * - `conversion` — pure function mapping the primary numeric value to the
+ *                  secondary unit. Called with the raw `number`; nullish
+ *                  primaries skip the secondary line entirely.
+ * - `format`     — optional spec controlling how the converted value is
+ *                  rendered (defaults to a plain `String()` conversion).
+ */
+export interface SecondaryUnitSpec {
+  /** Short label for the secondary unit, appended after the value. */
+  label: string;
+  /** Pure function converting the primary value to the secondary unit. */
+  conversion: (value: number) => number;
+  /** Optional format spec for the converted secondary value. */
+  format?: NumberFormatSpec;
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,5 +1,6 @@
 import type { Validator } from './validators';
 import type { OverflowPolicy, Density } from './overflow';
+import type { NumberFormatSpec, SecondaryUnitSpec } from './number-format';
 
 /**
  * Core type definitions for the datagrid system.
@@ -273,8 +274,30 @@ export interface ColumnDef<TData = Record<string, unknown>> {
   allowFreeText?: boolean;
   /** Placeholder text shown in empty cells. */
   placeholder?: string;
-  /** Display format string for `calendar` and `currency` columns. */
-  format?: string;
+  /**
+   * Display format for `numeric`, `calendar`, and `currency` columns.
+   *
+   * For numeric columns, accepts either:
+   * - the legacy shorthand string `'thousands'` (locale grouping separator);
+   * - a {@link NumberFormatSpec} object selecting an Excel-style preset
+   *   (`currency`, `percent`, `accounting`, `scientific`, `fixed`); or
+   * - a plain mask string forwarded to `calendar` / `currency` renderers
+   *   (e.g. `'YYYY-MM-DD'`, `'USD'`).
+   *
+   * See {@link formatNumber} for the runtime semantics of the object form.
+   */
+  format?: string | NumberFormatSpec;
+  /**
+   * Optional dual-unit sub-cell rendered below the primary value on
+   * `numeric` columns. The cell shows the primary value on the first line
+   * and a smaller, read-only converted value on a second line (e.g.
+   * `100 kg / 220.46 lb`). Edit mode is unchanged — only the primary value
+   * is editable; the secondary line is presentation-only and recomputed via
+   * the supplied `conversion` formula on every render.
+   *
+   * See {@link SecondaryUnitSpec} for the field contract.
+   */
+  secondaryUnit?: SecondaryUnitSpec;
   /** Minimum allowed numeric value for `numeric` columns. */
   min?: number;
   /** Maximum allowed numeric value for `numeric` columns. */

--- a/packages/extensions/src/export/index.ts
+++ b/packages/extensions/src/export/index.ts
@@ -219,16 +219,22 @@ export function generateCsv(
 export function formatCellForExcel(value: unknown, column: ColumnDef): { value: unknown; format?: string } {
   if (value == null) return { value: '' };
 
+  // `ColumnDef.format` admits both legacy mask strings and the
+  // NumberFormatSpec object (issue #92). Excel export still emits a plain
+  // mask string — coerce the object form to undefined so we fall back to the
+  // defaults below; bespoke Excel masks for the new presets are deferred.
+  const formatMask = typeof column.format === 'string' ? column.format : undefined;
+
   if (typeof value === 'number') {
     // Apply currency format when the column is typed as currency
     if (column.cellType === 'currency') {
-      return { value, format: column.format ?? '$#,##0.00' };
+      return { value, format: formatMask ?? '$#,##0.00' };
     }
-    return { value, format: column.format ?? '0' };
+    return { value, format: formatMask ?? '0' };
   }
 
   if (value instanceof Date) {
-    return { value, format: column.format ?? 'yyyy-mm-dd' };
+    return { value, format: formatMask ?? 'yyyy-mm-dd' };
   }
 
   return { value: String(value) };

--- a/packages/mui/src/cells/MuiCurrencyCell/MuiCurrencyCell.tsx
+++ b/packages/mui/src/cells/MuiCurrencyCell/MuiCurrencyCell.tsx
@@ -44,7 +44,11 @@ export const MuiCurrencyCell = React.memo(function MuiCurrencyCell<TData = Recor
   onCommit,
   onCancel,
 }: CellRendererProps<TData>) {
-  const { symbol, negativeRed } = parseCurrencyFormat(column.format);
+  // `column.format` may be either a legacy mask string ("USD", "EUR:€:no-red")
+  // or a NumberFormatSpec object (issue #92, numeric columns only). Currency
+  // cells continue to consume the mask form; ignore the object form here.
+  const rawFormat = typeof column.format === 'string' ? column.format : undefined;
+  const { symbol, negativeRed } = parseCurrencyFormat(rawFormat);
   const numericValue = value === null || value === undefined ? '' : String(value);
 
   const commitTransform = (raw: string): unknown => {

--- a/packages/mui/src/cells/MuiNumericCell/MuiNumericCell.tsx
+++ b/packages/mui/src/cells/MuiNumericCell/MuiNumericCell.tsx
@@ -6,16 +6,24 @@
  */
 import React from 'react';
 import Typography from '@mui/material/Typography';
-import type { CellValue } from '@iasbuilt/datagrid-core';
+import Box from '@mui/material/Box';
+import type { CellValue, ColumnDef } from '@iasbuilt/datagrid-core';
+import { formatNumber, isNumberFormatSpec } from '@iasbuilt/datagrid-core';
 import type { CellRendererProps } from '@iasbuilt/datagrid-react';
 import { useDraftState } from '@iasbuilt/datagrid-react';
 import { EditableTextField } from '../../components';
 
-function formatNumeric(value: CellValue, useThousands: boolean): string {
+/**
+ * Resolves a numeric cell value to its display string, honouring the
+ * Excel-style {@link NumberFormatSpec} shapes added for issue #92 as well
+ * as the legacy `'thousands'` shorthand.
+ */
+function formatNumeric(value: CellValue, format: ColumnDef['format']): string {
   if (value === null || value === undefined || value === '') return '';
   const num = Number(value);
   if (isNaN(num)) return '';
-  return useThousands ? num.toLocaleString() : String(num);
+  if (isNumberFormatSpec(format)) return formatNumber(num, format);
+  return String(num);
 }
 
 /**
@@ -28,9 +36,19 @@ export const MuiNumericCell = React.memo(function MuiNumericCell<TData = Record<
   onCommit,
   onCancel,
 }: CellRendererProps<TData>) {
-  const useThousands = column.format === 'thousands';
-  const displayValue = formatNumeric(value, useThousands);
+  const displayValue = formatNumeric(value, column.format);
   const rawValue = value === null || value === undefined ? '' : String(value);
+  // Optional dual-unit sub-cell (issue #92) — derived from the primary
+  // value via a pure conversion formula on every render.
+  const numericValue = (() => {
+    if (value === null || value === undefined || value === '') return null;
+    const n = Number(value);
+    return Number.isFinite(n) ? n : null;
+  })();
+  const secondary = column.secondaryUnit;
+  const secondaryDisplay = secondary && numericValue !== null
+    ? `${formatNumeric(secondary.conversion(numericValue), secondary.format) || String(secondary.conversion(numericValue))} ${secondary.label}`
+    : null;
 
   const clamp = (num: number): number => {
     let result = num;
@@ -56,6 +74,25 @@ export const MuiNumericCell = React.memo(function MuiNumericCell<TData = Record<
   });
 
   if (!isEditing) {
+    if (secondaryDisplay !== null) {
+      return (
+        <Box
+          data-testid="numeric-dual-unit"
+          sx={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', width: '100%', lineHeight: 1.15 }}
+        >
+          <Typography variant="body2" sx={{ textAlign: 'right', width: '100%' }} data-testid="numeric-primary">
+            {displayValue}
+          </Typography>
+          <Typography
+            variant="caption"
+            sx={{ textAlign: 'right', width: '100%', opacity: 0.65 }}
+            data-testid="numeric-secondary"
+          >
+            {secondaryDisplay}
+          </Typography>
+        </Box>
+      );
+    }
     return (
       <Typography variant="body2" sx={{ textAlign: 'right', width: '100%' }}>
         {displayValue}

--- a/packages/react/src/cells/CurrencyCell/CurrencyCell.tsx
+++ b/packages/react/src/cells/CurrencyCell/CurrencyCell.tsx
@@ -117,8 +117,12 @@ export const CurrencyCell = React.memo(function CurrencyCell<TData = Record<stri
   onCommit,
   onCancel,
 }: CurrencyCellProps<TData>) {
-  // Extract symbol and negative-red preference from the column format string
-  const { symbol, negativeRed } = parseCurrencyFormat(column.format);
+  // Extract symbol and negative-red preference from the column format string.
+  // `ColumnDef.format` now also admits a NumberFormatSpec object (issue #92,
+  // numeric columns only); ignore those here — currency columns predate that
+  // surface and continue to use the plain mask-string form.
+  const rawFormat = typeof column.format === 'string' ? column.format : undefined;
+  const { symbol, negativeRed } = parseCurrencyFormat(rawFormat);
   const numericValue = value === null || value === undefined ? '' : String(value);
   const [draft, setDraft] = useState(numericValue);
   const inputRef = useRef<HTMLInputElement>(null);

--- a/packages/react/src/cells/NumericCell/NumericCell.styles.ts
+++ b/packages/react/src/cells/NumericCell/NumericCell.styles.ts
@@ -5,6 +5,30 @@ export const displayValue: CSSProperties = {
   textAlign: 'right',
 };
 
+/**
+ * Outer container for the dual-unit numeric cell (issue #92): stacks the
+ * primary value and the secondary derived value vertically, preserving the
+ * column's right-alignment.
+ */
+export const dualUnitContainer: CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'flex-end',
+  lineHeight: 1.15,
+  width: '100%',
+};
+
+/**
+ * Visual styling for the secondary (derived) value line in a dual-unit cell.
+ * Smaller and muted so it reads as supporting information.
+ */
+export const secondaryValue: CSSProperties = {
+  display: 'block',
+  textAlign: 'right',
+  fontSize: '0.8em',
+  opacity: 0.65,
+};
+
 export const editInput: CSSProperties = {
   width: '100%',
   height: '100%',

--- a/packages/react/src/cells/NumericCell/NumericCell.tsx
+++ b/packages/react/src/cells/NumericCell/NumericCell.tsx
@@ -10,6 +10,7 @@
  */
 import React, { useState, useRef, useEffect } from 'react';
 import type { CellValue, ColumnDef } from '@iasbuilt/datagrid-core';
+import { formatNumber, isNumberFormatSpec } from '@iasbuilt/datagrid-core';
 import * as styles from './NumericCell.styles';
 
 /**
@@ -38,18 +39,22 @@ interface NumericCellProps<TData = Record<string, unknown>> {
  * Converts a cell value to a human-readable numeric string.
  *
  * Returns an empty string for null, undefined, empty-string, or NaN inputs.
- * When `useThousands` is true the number is locale-formatted with grouping
- * separators; otherwise a plain `String()` conversion is used.
+ * Delegates to {@link formatNumber} when the column declares an Excel-style
+ * format spec; otherwise falls back to `Number.toLocaleString()` when
+ * thousands grouping is requested or a plain `String()` conversion.
  *
- * @param value - The raw cell value to format.
- * @param useThousands - Whether to apply locale-based thousands grouping.
+ * @param value  - The raw cell value to format.
+ * @param format - The column's `format` field; may be a spec object,
+ *                 the `'thousands'` shorthand, or any other string (in
+ *                 which case it is ignored for numeric columns).
  * @returns The formatted numeric string, or `""` when the value is not a valid number.
  */
-function formatNumeric(value: CellValue, useThousands: boolean): string {
+export function formatNumeric(value: CellValue, format: ColumnDef['format']): string {
   if (value === null || value === undefined || value === '') return '';
   const num = Number(value);
   if (isNaN(num)) return '';
-  return useThousands ? num.toLocaleString() : String(num);
+  if (isNumberFormatSpec(format)) return formatNumber(num, format);
+  return String(num);
 }
 
 /**
@@ -87,10 +92,22 @@ export const NumericCell = React.memo(function NumericCell<TData = Record<string
   onCommit,
   onCancel,
 }: NumericCellProps<TData>) {
-  // Determine whether the thousands separator should be applied
-  // based on the column's format string.
-  const useThousands = column.format === 'thousands';
-  const displayValue = formatNumeric(value, useThousands);
+  // Resolve the display string from the column's `format` spec, supporting
+  // both the legacy `'thousands'` shorthand and the discriminated-union
+  // {@link NumberFormatSpec} object form added for issue #92.
+  const displayValue = formatNumeric(value, column.format);
+  // Optional dual-unit sub-cell (issue #92): rendered below the primary
+  // value when the column declares `secondaryUnit`, and only when the
+  // primary value is a finite number we can run the conversion on.
+  const numericValue = (() => {
+    if (value === null || value === undefined || value === '') return null;
+    const n = Number(value);
+    return Number.isFinite(n) ? n : null;
+  })();
+  const secondary = column.secondaryUnit;
+  const secondaryDisplay = secondary && numericValue !== null
+    ? `${formatNumeric(secondary.conversion(numericValue), secondary.format) || String(secondary.conversion(numericValue))} ${secondary.label}`
+    : null;
   const rawValue = value === null || value === undefined ? '' : String(value);
   const [draft, setDraft] = useState(rawValue);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -110,6 +127,17 @@ export const NumericCell = React.memo(function NumericCell<TData = Record<string
 
   // --- Display mode ---
   if (!isEditing) {
+    if (secondaryDisplay !== null) {
+      // Dual-unit sub-cell: primary value on the first line, smaller
+      // muted secondary value on a second line below. The container
+      // keeps the column's existing right-aligned numeric layout.
+      return (
+        <span style={styles.dualUnitContainer} data-testid="numeric-dual-unit">
+          <span style={styles.displayValue} data-testid="numeric-primary">{displayValue}</span>
+          <span style={styles.secondaryValue} data-testid="numeric-secondary">{secondaryDisplay}</span>
+        </span>
+      );
+    }
     return (
       <span style={styles.displayValue}>
         {displayValue}

--- a/packages/react/src/cells/TextCell/TextCell.tsx
+++ b/packages/react/src/cells/TextCell/TextCell.tsx
@@ -131,7 +131,7 @@ export const TextCell = React.memo(function TextCell<TData = Record<string, unkn
     // Guard: ignore Enter/Tab while an IME candidate window is open.
     // isComposing is not in React's synthetic type but is present on the native event.
     if ((e.nativeEvent as KeyboardEvent).isComposing || e.keyCode === 229) return;
-    if (e.key === 'Enter' && !column.format?.includes('multiline')) {
+    if (e.key === 'Enter' && !(typeof column.format === 'string' && column.format.includes('multiline'))) {
       e.preventDefault();
       e.stopPropagation();
       onCommit(draft, 'down');
@@ -153,7 +153,7 @@ export const TextCell = React.memo(function TextCell<TData = Record<string, unkn
   // --- Multiline variant ---
   // Renders a <textarea> when the column format specifies multiline,
   // allowing newlines within the cell value.
-  if (column.format?.includes('multiline')) {
+  if ((typeof column.format === 'string' && column.format.includes('multiline'))) {
     return (
       <textarea
         ref={inputRef as React.Ref<HTMLTextAreaElement>}

--- a/stories/NumberFormatPresets.stories.tsx
+++ b/stories/NumberFormatPresets.stories.tsx
@@ -1,0 +1,145 @@
+/**
+ * Stories exercising the Excel-style number-format presets and the
+ * optional dual-unit sub-cell introduced for issue #92.
+ *
+ * The `Presets` story exposes one numeric column per supported preset so
+ * the corresponding e2e (`e2e/issue-92-number-format-presets.spec.ts`)
+ * can assert each one renders correctly via `Intl.NumberFormat`. The
+ * `SecondaryUnit` story exposes a single editable `weight_kg` column with
+ * a `lb` dual-unit sub-cell so the e2e can verify both the initial render
+ * and the post-edit recomputation.
+ */
+import React, { useState, useMemo } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { MuiDataGrid } from '@iasbuilt/datagrid-mui';
+import type { ColumnDef } from '@iasbuilt/datagrid-core';
+import { storyContainer, gridContainer } from './helpers';
+import * as styles from './stories.styles';
+
+const meta: Meta = {
+  title: 'Examples/Number Format',
+};
+export default meta;
+
+// ---------------------------------------------------------------------------
+// Sample data — one row covers every preset; positive + negative values let
+// the e2e exercise the accounting parens path.
+// ---------------------------------------------------------------------------
+
+interface Row {
+  id: string;
+  thousands: number;
+  currency: number;
+  percent: number;
+  accounting: number;
+  scientific: number;
+  fixed: number;
+}
+
+const rows: Row[] = [
+  { id: '1', thousands: 1234567, currency: 1234.5, percent: 0.25, accounting: -1000, scientific: 123456, fixed: 3.14159 },
+  { id: '2', thousands: 42, currency: 19.99, percent: 0.125, accounting: 250, scientific: 0.000123, fixed: 2.71828 },
+];
+
+const presetColumns: ColumnDef<Row>[] = [
+  { id: 'thousands', field: 'thousands', title: 'Thousands', width: 140, cellType: 'numeric', editable: true, format: 'thousands' },
+  { id: 'currency', field: 'currency', title: 'Currency (USD)', width: 160, cellType: 'numeric', editable: true, format: { kind: 'currency', currency: 'USD', locale: 'en-US' } },
+  { id: 'percent', field: 'percent', title: 'Percent (1 dp)', width: 140, cellType: 'numeric', editable: true, format: { kind: 'percent', decimals: 1, locale: 'en-US' } },
+  { id: 'accounting', field: 'accounting', title: 'Accounting', width: 160, cellType: 'numeric', editable: true, format: { kind: 'accounting', currency: 'USD', locale: 'en-US' } },
+  { id: 'scientific', field: 'scientific', title: 'Scientific', width: 140, cellType: 'numeric', editable: true, format: { kind: 'scientific', decimals: 2 } },
+  { id: 'fixed', field: 'fixed', title: 'Fixed (3 dp)', width: 140, cellType: 'numeric', editable: true, format: { kind: 'fixed', decimals: 3, locale: 'en-US' } },
+];
+
+export const Presets: StoryObj = {
+  render: () => {
+    const [data, setData] = useState<Row[]>(rows);
+    const columns = useMemo(() => presetColumns, []);
+    return (
+      <div style={storyContainer}>
+        <h2 style={styles.heading}>Excel-style number format presets</h2>
+        <p style={styles.subtitle}>
+          One column per preset. Double-click a cell to edit; the new value
+          re-renders through <code>Intl.NumberFormat</code>.
+        </p>
+        <div style={gridContainer}>
+          <MuiDataGrid
+            data={data}
+            columns={columns as any}
+            rowKey="id"
+            selectionMode="cell"
+            keyboardNavigation
+            onCellEdit={(rowId, field, value) => {
+              setData((prev) =>
+                prev.map((r) => (r.id === rowId ? { ...r, [field]: value } : r)),
+              );
+            }}
+          />
+        </div>
+      </div>
+    );
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Dual-unit sub-cell — `weight_kg` with a derived `lb` second line.
+// ---------------------------------------------------------------------------
+
+interface WeightRow {
+  id: string;
+  weight_kg: number;
+}
+
+const weightRows: WeightRow[] = [
+  { id: '1', weight_kg: 100 },
+  { id: '2', weight_kg: 50 },
+];
+
+const weightColumns: ColumnDef<WeightRow>[] = [
+  {
+    id: 'weight_kg',
+    field: 'weight_kg',
+    title: 'Weight (kg)',
+    width: 200,
+    cellType: 'numeric',
+    editable: true,
+    format: { kind: 'fixed', decimals: 1, locale: 'en-US' },
+    secondaryUnit: {
+      label: 'lb',
+      // 1 kg = 2.20462 lb. Pure function — runs on every render.
+      conversion: (kg) => kg * 2.20462,
+      format: { kind: 'fixed', decimals: 2, locale: 'en-US' },
+    },
+  },
+];
+
+export const SecondaryUnit: StoryObj = {
+  name: 'Dual-unit sub-cell',
+  render: () => {
+    const [data, setData] = useState<WeightRow[]>(weightRows);
+    const columns = useMemo(() => weightColumns, []);
+    return (
+      <div style={storyContainer}>
+        <h2 style={styles.heading}>Dual-unit sub-cell</h2>
+        <p style={styles.subtitle}>
+          A <code>weight_kg</code> column with a derived <code>lb</code>
+          second line. Edit the primary value — the secondary line
+          recomputes automatically.
+        </p>
+        <div style={gridContainer}>
+          <MuiDataGrid
+            data={data}
+            columns={columns as any}
+            rowKey="id"
+            selectionMode="cell"
+            keyboardNavigation
+            onCellEdit={(rowId, field, value) => {
+              setData((prev) =>
+                prev.map((r) => (r.id === rowId ? { ...r, [field]: value } : r)),
+              );
+            }}
+          />
+        </div>
+      </div>
+    );
+  },
+};


### PR DESCRIPTION
Closes #92.

## Summary

- Adds a discriminated `NumberFormatSpec` union accepted by `ColumnDef.format` on numeric columns. Presets cover the common Excel cases: `currency` (per-currency, per-locale), `percent` (ratio with configurable decimals), `accounting` (parens around negatives, defaults to USD), `scientific` (uppercase `E` exponent), and `fixed` (no grouping, fixed decimals). The legacy `'thousands'` shorthand is preserved.
- Adds an optional `secondaryUnit: { label, conversion, format? }` field that renders a smaller, read-only derived value below the primary in the numeric cell (React and MUI). Edit mode is unchanged — only the primary is editable.
- Implementation lives in `packages/core/src/number-format.ts` as pure, framework-agnostic functions built on `Intl.NumberFormat`. Re-exported from `@iasbuilt/datagrid-core`.
- Existing `CurrencyCell`, `TextCell`, and the Excel export helper narrow `column.format` to the `string` branch so they keep their legacy mask semantics.

## Test plan

- [x] `pnpm vitest run packages/` — 1960/1960 passing, including 19 new unit tests in `packages/core/src/__tests__/number-format.test.ts` covering every preset, empty / non-finite inputs, and the `isNumberFormatSpec` guard.
- [x] `pnpm exec playwright test e2e/issue-92-number-format-presets.spec.ts` — 10/10 passing. Asserts each preset renders verbatim against the in-test `Intl.NumberFormat`, verifies the accounting parens path, the dual-unit primary/secondary lines + post-edit recompute, and that edit mode replaces the dual-unit display with a single input.
- [x] `pnpm typecheck` — clean.
- [x] Pre-commit hook (`typecheck` + `build` + `pnpm test` + tokens drift + script tests + actionlint) — all green.

## Deferred from the original issue body

The MVP shipped here covers (a) Excel-style number-format presets and (b) the optional dual-unit sub-cell with a conversion formula. The richer items from the issue body (per-cell toggle of which unit is master, `General`/`Fraction` presets, full Excel custom-format-string mask, and `Date`/`Time` numeric presets) are intentionally out of scope for this PR and can land as follow-ups.