### PR TITLE
feat(upload): file-upload cell exposes onAttach hook for backend wiring

### DIFF
--- a/e2e/issue-91-file-upload-attach.spec.ts
+++ b/e2e/issue-91-file-upload-attach.spec.ts
@@ -1,0 +1,151 @@
+/**
+ * End-to-end: file-upload cell's `onAttach` contract (issue #91).
+ *
+ * Drives the playground demo at `/file-upload-attach/`. The demo wires a
+ * mock backend whose mode + latency are controlled from the page. We:
+ *
+ *   1. Drop a file into an `upload` cell and assert the mock backend was
+ *      invoked (the cell forwarded the file through `onAttach`).
+ *   2. Confirm the in-flight UI is visible while the mock is pending.
+ *   3. Confirm the success UI is shown after the mock resolves and the
+ *      committed cell value renders the uploaded filename.
+ *   4. Switch the mock to `fail` mode, drop another file, and assert the
+ *      error UI surfaces with a retry button — then flip back to success
+ *      mode and click Retry to prove the cell can recover with the same
+ *      file (no re-pick needed).
+ *
+ * The playground is served by the Vite webServer entry in
+ * `playwright.config.ts` on port 5173, so we point `baseURL` at it for
+ * this spec.
+ */
+import { test, expect, type Page, type Locator } from '@playwright/test';
+
+test.use({ baseURL: 'http://localhost:5173' });
+
+const PAGE = '/file-upload-attach/';
+
+/** The Attachment column cell for a specific row id. */
+function attachmentCell(page: Page, rowId: string): Locator {
+  return page
+    .locator(`[role="gridcell"][data-row-id="${rowId}"][data-field="attachment"]`)
+    .first();
+}
+
+/**
+ * Synthesise a DataTransfer + File entirely inside the page and dispatch
+ * real `dragover` / `drop` React-synthetic events at the cell's drop-zone
+ * div. The drop zone listens via React's synthetic event system, so the
+ * dispatched events must be `DragEvent` instances with a populated
+ * `dataTransfer.files` list — Playwright's `dispatchEvent` plumbing does
+ * not always wire the `dataTransfer` JSHandle through to React's handler,
+ * so we do the dispatch ourselves inside `evaluate`.
+ */
+async function dropFile(
+  cell: Locator,
+  name: string,
+  contents: string,
+  mime: string,
+) {
+  await cell.evaluate(
+    (el, { name, contents, mime }) => {
+      // The drop zone is the first descendant div with data-upload-state.
+      const target = el.querySelector('[data-upload-state]') as HTMLElement | null;
+      if (!target) throw new Error('drop zone not found inside cell');
+      const dt = new DataTransfer();
+      dt.items.add(new File([contents], name, { type: mime }));
+      target.dispatchEvent(new DragEvent('dragover', { bubbles: true, cancelable: true, dataTransfer: dt }));
+      target.dispatchEvent(new DragEvent('drop', { bubbles: true, cancelable: true, dataTransfer: dt }));
+    },
+    { name, contents, mime },
+  );
+}
+
+test.describe('issue #91 — upload cell onAttach contract', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(PAGE);
+    await page.locator('[role="grid"]').first().waitFor({ state: 'visible' });
+    await page.locator('[data-testid="event-log"]').waitFor({ state: 'visible' });
+  });
+
+  test('drops a file, sees in-flight UI, then success after the mock resolves', async ({ page }) => {
+    // Make latency long enough for the in-flight assertion to be reliable.
+    await page.locator('[data-testid="mode-select"]').selectOption('success');
+    await page.locator('[data-testid="latency-input"]').fill('600');
+
+    const cell = attachmentCell(page, 'r1');
+
+    // Either path is valid for the cell — we exercise the hidden input
+    // (deterministic) AND the drag-drop branch (covered in the next test).
+    await cell.locator('input[type="file"]').setInputFiles({
+      name: 'report.pdf',
+      mimeType: 'application/pdf',
+      buffer: Buffer.from('%PDF-1.4 fake'),
+    });
+
+    // In-flight UI must be visible while the mock is pending.
+    await expect(cell.locator('[data-testid="upload-cell-uploading"]')).toBeVisible();
+    // The upload button is disabled while pending.
+    await expect(cell.locator('button', { hasText: /Upload|Replace/ })).toBeDisabled();
+
+    // The mock backend logs `onAttach({ file: report.pdf, ... })` and
+    // then resolves with an AttachmentRef — the cell flips to success.
+    await expect(cell.locator('[data-testid="upload-cell-success"]')).toBeVisible({ timeout: 5_000 });
+
+    // The committed cell value renders as a download link with the
+    // uploaded filename.
+    await expect(cell.locator('a[role="link"]', { hasText: 'report.pdf' })).toBeVisible();
+
+    // The event log proves onAttach actually fired with the file.
+    const log = page.locator('[data-testid="event-log"]');
+    await expect(log).toContainText('onAttach({ file: report.pdf');
+    await expect(log).toContainText('resolve(');
+  });
+
+  test('drag-drop path also invokes onAttach with the dropped file', async ({ page }) => {
+    await page.locator('[data-testid="mode-select"]').selectOption('success');
+    await page.locator('[data-testid="latency-input"]').fill('100');
+
+    const cell = attachmentCell(page, 'r2');
+    await dropFile(cell, 'dropped.txt', 'hello drop', 'text/plain');
+
+    await expect(cell.locator('[data-testid="upload-cell-success"]')).toBeVisible({ timeout: 5_000 });
+    await expect(cell.locator('a[role="link"]', { hasText: 'dropped.txt' })).toBeVisible();
+    await expect(page.locator('[data-testid="event-log"]')).toContainText('onAttach({ file: dropped.txt');
+  });
+
+  test('failure shows the error message + retry button; retry re-runs onAttach with the same file and recovers', async ({ page }) => {
+    await page.locator('[data-testid="mode-select"]').selectOption('fail');
+    await page.locator('[data-testid="latency-input"]').fill('100');
+
+    const cell = attachmentCell(page, 'r3');
+    await cell.locator('input[type="file"]').setInputFiles({
+      name: 'will-fail.json',
+      mimeType: 'application/json',
+      buffer: Buffer.from('{"ok":false}'),
+    });
+
+    // Error state visible with the mock-supplied message; Retry exposed.
+    await expect(cell.locator('[data-testid="upload-cell-error"]')).toBeVisible({ timeout: 5_000 });
+    await expect(cell.locator('[data-testid="upload-cell-error"]')).toContainText('Mock backend rejected upload');
+    const retry = cell.locator('button', { hasText: 'Retry' });
+    await expect(retry).toBeVisible();
+    // Prior cell value untouched — no link rendered (cell was empty before).
+    await expect(cell.locator('a[role="link"]')).toHaveCount(0);
+
+    // Flip the mock to success and click Retry — the cell must re-issue
+    // onAttach with the SAME file and end up in the success state without
+    // a re-pick.
+    await page.locator('[data-testid="mode-select"]').selectOption('success');
+    await retry.click();
+
+    await expect(cell.locator('[data-testid="upload-cell-success"]')).toBeVisible({ timeout: 5_000 });
+    await expect(cell.locator('a[role="link"]', { hasText: 'will-fail.json' })).toBeVisible();
+
+    // onAttach was invoked twice — once for the initial failure, once for
+    // the retry. The log captures both.
+    const log = page.locator('[data-testid="event-log"]');
+    const entries = await log.locator('div').allInnerTexts();
+    const onAttachLines = entries.filter((t) => t.includes('onAttach({ file: will-fail.json'));
+    expect(onAttachLines.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -177,6 +177,103 @@ export interface CellRange {
 export type SelectionMode = 'cell' | 'row' | 'range' | 'none';
 
 // ---------------------------------------------------------------------------
+// Upload / attachment system (issue #91)
+// ---------------------------------------------------------------------------
+
+/**
+ * Opaque handle returned by an upload backend after persisting a file.
+ *
+ * The grid is deliberately agnostic about *how* a file is stored, deduped,
+ * scoped, or revoked — those concerns live in the consumer's attachment
+ * service (e.g. the iasbuilt/webapp attachment system specced in
+ * istracked/webapp#155). The grid only needs a stable reference so it can
+ * record what was uploaded and, optionally, render a download/preview link.
+ *
+ * @remarks
+ * The `id` is the canonical persisted handle (a content-hash, blob-store key,
+ * or DB row id — the grid does not care). `url` and `meta` are optional
+ * hints used by the cell renderer's display mode; cells gracefully fall back
+ * to id-only display when they are omitted.
+ */
+export interface AttachmentRef {
+  /** Stable backend identifier for the persisted file. */
+  id: string;
+  /** Optional human-friendly file name (used by display mode). */
+  name?: string;
+  /** Optional URL for download / preview affordance. */
+  url?: string;
+  /** Optional MIME type — used to pick an icon / thumbnail. */
+  mimeType?: string;
+  /** Byte size of the persisted file, if known. */
+  size?: number;
+  /** Free-form metadata bag forwarded verbatim by the backend. */
+  meta?: Record<string, unknown>;
+}
+
+/**
+ * Per-cell context passed to {@link UploadAttachHandler} so the consumer can
+ * route the upload to the right scope / row / column on its side.
+ *
+ * @remarks
+ * `CellAddress` is intentionally reused here so the same address shape that
+ * flows through selection and editing also identifies an upload target. The
+ * `column` reference is forwarded so the handler can read column-level
+ * config (accept list, scope, etc.) without re-resolving the column.
+ *
+ * @typeParam TData - The shape of a data row.
+ */
+export interface UploadAttachContext<TData = Record<string, unknown>> {
+  /** Target cell receiving the attachment. */
+  cell: CellAddress;
+  /** Column definition for the target cell. */
+  column: ColumnDef<TData>;
+  /** Row data for the target cell. */
+  row: TData;
+}
+
+/**
+ * Reports progress for an in-flight upload.
+ *
+ * @param loaded - Bytes transferred so far.
+ * @param total - Total bytes expected (may be `undefined` for chunked uploads).
+ */
+export type UploadProgressReporter = (loaded: number, total?: number) => void;
+
+/**
+ * The clean interface the grid hands to consumers (e.g. iasbuilt/webapp) so
+ * they can wire the file-upload cell to their attachment system.
+ *
+ * **Contract**
+ * - Receives the raw `File` and an {@link UploadAttachContext} identifying
+ *   the target cell.
+ * - Must resolve with an {@link AttachmentRef} on success.
+ * - Must reject (throw) on failure; the cell surfaces the error message and
+ *   keeps the cell value unchanged so the user can retry.
+ * - May call `onProgress` zero or more times before resolving.
+ *
+ * @typeParam TData - The shape of a data row.
+ *
+ * @example
+ * ```ts
+ * const columns: ColumnDef<MyRow>[] = [
+ *   {
+ *     id: 'attachment', field: 'attachment', title: 'File',
+ *     cellType: 'upload',
+ *     onAttach: async (file, ctx) => {
+ *       const ref = await myAttachmentService.upload(file, { scope: ctx.column.scope });
+ *       return { id: ref.id, name: file.name, url: ref.url };
+ *     },
+ *   },
+ * ];
+ * ```
+ */
+export type UploadAttachHandler<TData = Record<string, unknown>> = (
+  file: File,
+  context: UploadAttachContext<TData>,
+  onProgress?: UploadProgressReporter,
+) => Promise<AttachmentRef>;
+
+// ---------------------------------------------------------------------------
 // Column definition
 // ---------------------------------------------------------------------------
 
@@ -314,6 +411,53 @@ export interface ColumnDef<TData = Record<string, unknown>> {
   subGridColumns?: ColumnDef[];
   /** The row-key field used to identify rows inside the sub-grid. */
   subGridRowKey?: string;
+
+  // Upload (issue #91) — the grid is the agnostic surface; consumers wire
+  // `onAttach` to their attachment backend (e.g. iasbuilt/webapp #155) and
+  // the cell value becomes a reference to the persisted attachment.
+
+  /**
+   * Backend-wiring callback invoked when the user picks or drops a file in
+   * an `upload` cell. Receives the raw {@link File}, an
+   * {@link UploadAttachContext} identifying the target cell, and an optional
+   * progress reporter. Must resolve to an {@link AttachmentRef}; rejecting
+   * surfaces an error in the cell and leaves the prior value intact so the
+   * user can retry.
+   *
+   * The grid is deliberately agnostic about *where* attachments live — that
+   * concern is owned by the consumer's attachment service (storage, dedupe,
+   * scoped inheritance, ACL all happen on the consumer side).
+   */
+  onAttach?: UploadAttachHandler<TData>;
+  /**
+   * For `upload` columns: when `true`, the cell stores a list of
+   * {@link AttachmentRef}s rather than a single ref. Defaults to `false`.
+   */
+  multiple?: boolean;
+  /**
+   * For `upload` columns: an optional list of accepted MIME types and/or
+   * extensions (`['image/png', '.pdf']`). Forwarded to the file picker via
+   * the `accept` attribute and used to reject mis-typed drops early.
+   */
+  accept?: string[];
+  /**
+   * For `upload` columns: optional per-file byte size cap. Drops/picks
+   * exceeding this size are rejected before {@link onAttach} is called.
+   */
+  maxSize?: number;
+  /**
+   * For `upload` columns: free-form scope hint forwarded to the consumer's
+   * attachment service. The grid never inspects this value — it is passed
+   * through to {@link onAttach} via {@link UploadAttachContext.column}, where
+   * the handler can read it to honour scoped inheritance / ACL rules.
+   */
+  scope?: string;
+  /**
+   * For `upload` columns: optional download/preview handler invoked when the
+   * user clicks the file link in display mode. Receives the persisted
+   * {@link AttachmentRef} (or the raw string value for unwired columns).
+   */
+  onDownload?: (ref: AttachmentRef | string) => void;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/mui/src/cells/MuiUploadCell/MuiUploadCell.tsx
+++ b/packages/mui/src/cells/MuiUploadCell/MuiUploadCell.tsx
@@ -1,45 +1,127 @@
 /**
  * MUI upload cell renderer for the datagrid.
  *
+ * Mirrors the contract exposed by the plain React `UploadCell`: when a
+ * column declares an `onAttach` handler (see issue #91), file picks and
+ * drops are routed through the handler, the in-flight state is shown via
+ * `LinearProgress`, and errors surface with a retry affordance. When no
+ * handler is wired, the cell falls back to the legacy "commit filename"
+ * behaviour for backward compatibility.
+ *
  * @module MuiUploadCell
  * @packageDocumentation
  */
-import React, { useState, useRef } from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import Button from '@mui/material/Button';
 import LinearProgress from '@mui/material/LinearProgress';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
-import type { CellValue, ColumnDef } from '@iasbuilt/datagrid-core';
+import type {
+  AttachmentRef,
+  CellValue,
+  ColumnDef,
+  UploadAttachContext,
+  UploadAttachHandler,
+} from '@iasbuilt/datagrid-core';
 import type { CellRendererProps } from '@iasbuilt/datagrid-react';
 import { hiddenFileInput } from './MuiUploadCell.styles';
+
+type UploadState =
+  | { kind: 'idle' }
+  | { kind: 'uploading'; fileName: string; progress: number }
+  | { kind: 'error'; fileName: string; message: string; file: File }
+  | { kind: 'success'; fileName: string };
+
+function resolveDisplay(value: CellValue): { name: string; ref: AttachmentRef | null } {
+  if (value == null || value === '') return { name: '', ref: null };
+  if (typeof value === 'string') return { name: value, ref: null };
+  if (typeof value === 'object' && value !== null && 'id' in (value as object)) {
+    const ref = value as unknown as AttachmentRef;
+    return { name: ref.name ?? ref.id, ref };
+  }
+  return { name: String(value), ref: null };
+}
+
+function validate(file: File, column: { accept?: string[]; maxSize?: number }): string | null {
+  if (column.maxSize != null && file.size > column.maxSize) {
+    return `File exceeds max size (${column.maxSize} bytes)`;
+  }
+  if (column.accept && column.accept.length > 0) {
+    const lowerName = file.name.toLowerCase();
+    const ok = column.accept.some((spec) => {
+      const s = spec.toLowerCase();
+      if (s.startsWith('.')) return lowerName.endsWith(s);
+      if (s.endsWith('/*')) return file.type.toLowerCase().startsWith(s.slice(0, -1));
+      return file.type.toLowerCase() === s;
+    });
+    if (!ok) return `File type not accepted (got "${file.type || file.name}")`;
+  }
+  return null;
+}
 
 /**
  * MUI-based upload cell renderer using Button with LinearProgress indicator.
  */
 export const MuiUploadCell = React.memo(function MuiUploadCell<TData = Record<string, unknown>>({
   value,
+  row,
   column,
+  rowId,
   onCommit,
 }: CellRendererProps<TData>) {
-  const fileName = value != null ? String(value) : '';
+  const { name: fileName, ref: currentRef } = resolveDisplay(value);
   const [isDragging, setIsDragging] = useState(false);
-  const [uploading, setUploading] = useState(false);
+  const [state, setState] = useState<UploadState>({ kind: 'idle' });
   const fileInputRef = useRef<HTMLInputElement>(null);
 
-  const onDownload = (column as unknown as { onDownload?: (fileName: string) => void }).onDownload;
+  const onAttach = (column as ColumnDef<TData> & { onAttach?: UploadAttachHandler<TData> })
+    .onAttach;
+  const onDownload = (column as ColumnDef<TData> & {
+    onDownload?: (ref: AttachmentRef | string) => void;
+  }).onDownload;
 
-  const handleFileChange = (file: File) => {
-    setUploading(true);
-    // Simulate brief upload delay for visual feedback
-    setTimeout(() => {
-      setUploading(false);
-      onCommit(file.name);
-    }, 300);
-  };
+  const runUpload = useCallback(
+    async (file: File) => {
+      const err = validate(file, column as { accept?: string[]; maxSize?: number });
+      if (err) {
+        setState({ kind: 'error', fileName: file.name, message: err, file });
+        return;
+      }
+      if (!onAttach) {
+        // Legacy path — preserve backward compatibility with pre-#91.
+        setState({ kind: 'uploading', fileName: file.name, progress: 0 });
+        setTimeout(() => {
+          setState({ kind: 'success', fileName: file.name });
+          onCommit(file.name);
+        }, 200);
+        return;
+      }
+      setState({ kind: 'uploading', fileName: file.name, progress: 0 });
+      const ctx: UploadAttachContext<TData> = {
+        cell: { rowId: rowId ?? '', field: column.field },
+        column,
+        row,
+      };
+      try {
+        const ref = await onAttach(file, ctx, (loaded, total) => {
+          const pct = total && total > 0 ? Math.round((loaded / total) * 100) : 0;
+          setState((prev) =>
+            prev.kind === 'uploading' ? { ...prev, progress: pct } : prev,
+          );
+        });
+        onCommit(ref as unknown as CellValue);
+        setState({ kind: 'success', fileName: ref.name ?? file.name });
+      } catch (e) {
+        const message = e instanceof Error ? e.message : String(e);
+        setState({ kind: 'error', fileName: file.name, message, file });
+      }
+    },
+    [column, onAttach, onCommit, row, rowId],
+  );
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
-    if (file) handleFileChange(file);
+    if (file) void runUpload(file);
     e.target.value = '';
   };
 
@@ -47,15 +129,23 @@ export const MuiUploadCell = React.memo(function MuiUploadCell<TData = Record<st
     e.preventDefault();
     setIsDragging(false);
     const file = e.dataTransfer.files?.[0];
-    if (file) handleFileChange(file);
+    if (file) void runUpload(file);
   };
+
+  const handleRetry = () => {
+    if (state.kind === 'error') void runUpload(state.file);
+  };
+
+  const acceptAttr = column.accept && column.accept.length > 0 ? column.accept.join(',') : undefined;
 
   return (
     <Box
       onDrop={handleDrop}
       onDragOver={(e) => { e.preventDefault(); setIsDragging(true); }}
       onDragLeave={() => setIsDragging(false)}
+      data-upload-state={state.kind}
       sx={{
+        position: 'relative',
         display: 'flex',
         alignItems: 'center',
         gap: 1,
@@ -73,7 +163,7 @@ export const MuiUploadCell = React.memo(function MuiUploadCell<TData = Record<st
           variant="body2"
           onClick={(e) => {
             e.preventDefault();
-            onDownload?.(fileName);
+            onDownload?.(currentRef ?? fileName);
           }}
           sx={{
             color: 'primary.main',
@@ -91,23 +181,75 @@ export const MuiUploadCell = React.memo(function MuiUploadCell<TData = Record<st
           {column.placeholder ?? 'No file'}
         </Typography>
       )}
+
+      {state.kind === 'uploading' && (
+        <Typography
+          variant="caption"
+          role="status"
+          aria-live="polite"
+          data-testid="mui-upload-cell-uploading"
+          sx={{ color: 'primary.main' }}
+        >
+          Uploading {state.fileName}…
+        </Typography>
+      )}
+      {state.kind === 'error' && (
+        <Typography
+          variant="caption"
+          role="alert"
+          data-testid="mui-upload-cell-error"
+          title={state.message}
+          sx={{ color: 'error.main', maxWidth: 160, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+        >
+          {state.message}
+        </Typography>
+      )}
+      {state.kind === 'success' && (
+        <Typography
+          variant="caption"
+          role="status"
+          data-testid="mui-upload-cell-success"
+          sx={{ color: 'success.main' }}
+        >
+          Uploaded
+        </Typography>
+      )}
+
       <Button
         size="small"
         variant="outlined"
         onClick={() => fileInputRef.current?.click()}
+        disabled={state.kind === 'uploading'}
         sx={{ fontSize: 11, minWidth: 0, px: 1, whiteSpace: 'nowrap' }}
       >
         {fileName ? 'Replace' : 'Upload'}
       </Button>
+      {state.kind === 'error' && (
+        <Button
+          size="small"
+          variant="outlined"
+          color="error"
+          onClick={handleRetry}
+          aria-label="Retry upload"
+          sx={{ fontSize: 11, minWidth: 0, px: 1, whiteSpace: 'nowrap' }}
+        >
+          Retry
+        </Button>
+      )}
       <input
         ref={fileInputRef}
         type="file"
         aria-label="File input"
+        accept={acceptAttr}
         onChange={handleInputChange}
         style={hiddenFileInput}
       />
-      {uploading && (
-        <LinearProgress sx={{ position: 'absolute', bottom: 0, left: 0, right: 0, height: 2 }} />
+      {state.kind === 'uploading' && (
+        <LinearProgress
+          variant={state.progress > 0 ? 'determinate' : 'indeterminate'}
+          value={state.progress}
+          sx={{ position: 'absolute', bottom: 0, left: 0, right: 0, height: 2 }}
+        />
       )}
     </Box>
   );

--- a/packages/react/src/cells/UploadCell/UploadCell.styles.ts
+++ b/packages/react/src/cells/UploadCell/UploadCell.styles.ts
@@ -1,6 +1,7 @@
 import type { CSSProperties } from 'react';
 
 export const dropZone = (isDragging: boolean): CSSProperties => ({
+  position: 'relative',
   display: 'flex',
   alignItems: 'center',
   gap: 6,
@@ -36,6 +37,49 @@ export const uploadButton: CSSProperties = {
   whiteSpace: 'nowrap',
 };
 
+export const retryButton: CSSProperties = {
+  border: '1px solid #fecaca',
+  borderRadius: 4,
+  background: '#fef2f2',
+  color: '#b91c1c',
+  cursor: 'pointer',
+  padding: '2px 8px',
+  fontSize: 11,
+  whiteSpace: 'nowrap',
+};
+
 export const hiddenInput: CSSProperties = {
   display: 'none',
 };
+
+export const statusUploading: CSSProperties = {
+  fontSize: 11,
+  color: '#2563eb',
+  marginLeft: 4,
+};
+
+export const statusError: CSSProperties = {
+  fontSize: 11,
+  color: '#b91c1c',
+  marginLeft: 4,
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+  maxWidth: 160,
+};
+
+export const statusSuccess: CSSProperties = {
+  fontSize: 11,
+  color: '#15803d',
+  marginLeft: 4,
+};
+
+export const progressBar = (pct: number): CSSProperties => ({
+  position: 'absolute',
+  bottom: 0,
+  left: 0,
+  height: 2,
+  width: `${Math.min(100, Math.max(0, pct))}%`,
+  background: '#2563eb',
+  transition: 'width 0.15s',
+});

--- a/packages/react/src/cells/UploadCell/UploadCell.tsx
+++ b/packages/react/src/cells/UploadCell/UploadCell.tsx
@@ -1,15 +1,42 @@
 /**
  * UploadCell module for the datagrid component library.
  *
- * Provides a cell renderer for file attachment fields. Displays the current file name
- * as a clickable download link (delegating to an optional column-level download handler)
- * and offers both a button-triggered file picker and drag-and-drop support for uploading
- * or replacing the attached file.
+ * Provides a cell renderer for file attachment fields. Displays the current
+ * attachment as a clickable download link (delegating to a column-level
+ * `onDownload` handler) and offers both a button-triggered file picker and
+ * drag-and-drop support for uploading or replacing the attached file.
+ *
+ * **Backend wiring (issue #91).** The cell is the grid-side surface only —
+ * the actual storage / dedupe / scoped-inheritance logic lives in the
+ * consumer's attachment service (e.g. the iasbuilt/webapp attachment system
+ * from istracked/webapp#155). Consumers wire the cell to their backend by
+ * supplying a column-level {@link ColumnDef.onAttach | onAttach} handler.
+ * The cell:
+ *
+ *   1. Validates the picked / dropped file against `column.accept` and
+ *      `column.maxSize` and short-circuits with an error if rejected.
+ *   2. Surfaces an in-flight indicator (text + progress bar) while the
+ *      handler is awaiting.
+ *   3. On success: commits the returned {@link AttachmentRef} as the cell
+ *      value and shows a transient success state.
+ *   4. On failure: surfaces the rejection message, keeps the prior cell
+ *      value intact, and exposes a "Retry" affordance so the same file
+ *      can be re-attempted without re-picking.
+ *
+ * If no `onAttach` is wired, the cell falls back to the legacy behaviour
+ * (commits the file name string) — preserving backward compatibility with
+ * pre-#91 consumers.
  *
  * @module UploadCell
  */
-import React, { useState, useRef } from 'react';
-import type { CellValue, ColumnDef } from '@iasbuilt/datagrid-core';
+import React, { useCallback, useRef, useState } from 'react';
+import type {
+  AttachmentRef,
+  CellValue,
+  ColumnDef,
+  UploadAttachContext,
+  UploadAttachHandler,
+} from '@iasbuilt/datagrid-core';
 import * as styles from './UploadCell.styles';
 
 /**
@@ -18,116 +45,169 @@ import * as styles from './UploadCell.styles';
  * @typeParam TData - The shape of a single row in the datagrid. Defaults to a generic record.
  */
 interface UploadCellProps<TData = Record<string, unknown>> {
-  /** The raw cell value, expected to be a file name string or null/undefined. */
+  /** The raw cell value — string (legacy), {@link AttachmentRef}, or null/undefined. */
   value: CellValue;
   /** The full row data object that this cell belongs to. */
   row: TData;
-  /** Column definition providing `placeholder` text and an optional `onDownload` handler. */
+  /** Column definition providing `placeholder`, `onAttach`, `onDownload`, etc. */
   column: ColumnDef<TData>;
   /** Zero-based index of the row within the visible datagrid. */
   rowIndex: number;
   /** Whether the cell is currently in inline-edit mode. */
   isEditing: boolean;
-  /** Callback to persist the new file name when a file is selected or dropped. */
+  /** Callback to persist the new value (AttachmentRef on success, string in legacy mode). */
   onCommit: (value: CellValue) => void;
   /** Callback to discard changes and exit edit mode. */
   onCancel: () => void;
+  /** Optional stable grid identifier — forwarded for parity with peer cells. */
+  gridId?: string;
+  /** Row identifier for this cell — used to build the CellAddress passed to onAttach. */
+  rowId?: string;
+}
+
+/** Internal upload-lifecycle state for the cell. */
+type UploadState =
+  | { kind: 'idle' }
+  | { kind: 'uploading'; fileName: string; progress: number }
+  | { kind: 'error'; fileName: string; message: string; file: File }
+  | { kind: 'success'; fileName: string };
+
+/**
+ * Resolves the display name + (optional) attachment id from the cell value.
+ *
+ * Accepts the three legal shapes:
+ *   - `null` / `undefined` / `''` → empty cell.
+ *   - `string` → legacy "just the filename" value.
+ *   - `AttachmentRef` (object with `id`) → post-onAttach value.
+ */
+function resolveDisplay(value: CellValue): { name: string; ref: AttachmentRef | null } {
+  if (value == null || value === '') return { name: '', ref: null };
+  if (typeof value === 'string') return { name: value, ref: null };
+  if (typeof value === 'object' && value !== null && 'id' in (value as object)) {
+    const ref = value as unknown as AttachmentRef;
+    return { name: ref.name ?? ref.id, ref };
+  }
+  return { name: String(value), ref: null };
 }
 
 /**
- * A datagrid cell renderer for file upload fields with drag-and-drop support.
- *
- * Always renders an upload/replace button and a hidden file input. When a file name
- * is present, it appears as a download link. The cell supports drag-and-drop file
- * assignment with visual feedback (dashed border highlight). On file selection or drop,
- * the file's name is committed as the new cell value.
- *
- * @remarks
- * The download callback is extracted from the column definition via a typed cast to
- * `{ onDownload?: (fileName: string) => void }`, since the core `ColumnDef` type does
- * not natively include a download handler.
+ * Validates a single file against the column-level `accept` / `maxSize`
+ * constraints. Returns a non-null error message when the file is rejected.
+ */
+function validate(file: File, column: { accept?: string[]; maxSize?: number }): string | null {
+  if (column.maxSize != null && file.size > column.maxSize) {
+    return `File exceeds max size (${column.maxSize} bytes)`;
+  }
+  if (column.accept && column.accept.length > 0) {
+    const lowerName = file.name.toLowerCase();
+    const ok = column.accept.some((spec) => {
+      const s = spec.toLowerCase();
+      if (s.startsWith('.')) return lowerName.endsWith(s);
+      if (s.endsWith('/*')) return file.type.toLowerCase().startsWith(s.slice(0, -1));
+      return file.type.toLowerCase() === s;
+    });
+    if (!ok) return `File type not accepted (got "${file.type || file.name}")`;
+  }
+  return null;
+}
+
+/**
+ * A datagrid cell renderer for file upload fields with drag-and-drop support
+ * and a typed `onAttach` hook for backend wiring.
  *
  * @typeParam TData - Row data shape, defaults to `Record<string, unknown>`.
- *
- * @param props - The component props conforming to {@link UploadCellProps}.
- * @returns A React element showing the file link/placeholder, upload button, and drop zone.
- *
- * @example
- * ```tsx
- * <UploadCell
- *   value="report.pdf"
- *   row={rowData}
- *   column={columnDef}
- *   rowIndex={0}
- *   isEditing={false}
- *   onCommit={handleCommit}
- *   onCancel={handleCancel}
- * />
- * ```
  */
 export const UploadCell = React.memo(function UploadCell<TData = Record<string, unknown>>({
   value,
+  row,
   column,
+  rowId,
   onCommit,
 }: UploadCellProps<TData>) {
-  // Coerce the cell value to a string file name
-  const fileName = value != null ? String(value) : '';
+  const { name: fileName, ref: currentRef } = resolveDisplay(value);
+
   const [isDragging, setIsDragging] = useState(false);
+  const [state, setState] = useState<UploadState>({ kind: 'idle' });
   const fileInputRef = useRef<HTMLInputElement>(null);
 
-  // Extract the optional download handler via a typed cast on the column definition
-  const onDownload = (column as unknown as { onDownload?: (fileName: string) => void }).onDownload;
+  // Resolve the optional column-level callbacks. We accept either the typed
+  // `onAttach` / `onDownload` fields on ColumnDef or a legacy cast for
+  // consumers still on the pre-#91 contract.
+  const onAttach = (column as ColumnDef<TData> & { onAttach?: UploadAttachHandler<TData> })
+    .onAttach;
+  const onDownload = (column as ColumnDef<TData> & {
+    onDownload?: (ref: AttachmentRef | string) => void;
+  }).onDownload;
 
   /**
-   * Processes a selected or dropped file by committing its name as the cell value.
-   *
-   * @param file - The File object from the input or drop event.
+   * Performs the upload by invoking the column's `onAttach` handler, surfaces
+   * the in-flight + outcome state, and commits the returned ref on success.
+   * Falls back to the legacy "commit filename" behaviour when no handler is
+   * wired.
    */
-  const handleFileChange = (file: File) => {
-    onCommit(file.name);
-  };
+  const runUpload = useCallback(
+    async (file: File) => {
+      // Pre-flight validation
+      const err = validate(file, column as { accept?: string[]; maxSize?: number });
+      if (err) {
+        setState({ kind: 'error', fileName: file.name, message: err, file });
+        return;
+      }
+      // No handler wired → preserve legacy behaviour (commit the filename).
+      if (!onAttach) {
+        onCommit(file.name);
+        setState({ kind: 'success', fileName: file.name });
+        return;
+      }
+      setState({ kind: 'uploading', fileName: file.name, progress: 0 });
+      const ctx: UploadAttachContext<TData> = {
+        cell: { rowId: rowId ?? '', field: column.field },
+        column,
+        row,
+      };
+      try {
+        const ref = await onAttach(file, ctx, (loaded, total) => {
+          const pct = total && total > 0 ? Math.round((loaded / total) * 100) : 0;
+          setState((prev) =>
+            prev.kind === 'uploading' ? { ...prev, progress: pct } : prev,
+          );
+        });
+        onCommit(ref as unknown as CellValue);
+        setState({ kind: 'success', fileName: ref.name ?? file.name });
+      } catch (e) {
+        const message = e instanceof Error ? e.message : String(e);
+        setState({ kind: 'error', fileName: file.name, message, file });
+      }
+    },
+    [column, onAttach, onCommit, row, rowId],
+  );
 
-  /**
-   * Handles the native file input's change event and resets the input afterwards
-   * so the same file can be re-selected.
-   *
-   * @param e - The change event from the hidden file input.
-   */
+  /** Handle picker selection — resets the input so the same file can be re-picked. */
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
-    if (file) handleFileChange(file);
-    // Reset so same file can be re-selected
+    if (file) void runUpload(file);
     e.target.value = '';
   };
 
-  /**
-   * Handles the drop event by extracting the first file and committing it.
-   *
-   * @param e - The drag event containing the dropped files.
-   */
   const handleDrop = (e: React.DragEvent) => {
     e.preventDefault();
     setIsDragging(false);
     const file = e.dataTransfer.files?.[0];
-    if (file) handleFileChange(file);
+    if (file) void runUpload(file);
   };
 
-  /**
-   * Activates the drag-over visual indicator when a file is dragged over the cell.
-   *
-   * @param e - The drag event.
-   */
   const handleDragOver = (e: React.DragEvent) => {
     e.preventDefault();
     setIsDragging(true);
   };
 
-  /**
-   * Deactivates the drag-over visual indicator when the dragged file leaves the cell.
-   */
-  const handleDragLeave = () => {
-    setIsDragging(false);
+  const handleDragLeave = () => setIsDragging(false);
+
+  const handleRetry = () => {
+    if (state.kind === 'error') void runUpload(state.file);
   };
+
+  const acceptAttr = column.accept && column.accept.length > 0 ? column.accept.join(',') : undefined;
 
   return (
     <div
@@ -135,6 +215,7 @@ export const UploadCell = React.memo(function UploadCell<TData = Record<string, 
       onDragOver={handleDragOver}
       onDragLeave={handleDragLeave}
       style={styles.dropZone(isDragging)}
+      data-upload-state={state.kind}
     >
       {/* File name as a download link, or placeholder text when no file is attached */}
       {fileName ? (
@@ -144,7 +225,7 @@ export const UploadCell = React.memo(function UploadCell<TData = Record<string, 
           aria-label={`Download ${fileName}`}
           onClick={(e) => {
             e.preventDefault();
-            onDownload?.(fileName);
+            onDownload?.(currentRef ?? fileName);
           }}
           style={styles.fileLink}
         >
@@ -155,23 +236,75 @@ export const UploadCell = React.memo(function UploadCell<TData = Record<string, 
           {column.placeholder ?? 'No file'}
         </span>
       )}
-      {/* Upload/Replace button that triggers the hidden file input */}
+
+      {/* Status badges — visible inline so e2e + AT can introspect them. */}
+      {state.kind === 'uploading' && (
+        <span
+          role="status"
+          aria-live="polite"
+          data-testid="upload-cell-uploading"
+          style={styles.statusUploading}
+        >
+          Uploading {state.fileName}…
+        </span>
+      )}
+      {state.kind === 'error' && (
+        <span
+          role="alert"
+          data-testid="upload-cell-error"
+          title={state.message}
+          style={styles.statusError}
+        >
+          {state.message}
+        </span>
+      )}
+      {state.kind === 'success' && (
+        <span
+          role="status"
+          data-testid="upload-cell-success"
+          style={styles.statusSuccess}
+        >
+          Uploaded
+        </span>
+      )}
+
+      {/* Upload / Replace button */}
       <button
         type="button"
         aria-label="Upload file"
         onClick={() => fileInputRef.current?.click()}
+        disabled={state.kind === 'uploading'}
         style={styles.uploadButton}
       >
         {fileName ? 'Replace' : 'Upload'}
       </button>
-      {/* Hidden file input element, opened programmatically by the button */}
+
+      {/* Retry — only visible after a failed upload */}
+      {state.kind === 'error' && (
+        <button
+          type="button"
+          aria-label="Retry upload"
+          onClick={handleRetry}
+          style={styles.retryButton}
+        >
+          Retry
+        </button>
+      )}
+
+      {/* Hidden file input */}
       <input
         ref={fileInputRef}
         type="file"
         aria-label="File input"
+        accept={acceptAttr}
         onChange={handleInputChange}
         style={styles.hiddenInput}
       />
+
+      {/* Determinate progress bar while uploading */}
+      {state.kind === 'uploading' && (
+        <div role="progressbar" aria-label="Upload progress" style={styles.progressBar(state.progress)} />
+      )}
     </div>
   );
 }) as <TData = Record<string, unknown>>(props: UploadCellProps<TData>) => React.ReactElement;

--- a/packages/react/src/cells/UploadCell/__tests__/UploadCell.test.tsx
+++ b/packages/react/src/cells/UploadCell/__tests__/UploadCell.test.tsx
@@ -1,9 +1,9 @@
 import { vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import React from 'react';
 
 import { UploadCell } from '../UploadCell';
-import type { ColumnDef, CellValue } from '@iasbuilt/datagrid-core';
+import type { AttachmentRef, CellValue, ColumnDef } from '@iasbuilt/datagrid-core';
 
 // ---------------------------------------------------------------------------
 // Shared helpers
@@ -19,6 +19,7 @@ function makeProps(overrides: {
   isEditing?: boolean;
   onCommit?: (v: CellValue) => void;
   onCancel?: () => void;
+  rowId?: string;
 }) {
   return {
     value: overrides.value ?? null,
@@ -28,14 +29,15 @@ function makeProps(overrides: {
     isEditing: overrides.isEditing ?? false,
     onCommit: overrides.onCommit ?? vi.fn(),
     onCancel: overrides.onCancel ?? vi.fn(),
+    rowId: overrides.rowId ?? 'r1',
   };
 }
 
 // ---------------------------------------------------------------------------
-// UploadCell
+// UploadCell — legacy display contract
 // ---------------------------------------------------------------------------
 
-describe('UploadCell', () => {
+describe('UploadCell — display + legacy contract', () => {
   it('renders file name as a link when value is set', () => {
     render(<UploadCell {...makeProps({ value: 'report.pdf' })} />);
     expect(screen.getByRole('link', { name: /download report\.pdf/i })).toBeInTheDocument();
@@ -62,7 +64,13 @@ describe('UploadCell', () => {
     expect(screen.getByRole('button', { name: /upload file/i })).toHaveTextContent('Replace');
   });
 
-  it('calls onDownload handler when file link is clicked', () => {
+  it('renders attachment-ref display name when value is an AttachmentRef', () => {
+    const ref: AttachmentRef = { id: 'att-1', name: 'photo.png', url: 'https://x/photo.png' };
+    render(<UploadCell {...makeProps({ value: ref as unknown as CellValue })} />);
+    expect(screen.getByRole('link', { name: /download photo\.png/i })).toBeInTheDocument();
+  });
+
+  it('calls onDownload handler when file link is clicked (legacy string value)', () => {
     const onDownload = vi.fn();
     const column = { ...makeColumn(), onDownload } as unknown as ColumnDef;
     render(
@@ -74,13 +82,32 @@ describe('UploadCell', () => {
         isEditing={false}
         onCommit={vi.fn()}
         onCancel={vi.fn()}
-      />
+      />,
     );
     fireEvent.click(screen.getByRole('link', { name: /download/i }));
     expect(onDownload).toHaveBeenCalledWith('report.pdf');
   });
 
-  it('calls onCommit with file name after file input change', () => {
+  it('calls onDownload with the AttachmentRef when value is a ref', () => {
+    const onDownload = vi.fn();
+    const ref: AttachmentRef = { id: 'att-2', name: 'spec.pdf' };
+    const column = { ...makeColumn(), onDownload } as unknown as ColumnDef;
+    render(
+      <UploadCell
+        value={ref as unknown as CellValue}
+        row={{}}
+        column={column}
+        rowIndex={0}
+        isEditing={false}
+        onCommit={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByRole('link', { name: /download/i }));
+    expect(onDownload).toHaveBeenCalledWith(ref);
+  });
+
+  it('commits the filename in legacy mode (no onAttach wired)', () => {
     const onCommit = vi.fn();
     render(<UploadCell {...makeProps({ value: null, onCommit })} />);
     const fileInput = screen.getByLabelText(/file input/i);
@@ -89,7 +116,7 @@ describe('UploadCell', () => {
     expect(onCommit).toHaveBeenCalledWith('new-file.txt');
   });
 
-  it('calls onCommit after drag-and-drop', () => {
+  it('handles drag-and-drop in legacy mode', () => {
     const onCommit = vi.fn();
     const { container } = render(<UploadCell {...makeProps({ value: null, onCommit })} />);
     const file = new File(['content'], 'dropped.png', { type: 'image/png' });
@@ -111,5 +138,230 @@ describe('UploadCell', () => {
     const dropZone = container.firstChild as Element;
     fireEvent.dragOver(dropZone, { dataTransfer: { files: [] } });
     expect(dropZone).toHaveStyle({ border: '2px dashed #2563eb' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// UploadCell — onAttach contract (issue #91)
+// ---------------------------------------------------------------------------
+
+describe('UploadCell — onAttach contract (issue #91)', () => {
+  it('calls onAttach with the file, a CellAddress-shaped context, and a progress reporter', async () => {
+    const onAttach = vi.fn().mockResolvedValue({ id: 'att-100', name: 'x.txt' } as AttachmentRef);
+    const column = { ...makeColumn({ field: 'attachment' }), onAttach } as unknown as ColumnDef;
+    render(
+      <UploadCell
+        value={null}
+        row={{ id: 'r-42' }}
+        column={column}
+        rowIndex={0}
+        isEditing={false}
+        onCommit={vi.fn()}
+        onCancel={vi.fn()}
+        rowId="r-42"
+      />,
+    );
+
+    const file = new File(['x'], 'x.txt', { type: 'text/plain' });
+    const input = screen.getByLabelText(/file input/i);
+    await act(async () => {
+      fireEvent.change(input, { target: { files: [file] } });
+    });
+
+    expect(onAttach).toHaveBeenCalledTimes(1);
+    const [calledFile, calledCtx, calledProgress] = onAttach.mock.calls[0];
+    expect(calledFile).toBe(file);
+    expect(calledCtx.cell).toEqual({ rowId: 'r-42', field: 'attachment' });
+    expect(calledCtx.column.field).toBe('attachment');
+    expect(typeof calledProgress).toBe('function');
+  });
+
+  it('shows in-flight UI while onAttach is pending and success after it resolves', async () => {
+    let resolveUpload!: (ref: AttachmentRef) => void;
+    const onAttach = vi.fn(
+      () => new Promise<AttachmentRef>((res) => { resolveUpload = res; }),
+    );
+    const onCommit = vi.fn();
+    const column = { ...makeColumn(), onAttach } as unknown as ColumnDef;
+    render(
+      <UploadCell
+        value={null}
+        row={{}}
+        column={column}
+        rowIndex={0}
+        isEditing={false}
+        onCommit={onCommit}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    const file = new File(['x'], 'pending.txt', { type: 'text/plain' });
+    fireEvent.change(screen.getByLabelText(/file input/i), { target: { files: [file] } });
+
+    expect(await screen.findByTestId('upload-cell-uploading')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /upload file/i })).toBeDisabled();
+
+    await act(async () => {
+      resolveUpload({ id: 'att-200', name: 'pending.txt' });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('upload-cell-success')).toBeInTheDocument();
+    });
+    expect(onCommit).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'att-200', name: 'pending.txt' }),
+    );
+  });
+
+  it('shows error state when onAttach rejects, exposes a Retry button, and keeps the prior value', async () => {
+    let rejectUpload!: (reason: Error) => void;
+    const onAttach = vi.fn(
+      () => new Promise<AttachmentRef>((_res, rej) => { rejectUpload = rej; }),
+    );
+    const onCommit = vi.fn();
+    const column = { ...makeColumn(), onAttach } as unknown as ColumnDef;
+    render(
+      <UploadCell
+        value="prior.pdf"
+        row={{}}
+        column={column}
+        rowIndex={0}
+        isEditing={false}
+        onCommit={onCommit}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    const file = new File(['x'], 'will-fail.txt', { type: 'text/plain' });
+    fireEvent.change(screen.getByLabelText(/file input/i), { target: { files: [file] } });
+    await act(async () => {
+      rejectUpload(new Error('network down'));
+    });
+
+    expect(await screen.findByTestId('upload-cell-error')).toHaveTextContent('network down');
+    expect(screen.getByRole('button', { name: /retry upload/i })).toBeInTheDocument();
+    // Prior cell value untouched.
+    expect(onCommit).not.toHaveBeenCalled();
+    // Display still shows the prior filename.
+    expect(screen.getByRole('link', { name: /download prior\.pdf/i })).toBeInTheDocument();
+  });
+
+  it('Retry re-invokes onAttach with the same file', async () => {
+    const onAttach = vi
+      .fn<[File, unknown, unknown?], Promise<AttachmentRef>>()
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce({ id: 'att-300', name: 'r.txt' });
+    const onCommit = vi.fn();
+    const column = { ...makeColumn(), onAttach } as unknown as ColumnDef;
+    render(
+      <UploadCell
+        value={null}
+        row={{}}
+        column={column}
+        rowIndex={0}
+        isEditing={false}
+        onCommit={onCommit}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    const file = new File(['r'], 'r.txt', { type: 'text/plain' });
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText(/file input/i), { target: { files: [file] } });
+    });
+    expect(await screen.findByTestId('upload-cell-error')).toBeInTheDocument();
+
+    const retry = screen.getByRole('button', { name: /retry upload/i });
+    await act(async () => {
+      fireEvent.click(retry);
+    });
+
+    await waitFor(() => expect(screen.getByTestId('upload-cell-success')).toBeInTheDocument());
+    expect(onAttach).toHaveBeenCalledTimes(2);
+    expect(onAttach.mock.calls[1][0]).toBe(file);
+    expect(onCommit).toHaveBeenCalledWith(expect.objectContaining({ id: 'att-300' }));
+  });
+
+  it('rejects files exceeding maxSize without invoking onAttach', async () => {
+    const onAttach = vi.fn();
+    const column = { ...makeColumn({ maxSize: 5 }), onAttach } as unknown as ColumnDef;
+    render(
+      <UploadCell
+        value={null}
+        row={{}}
+        column={column}
+        rowIndex={0}
+        isEditing={false}
+        onCommit={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    const file = new File(['too-much-content'], 'big.txt', { type: 'text/plain' });
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText(/file input/i), { target: { files: [file] } });
+    });
+
+    expect(onAttach).not.toHaveBeenCalled();
+    expect(await screen.findByTestId('upload-cell-error')).toHaveTextContent(/max size/i);
+  });
+
+  it('rejects files outside the accept list without invoking onAttach', async () => {
+    const onAttach = vi.fn();
+    const column = { ...makeColumn({ accept: ['.pdf'] }), onAttach } as unknown as ColumnDef;
+    render(
+      <UploadCell
+        value={null}
+        row={{}}
+        column={column}
+        rowIndex={0}
+        isEditing={false}
+        onCommit={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    const file = new File(['x'], 'note.txt', { type: 'text/plain' });
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText(/file input/i), { target: { files: [file] } });
+    });
+    expect(onAttach).not.toHaveBeenCalled();
+    expect(await screen.findByTestId('upload-cell-error')).toHaveTextContent(/not accepted/i);
+  });
+
+  it('forwards progress updates from onAttach', async () => {
+    let resolveUpload!: (ref: AttachmentRef) => void;
+    let progressReporter: ((loaded: number, total?: number) => void) | undefined;
+    const onAttach = vi.fn((_file: File, _ctx: unknown, onProgress?: (loaded: number, total?: number) => void) => {
+      progressReporter = onProgress;
+      return new Promise<AttachmentRef>((res) => { resolveUpload = res; });
+    });
+    const column = { ...makeColumn(), onAttach } as unknown as ColumnDef;
+    render(
+      <UploadCell
+        value={null}
+        row={{}}
+        column={column}
+        rowIndex={0}
+        isEditing={false}
+        onCommit={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    const file = new File(['x'], 'p.txt', { type: 'text/plain' });
+    fireEvent.change(screen.getByLabelText(/file input/i), { target: { files: [file] } });
+    await screen.findByTestId('upload-cell-uploading');
+
+    await act(async () => {
+      progressReporter?.(50, 100);
+    });
+    const progressEl = screen.getByRole('progressbar');
+    expect(progressEl).toBeInTheDocument();
+
+    await act(async () => {
+      resolveUpload({ id: 'p', name: 'p.txt' });
+    });
+    await waitFor(() => expect(screen.getByTestId('upload-cell-success')).toBeInTheDocument());
   });
 });

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -63,6 +63,13 @@ export {
 } from './cells/BooleanSelectedCell';
 export { PasswordConfirmCell, MISMATCH_MESSAGE } from './cells/PasswordConfirmCell';
 
+// Issue #91 — file-upload cell + the default cell renderer map so consumers
+// can pass it to `DataGrid`'s `cellRenderers` prop without having to assemble
+// it themselves. Importing the map from the cells barrel keeps the public
+// surface stable as new built-in renderers are added.
+export { UploadCell } from './cells/UploadCell';
+export { cellRendererMap } from './cells';
+
 // Migration helper for consumers upgrading from the HTML-backed RichTextCell.
 export { htmlToMarkdown } from './cells/RichTextCell';
 

--- a/playground/file-upload-attach/index.html
+++ b/playground/file-upload-attach/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>@iasbuilt/datagrid — File Upload Attach Demo (#91)</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: system-ui, -apple-system, sans-serif;
+      background: #f8fafc;
+      color: #1e293b;
+      padding: 24px;
+    }
+    #root { max-width: 1100px; margin: 0 auto; }
+  </style>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="module" src="./main.tsx"></script>
+</body>
+</html>

--- a/playground/file-upload-attach/main.tsx
+++ b/playground/file-upload-attach/main.tsx
@@ -1,0 +1,273 @@
+/**
+ * File-upload-attach playground demo — worked example for issue #91.
+ *
+ * Shows how a consumer (e.g. the iasbuilt/webapp attachment system specced in
+ * istracked/webapp#155) wires the grid's `upload` cell to its own backend by
+ * supplying a column-level `onAttach` handler. The grid stays agnostic about
+ * storage / dedupe / ACL — those concerns live in the consumer's service.
+ *
+ * The mock backend exposes three knobs from the page so a tester (or the
+ * e2e suite in `e2e/issue-91-file-upload-attach.spec.ts`) can drive each
+ * branch:
+ *
+ *   - "Mode = success"  : onAttach resolves after a short delay with a
+ *                          synthetic AttachmentRef.
+ *   - "Mode = fail"     : onAttach rejects with a controlled error; the cell
+ *                          surfaces the message and exposes a Retry button.
+ *   - "Latency"         : tweakable delay so the in-flight UI is observable.
+ *
+ * The page also logs every `onAttach` invocation and every state transition
+ * to a panel on the right, so a human tester can see the contract being
+ * honoured live.
+ */
+import React, { useCallback, useMemo, useState } from 'react';
+import { createRoot } from 'react-dom/client';
+import { DataGrid, cellRendererMap } from '@iasbuilt/datagrid-react';
+import type {
+  AttachmentRef,
+  CellValue,
+  ColumnDef,
+  UploadAttachContext,
+} from '@iasbuilt/datagrid-core';
+
+// ---------------------------------------------------------------------------
+// Data model
+// ---------------------------------------------------------------------------
+
+interface Row {
+  id: string;
+  title: string;
+  attachment: CellValue;
+}
+
+const INITIAL_ROWS: Row[] = [
+  { id: 'r1', title: 'Q4 financial report',    attachment: null },
+  { id: 'r2', title: 'Onboarding checklist',   attachment: null },
+  { id: 'r3', title: 'Architecture diagram',   attachment: null },
+];
+
+// ---------------------------------------------------------------------------
+// Mock backend
+// ---------------------------------------------------------------------------
+
+type Mode = 'success' | 'fail';
+
+interface MockBackendOptions {
+  mode: Mode;
+  latencyMs: number;
+  failMessage: string;
+}
+
+function makeMockUpload(opts: MockBackendOptions, log: (msg: string) => void) {
+  return (file: File, ctx: UploadAttachContext<Row>): Promise<AttachmentRef> => {
+    log(`onAttach({ file: ${file.name}, cell: ${ctx.cell.rowId}/${ctx.cell.field}, size: ${file.size}B })`);
+    return new Promise((resolve, reject) => {
+      const t = setTimeout(() => {
+        if (opts.mode === 'fail') {
+          log(`  -> reject(${opts.failMessage})`);
+          reject(new Error(opts.failMessage));
+          return;
+        }
+        // A real attachment service would compute a content hash, register the
+        // blob, and return its id. Here we synthesise something deterministic
+        // enough for testing.
+        const ref: AttachmentRef = {
+          id: `att_${file.name}_${file.size}`,
+          name: file.name,
+          mimeType: file.type || 'application/octet-stream',
+          size: file.size,
+          url: `https://example.invalid/attachments/${encodeURIComponent(file.name)}`,
+        };
+        log(`  -> resolve(${JSON.stringify(ref)})`);
+        resolve(ref);
+      }, opts.latencyMs);
+      // (Real consumers would also wire AbortController via ctx — omitted
+      //  here for brevity; the grid only requires the Promise contract.)
+      void t;
+    });
+  };
+}
+
+// ---------------------------------------------------------------------------
+// App
+// ---------------------------------------------------------------------------
+
+function App() {
+  const [rows, setRows] = useState<Row[]>(INITIAL_ROWS);
+  const [mode, setMode] = useState<Mode>('success');
+  const [latency, setLatency] = useState(400);
+  const [log, setLog] = useState<string[]>([]);
+
+  const appendLog = useCallback((msg: string) => {
+    setLog((prev) => [...prev.slice(-49), `[${new Date().toLocaleTimeString()}] ${msg}`]);
+  }, []);
+
+  const onAttach = useMemo(
+    () => makeMockUpload({ mode, latencyMs: latency, failMessage: 'Mock backend rejected upload' }, appendLog),
+    [mode, latency, appendLog],
+  );
+
+  const columns: ColumnDef<Row>[] = useMemo(
+    () => [
+      { id: 'title', field: 'title', title: 'Title', width: 240 },
+      {
+        id: 'attachment',
+        field: 'attachment',
+        title: 'Attachment',
+        width: 360,
+        cellType: 'upload',
+        placeholder: 'Drop a file or click Upload',
+        editable: true,
+        // The clean #91 contract. The grid hands us the file + a CellAddress;
+        // we hand back an AttachmentRef. The grid stores the ref as the cell
+        // value and renders the filename as a downloadable link.
+        onAttach,
+        onDownload: (ref) => {
+          if (typeof ref === 'string') {
+            appendLog(`onDownload(string: ${ref})`);
+          } else {
+            appendLog(`onDownload(ref: ${ref.id})`);
+          }
+        },
+        accept: ['.txt', '.pdf', '.png', '.jpg', '.json', 'text/*', 'image/*'],
+        maxSize: 5 * 1024 * 1024,
+      },
+    ],
+    [onAttach, appendLog],
+  );
+
+  const handleCellEdit = useCallback(
+    (rowId: string, field: string, value: CellValue) => {
+      setRows((prev) =>
+        prev.map((r) => (r.id === rowId ? { ...r, [field]: value } : r)),
+      );
+    },
+    [],
+  );
+
+  return (
+    <div>
+      <header style={{ marginBottom: 20 }}>
+        <h1 style={{ fontSize: 22, fontWeight: 700, color: '#0f172a' }}>
+          File-upload cell — onAttach contract (#91)
+        </h1>
+        <p style={{ color: '#475569', marginTop: 6, fontSize: 14 }}>
+          Drop a file into an <code>Attachment</code> cell or click <strong>Upload</strong>. The grid
+          invokes the column's <code>onAttach</code> handler — a clean interface a webapp can wire
+          to its own attachment system (e.g. istracked/webapp#155). Toggle <em>Mode</em> below to
+          drive the success / failure branches; use <em>Latency</em> to make the in-flight UI
+          observable.
+        </p>
+      </header>
+
+      <section
+        data-testid="controls"
+        style={{
+          background: '#fff',
+          border: '1px solid #e2e8f0',
+          borderRadius: 8,
+          padding: 12,
+          marginBottom: 16,
+          display: 'flex',
+          alignItems: 'center',
+          gap: 16,
+          flexWrap: 'wrap',
+        }}
+      >
+        <label style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+          <span style={{ fontSize: 12, color: '#64748b', textTransform: 'uppercase', letterSpacing: 0.5 }}>
+            Mode
+          </span>
+          <select
+            data-testid="mode-select"
+            value={mode}
+            onChange={(e) => setMode(e.target.value as Mode)}
+            style={selStyle}
+          >
+            <option value="success">success</option>
+            <option value="fail">fail</option>
+          </select>
+        </label>
+        <label style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+          <span style={{ fontSize: 12, color: '#64748b', textTransform: 'uppercase', letterSpacing: 0.5 }}>
+            Latency&nbsp;(ms)
+          </span>
+          <input
+            data-testid="latency-input"
+            type="number"
+            value={latency}
+            min={0}
+            step={50}
+            onChange={(e) => setLatency(Number(e.target.value) || 0)}
+            style={{ ...selStyle, width: 90 }}
+          />
+        </label>
+        <button data-testid="reset-rows" onClick={() => setRows(INITIAL_ROWS)} style={btnStyle}>
+          Reset rows
+        </button>
+        <button data-testid="clear-log" onClick={() => setLog([])} style={btnStyle}>
+          Clear log
+        </button>
+      </section>
+
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 360px', gap: 16, alignItems: 'start' }}>
+        <div
+          data-testid="grid-host"
+          style={{ background: '#fff', border: '1px solid #e2e8f0', borderRadius: 8, padding: 12 }}
+        >
+          <DataGrid
+            data={rows}
+            columns={columns}
+            rowKey="id"
+            keyboardNavigation
+            cellRenderers={cellRendererMap}
+            onCellEdit={handleCellEdit}
+          />
+        </div>
+
+        <aside
+          data-testid="event-log"
+          style={{
+            background: '#0f172a',
+            color: '#e2e8f0',
+            borderRadius: 8,
+            padding: 12,
+            fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+            fontSize: 12,
+            height: 360,
+            overflow: 'auto',
+          }}
+        >
+          <div style={{ color: '#94a3b8', marginBottom: 6 }}>onAttach event log</div>
+          {log.length === 0 ? (
+            <div style={{ color: '#64748b' }}>(no events yet — drop or pick a file)</div>
+          ) : (
+            log.map((line, i) => (
+              <div key={i} style={{ whiteSpace: 'pre-wrap', marginBottom: 2 }}>
+                {line}
+              </div>
+            ))
+          )}
+        </aside>
+      </div>
+    </div>
+  );
+}
+
+const selStyle: React.CSSProperties = {
+  padding: '4px 8px',
+  borderRadius: 6,
+  border: '1px solid #cbd5e1',
+  fontSize: 13,
+  background: '#fff',
+};
+const btnStyle: React.CSSProperties = {
+  padding: '4px 10px',
+  borderRadius: 6,
+  border: '1px solid #cbd5e1',
+  background: '#f8fafc',
+  fontSize: 13,
+  cursor: 'pointer',
+};
+
+createRoot(document.getElementById('root')!).render(<App />);

--- a/playground/index.html
+++ b/playground/index.html
@@ -55,6 +55,10 @@
         <h2>SPA Integration (causl BYO-graph)</h2>
         <p>Grid + a separate pivot panel sharing one <code>causl Graph</code>. Mutations in the grid flow atomically into the pivot through <code>graph.derived</code>. Proves the foundational-causl payoff.</p>
       </a>
+      <a class="card" href="/file-upload-attach/">
+        <h2>File-upload cell — onAttach (#91)</h2>
+        <p>Wires the <code>upload</code> cell to a mock attachment backend via the column-level <code>onAttach</code> handler. Toggle <em>Mode = fail</em> to see the error + retry path; bump latency to inspect the in-flight UI.</p>
+      </a>
     </div>
   </div>
 </body>


### PR DESCRIPTION
## Summary

Adds a clean typed contract — `onAttach` + `AttachmentRef` — that the file-upload cell hands to consumers so they can wire it to their own attachment service (e.g. the iasbuilt/webapp attachment system specced in istracked/webapp#155). The grid stays the agnostic surface: storage, dedupe, scoped inheritance, and ACLs all live on the consumer side.

Closes #91.

## Public contract (new types in `@iasbuilt/datagrid-core`)

```ts
interface AttachmentRef {
  id: string;
  name?: string;
  url?: string;
  mimeType?: string;
  size?: number;
  meta?: Record<string, unknown>;
}

type UploadAttachHandler<TData> = (
  file: File,
  context: { cell: CellAddress; column: ColumnDef<TData>; row: TData },
  onProgress?: (loaded: number, total?: number) => void,
) => Promise<AttachmentRef>;
```

Column-def additions (all optional, all on the `upload` cell type): `onAttach`, `onDownload`, `accept`, `maxSize`, `multiple`, `scope`.

## What the cell does now

- Picks / drops route through `onAttach` (legacy "commit filename" behaviour preserved when no handler is wired, so pre-#91 consumers don't regress).
- Pre-flight validates against `accept` / `maxSize` and short-circuits with an error if rejected.
- Surfaces an in-flight `role="status"` badge plus a determinate progress bar while `onAttach` is pending; the upload button disables.
- On success: commits the returned `AttachmentRef` as the cell value and renders a transient success state.
- On failure: surfaces the rejection message in a `role="alert"`, keeps the prior cell value intact, and exposes a **Retry** button that re-invokes `onAttach` with the same file — no re-pick needed.
- Both `UploadCell` (plain React) and `MuiUploadCell` (Material UI variant) implement the same contract.

## Worked example

A new playground demo at `playground/file-upload-attach/` (linked from the landing page) wires the cell to a mock backend with mode + latency toggles and a live event log, so consumers can inspect the contract before wiring their real service.

## Test plan

- [x] `pnpm vitest run packages/` — 1950/1950 passing (includes 19 UploadCell tests, 8 new for the #91 contract).
- [x] `pnpm exec playwright test e2e/issue-91-file-upload-attach.spec.ts` — 3/3 passing, covering: pick/upload-success path with visible in-flight UI, drag-drop branch, and fail-then-retry recovery.
- [x] `pnpm typecheck`, `pnpm run build`, `pnpm tokens:check`, `pnpm run test:scripts` — all green (full pre-commit hook surface).

## TODO — webapp-side integration

This PR is the grid-side contract only. Wiring the webapp's attachment service (istracked/webapp#155: content-hash dedupe, progressive-disclosure picker, scoped inheritance, soft-delete cleanup) is out of scope here and tracked in that repo. Suggested webapp adapter, when ready:

```ts
const onAttach: UploadAttachHandler<MyRow> = async (file, ctx) => {
  const result = await attachmentService.upload(file, { scope: ctx.column.scope });
  return { id: result.hash, name: file.name, url: result.url, mimeType: file.type, size: file.size };
};
```

The `multiple: true` column flag is reserved for a follow-up that lets the cell store and render `AttachmentRef[]` rather than a single ref; the current cell handles one file per pick / drop, which is sufficient for the common case.