### PR TITLE
feat(richtext): ALT+ENTER soft line break (closes #97)

### DIFF
--- a/e2e/issue-97-richtext-alt-enter.spec.ts
+++ b/e2e/issue-97-richtext-alt-enter.spec.ts
@@ -1,0 +1,102 @@
+/**
+ * End-to-end: RichText cell ALT+ENTER soft line break (issue #97 — Excel parity).
+ *
+ * Drives the `Examples/Cell Types → AllCellTypes` story (the same harness
+ * exercised by `rich-text-floating-menu.spec.ts` and `grid-xss.spec.ts`),
+ * which provides a `MuiRichTextCell`-rendered `richText` column.
+ *
+ * Contract (matches issue #97):
+ *   - Plain ENTER while editing commits the draft and exits edit mode.
+ *   - ALT+ENTER inserts a `\n` at the caret WITHOUT committing or moving
+ *     selection off the cell — Excel users expect this gesture for
+ *     multi-line cell content.
+ *   - The committed value must include both `line1` and `line2` separated
+ *     by a soft break.
+ *   - After commit, the rendered display surface must visually present
+ *     two lines (`<br>` from markdown's "two trailing spaces" or two
+ *     paragraphs from a blank-line separator are both acceptable; we
+ *     assert via measured line count on the rendered surface).
+ */
+import { test, expect, type Locator, type Page } from '@playwright/test';
+
+const CELL_TYPES_URL =
+  '/iframe.html?viewMode=story&id=examples-cell-types--all-cell-types';
+
+function richTextCell(page: Page, rowId: string): Locator {
+  return page.locator(
+    `[role="gridcell"][data-row-id="${rowId}"][data-field="richText"]`,
+  );
+}
+
+/**
+ * Enters edit mode on a rich-text cell via double-click. Mirrors the helper
+ * used in `rich-text-floating-menu.spec.ts` so editor-surface resolution
+ * works across either the textarea or the contenteditable companion.
+ */
+async function enterEditMode(cell: Locator): Promise<void> {
+  await cell.dblclick();
+  await cell
+    .locator('textarea, [contenteditable="true"]')
+    .first()
+    .waitFor({ state: 'visible' });
+}
+
+test.describe('RichText cell – ALT+ENTER soft line break (#97)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(CELL_TYPES_URL);
+    await page.locator('[role="grid"]').first().waitFor({ state: 'visible' });
+  });
+
+  test('ALT+ENTER inserts a soft line break; ENTER commits both lines (#97)', async ({ page }) => {
+    const cell = richTextCell(page, '1');
+    await expect(cell).toBeVisible();
+    await enterEditMode(cell);
+
+    // The textarea mirror is the canonical raw-markdown source — driving it
+    // directly avoids contenteditable selection ambiguity and matches the
+    // pattern in `grid-xss.spec.ts`.
+    const textarea = cell.locator('textarea').first();
+    await expect(textarea).toBeVisible();
+
+    // Clear any seed markdown so the assertion below reasons about only
+    // what this test typed.
+    await textarea.click();
+    await textarea.press('ControlOrMeta+a');
+    await textarea.press('Delete');
+
+    await textarea.type('line1');
+    await textarea.press('Alt+Enter');
+    await textarea.type('line2');
+
+    // ALT+ENTER must NOT have committed — the textarea is still visible and
+    // its current value carries both lines separated by a CommonMark hard
+    // break (`  \n` — two trailing spaces then newline), which renders as
+    // `<br>` in display mode without a `remark-breaks` plugin.
+    await expect(textarea).toBeVisible();
+    const midValue = await textarea.inputValue();
+    expect(midValue).toBe('line1  \nline2');
+
+    // Plain ENTER commits the draft and leaves the cell in display mode.
+    await textarea.press('Enter');
+
+    // The textarea is gone — we are back in display mode.
+    await expect(cell.locator('textarea')).toHaveCount(0);
+
+    // Rendered display surface contains both lines.
+    const rendered = cell.locator('[data-testid="richtext-rendered"]');
+    await expect(rendered).toBeVisible();
+    const text = (await rendered.innerText()).trim();
+    expect(text).toContain('line1');
+    expect(text).toContain('line2');
+
+    // The break must materialise as a `<br>` element — that is the
+    // CommonMark rendering of the `  \n` hard-break we inserted, and the
+    // load-bearing piece of "Excel parity": the display must visually
+    // wrap the cell onto two lines.
+    const breakCount = await rendered.locator('br').count();
+    expect(
+      breakCount,
+      `expected a <br> in the rendered cell after ALT+ENTER + ENTER`,
+    ).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/packages/mui/src/cells/MuiRichTextCell/MuiRichTextCell.tsx
+++ b/packages/mui/src/cells/MuiRichTextCell/MuiRichTextCell.tsx
@@ -408,10 +408,69 @@ export const MuiRichTextCell = React.memo(function MuiRichTextCell<TData = Recor
     [],
   );
 
+  /**
+   * Inserts a CommonMark hard line break (`  \n` — two trailing spaces
+   * followed by `\n`) at the textarea mirror's caret position and returns
+   * the new value + caret offset. The two-space prefix is the standard
+   * CommonMark hard-break encoding, which makes `react-markdown` render
+   * the break as `<br>` in display mode without needing a `remark-breaks`
+   * plugin. Used by the Alt+Enter handler so the existing draft-state
+   * plumbing (setDraft + draftRef) updates in lockstep with the
+   * DOM-level insertion.
+   */
+  const insertNewlineInTextarea = (ta: HTMLTextAreaElement): { value: string; caret: number } => {
+    const { value, selectionStart, selectionEnd } = ta;
+    const insertion = '  \n';
+    const next = value.slice(0, selectionStart) + insertion + value.slice(selectionEnd);
+    const caret = selectionStart + insertion.length;
+    return { value: next, caret };
+  };
+
   const handleKeyDown = (e: React.KeyboardEvent<HTMLElement>) => {
     if (e.key === 'Escape') {
       e.preventDefault();
       onCancel();
+      return;
+    }
+    // Enter handling — Excel parity (issue #97):
+    //   • ALT+ENTER inserts a soft line break (`\n`) at the caret without
+    //     committing the edit, regardless of whether the user is typing in
+    //     the contenteditable visual surface or the textarea mirror.
+    //   • SHIFT+ENTER preserves the existing native behaviour on each
+    //     surface (newline) so the legacy shortcut keeps working.
+    //   • Plain ENTER commits the current draft, matching the rest of the
+    //     grid's edit-end convention.
+    if (e.key === 'Enter') {
+      if (e.altKey) {
+        e.preventDefault();
+        const target = e.currentTarget;
+        if (target === textareaRef.current && textareaRef.current) {
+          // Textarea mirror: splice `\n` into `.value` and reposition caret.
+          const ta = textareaRef.current;
+          const { value: next, caret } = insertNewlineInTextarea(ta);
+          ta.value = next;
+          ta.setSelectionRange(caret, caret);
+          setDraft(next);
+          draftRef.current = next;
+        } else {
+          // Contenteditable visual surface: splice the CommonMark hard
+          // line break (`  \n`) at the flat-text caret and let the layout
+          // effect re-project the visible text.
+          applyTransform((value, s, end) => {
+            const insertion = '  \n';
+            const next = value.slice(0, s) + insertion + value.slice(end);
+            const caret = s + insertion.length;
+            return { value: next, selectionStart: caret, selectionEnd: caret };
+          });
+        }
+        return;
+      }
+      if (e.shiftKey) {
+        // Let each surface insert its own native newline.
+        return;
+      }
+      e.preventDefault();
+      onCommit(draftRef.current);
       return;
     }
     const mod = e.ctrlKey || e.metaKey;

--- a/packages/mui/src/cells/__tests__/MuiRichTextCell-alt-enter.test.tsx
+++ b/packages/mui/src/cells/__tests__/MuiRichTextCell-alt-enter.test.tsx
@@ -1,0 +1,108 @@
+/**
+ * Unit tests for {@link MuiRichTextCell}'s ALT+ENTER soft line break
+ * (issue #97 — Excel parity).
+ *
+ * The MUI variant carries two synchronised editing surfaces — a
+ * contenteditable visual editor and a textarea raw-source mirror — both
+ * wired to the same keydown handler. ALT+ENTER must insert `\n` on
+ * whichever surface holds focus; plain ENTER commits; SHIFT+ENTER falls
+ * through to native behaviour so existing multi-line workflows are
+ * unaffected.
+ */
+import { vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+
+import { MuiRichTextCell } from '../MuiRichTextCell';
+import type { ColumnDef, CellValue } from '@iasbuilt/datagrid-core';
+
+function makeColumn(overrides: Partial<ColumnDef> = {}): ColumnDef {
+  return { id: 'col1', field: 'col1', title: 'Column 1', ...overrides };
+}
+
+function makeProps(overrides: {
+  value?: CellValue;
+  column?: Partial<ColumnDef>;
+  isEditing?: boolean;
+  onCommit?: (v: CellValue) => void;
+  onCancel?: () => void;
+}) {
+  return {
+    value: overrides.value ?? null,
+    row: {},
+    column: makeColumn(overrides.column),
+    rowIndex: 0,
+    isEditing: overrides.isEditing ?? false,
+    onCommit: overrides.onCommit ?? vi.fn(),
+    onCancel: overrides.onCancel ?? vi.fn(),
+  } as const;
+}
+
+describe('MuiRichTextCell — ALT+ENTER soft line break (#97)', () => {
+  it('ALT+ENTER on the textarea mirror inserts a CommonMark hard break at the caret without committing', () => {
+    const onCommit = vi.fn();
+    render(
+      <MuiRichTextCell {...makeProps({ isEditing: true, value: 'line1', onCommit })} />,
+    );
+    const textarea = screen.getByLabelText('Markdown source') as HTMLTextAreaElement;
+    textarea.focus();
+    textarea.setSelectionRange(textarea.value.length, textarea.value.length);
+
+    fireEvent.keyDown(textarea, { key: 'Enter', altKey: true });
+
+    // Two trailing spaces + `\n` is the standard CommonMark hard-break
+    // encoding; `react-markdown` renders this as `<br>` without a plugin.
+    expect(textarea.value).toBe('line1  \n');
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+
+  it('plain ENTER on the textarea mirror commits the draft', () => {
+    const onCommit = vi.fn();
+    render(
+      <MuiRichTextCell {...makeProps({ isEditing: true, value: '', onCommit })} />,
+    );
+    const textarea = screen.getByLabelText('Markdown source') as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: 'line1\nline2' } });
+    fireEvent.keyDown(textarea, { key: 'Enter' });
+
+    expect(onCommit).toHaveBeenCalledWith('line1\nline2');
+  });
+
+  it('SHIFT+ENTER on the textarea mirror does NOT commit', () => {
+    const onCommit = vi.fn();
+    render(
+      <MuiRichTextCell {...makeProps({ isEditing: true, value: 'x', onCommit })} />,
+    );
+    const textarea = screen.getByLabelText('Markdown source') as HTMLTextAreaElement;
+    fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: true });
+
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+
+  it('plain ENTER on the contenteditable surface commits the draft', () => {
+    const onCommit = vi.fn();
+    render(
+      <MuiRichTextCell {...makeProps({ isEditing: true, value: '', onCommit })} />,
+    );
+    const editor = screen.getByLabelText('Markdown editor');
+    editor.textContent = '**done**';
+    fireEvent.input(editor, { target: { textContent: '**done**' } });
+    fireEvent.keyDown(editor, { key: 'Enter' });
+
+    expect(onCommit).toHaveBeenCalledWith('**done**');
+  });
+
+  it('ALT+ENTER on the contenteditable surface does NOT commit', () => {
+    const onCommit = vi.fn();
+    render(
+      <MuiRichTextCell {...makeProps({ isEditing: true, value: '', onCommit })} />,
+    );
+    const editor = screen.getByLabelText('Markdown editor');
+    editor.textContent = 'hello';
+    fireEvent.input(editor, { target: { textContent: 'hello' } });
+
+    fireEvent.keyDown(editor, { key: 'Enter', altKey: true });
+
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+});

--- a/packages/react/src/cells/RichTextCell/RichTextCell.tsx
+++ b/packages/react/src/cells/RichTextCell/RichTextCell.tsx
@@ -388,6 +388,41 @@ export const RichTextCell = React.memo(function RichTextCell<TData = Record<stri
       onCancel();
       return;
     }
+    // Enter handling — Excel parity (issue #97):
+    //   • ALT+ENTER inserts a CommonMark hard line break (`  \n` — two
+    //     trailing spaces followed by `\n`) at the caret without
+    //     committing the edit. The two-space prefix is the standard
+    //     CommonMark hard-break encoding, which makes `react-markdown`
+    //     render the break as `<br>` in display mode without needing an
+    //     additional `remark-breaks` plugin. Excel users get the same
+    //     "wrap within the cell" affordance.
+    //   • SHIFT+ENTER preserves the native textarea behaviour (insert
+    //     `\n`) so the existing soft-paragraph shortcut keeps working.
+    //   • Plain ENTER commits the current draft, mirroring how every
+    //     other cell type ends an edit session via the keyboard.
+    if (e.key === 'Enter') {
+      if (e.altKey) {
+        e.preventDefault();
+        applyTransform((ta) => {
+          const { value, selectionStart, selectionEnd } = ta;
+          const insertion = '  \n';
+          const next =
+            value.slice(0, selectionStart) +
+            insertion +
+            value.slice(selectionEnd);
+          const caret = selectionStart + insertion.length;
+          return { value: next, selectionStart: caret, selectionEnd: caret };
+        });
+        return;
+      }
+      if (e.shiftKey) {
+        // Let the textarea insert a newline natively.
+        return;
+      }
+      e.preventDefault();
+      onCommit(draft);
+      return;
+    }
     const mod = e.ctrlKey || e.metaKey;
     if (!mod) return;
     const key = e.key.toLowerCase();

--- a/packages/react/src/cells/RichTextCell/__tests__/alt-enter.test.tsx
+++ b/packages/react/src/cells/RichTextCell/__tests__/alt-enter.test.tsx
@@ -1,0 +1,138 @@
+/**
+ * Unit tests for {@link RichTextCell}'s ALT+ENTER soft line break shortcut
+ * (issue #97 — Excel parity).
+ *
+ * The rich-text editor stores plain markdown as a string, so a "soft line
+ * break" is just a `\n` spliced at the caret. The keydown handler must:
+ *
+ *   - ALT+ENTER:   insert `\n` at the caret; do NOT commit; the textarea
+ *                  value reflects the new newline and the caret advances.
+ *   - SHIFT+ENTER: do NOT call onCommit — keep the prior native textarea
+ *                  semantics (a `\n` is inserted by the browser/jsdom
+ *                  default action), so user multi-line workflows keep
+ *                  working without regression.
+ *   - ENTER:       commit the current draft (the new edit-end gesture
+ *                  introduced alongside ALT+ENTER, so Excel users get a
+ *                  predictable commit gesture).
+ */
+import { vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+
+import { RichTextCell } from '../RichTextCell';
+import type { ColumnDef, CellValue } from '@iasbuilt/datagrid-core';
+
+function makeColumn(overrides: Partial<ColumnDef> = {}): ColumnDef {
+  return { id: 'col1', field: 'col1', title: 'Column 1', ...overrides };
+}
+
+function makeProps(overrides: {
+  value?: CellValue;
+  column?: Partial<ColumnDef>;
+  isEditing?: boolean;
+  onCommit?: (v: CellValue) => void;
+  onCancel?: () => void;
+}) {
+  return {
+    value: overrides.value ?? null,
+    row: {},
+    column: makeColumn(overrides.column),
+    rowIndex: 0,
+    isEditing: overrides.isEditing ?? false,
+    onCommit: overrides.onCommit ?? vi.fn(),
+    onCancel: overrides.onCancel ?? vi.fn(),
+  };
+}
+
+describe('RichTextCell — ALT+ENTER soft line break (#97)', () => {
+  it('ALT+ENTER inserts a CommonMark hard line break at the caret without committing', async () => {
+    const onCommit = vi.fn();
+    render(
+      <RichTextCell {...makeProps({ isEditing: true, value: 'line1', onCommit })} />,
+    );
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+    textarea.focus();
+    textarea.setSelectionRange(textarea.value.length, textarea.value.length);
+
+    fireEvent.keyDown(textarea, { key: 'Enter', altKey: true });
+
+    // Wait for the rAF caret restore; the value is updated synchronously in
+    // setDraft → re-render so the assertion below resolves after a microtask.
+    await new Promise((r) => requestAnimationFrame(() => r(null)));
+
+    // CommonMark hard break = two trailing spaces + `\n`. The display
+    // surface renders this as a `<br>` without needing remark-breaks.
+    expect(textarea.value).toBe('line1  \n');
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+
+  it('ALT+ENTER inserts the hard break at the caret position (mid-string)', async () => {
+    render(<RichTextCell {...makeProps({ isEditing: true, value: 'abXYef' })} />);
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+    textarea.focus();
+    textarea.setSelectionRange(2, 4); // select "XY"
+
+    fireEvent.keyDown(textarea, { key: 'Enter', altKey: true });
+    await new Promise((r) => requestAnimationFrame(() => r(null)));
+
+    // The selection is replaced by the hard-break sequence, mirroring
+    // textarea insert-replace semantics.
+    expect(textarea.value).toBe('ab  \nef');
+  });
+
+  it('plain ENTER commits the current draft', () => {
+    const onCommit = vi.fn();
+    render(
+      <RichTextCell {...makeProps({ isEditing: true, value: 'hello', onCommit })} />,
+    );
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: 'hello world' } });
+    fireEvent.keyDown(textarea, { key: 'Enter' });
+
+    expect(onCommit).toHaveBeenCalledWith('hello world');
+  });
+
+  it('SHIFT+ENTER does NOT commit (prior multi-line behaviour preserved)', () => {
+    const onCommit = vi.fn();
+    render(<RichTextCell {...makeProps({ isEditing: true, value: 'x', onCommit })} />);
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+    fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: true });
+
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+
+  it('ALT+ENTER does NOT trigger onCancel', async () => {
+    const onCancel = vi.fn();
+    render(<RichTextCell {...makeProps({ isEditing: true, value: '', onCancel })} />);
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+    textarea.focus();
+
+    fireEvent.keyDown(textarea, { key: 'Enter', altKey: true });
+    await new Promise((r) => requestAnimationFrame(() => r(null)));
+
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+
+  it('two ALT+ENTER presses produce two hard breaks and final commit round-trips them', async () => {
+    const onCommit = vi.fn();
+    render(<RichTextCell {...makeProps({ isEditing: true, value: '', onCommit })} />);
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+
+    fireEvent.change(textarea, { target: { value: 'a' } });
+    textarea.focus();
+    textarea.setSelectionRange(1, 1);
+    fireEvent.keyDown(textarea, { key: 'Enter', altKey: true });
+    await new Promise((r) => requestAnimationFrame(() => r(null)));
+
+    // After the first hard-break insertion the textarea now holds `a  \n`.
+    fireEvent.change(textarea, { target: { value: 'a  \nb' } });
+    textarea.setSelectionRange(5, 5);
+    fireEvent.keyDown(textarea, { key: 'Enter', altKey: true });
+    await new Promise((r) => requestAnimationFrame(() => r(null)));
+
+    fireEvent.change(textarea, { target: { value: 'a  \nb  \nc' } });
+    fireEvent.keyDown(textarea, { key: 'Enter' });
+
+    expect(onCommit).toHaveBeenCalledWith('a  \nb  \nc');
+  });
+});


### PR DESCRIPTION
## Summary

- ALT+ENTER in the rich-text editor inserts a CommonMark hard line break (`  \n`) at the caret without committing — Excel parity.
- Plain ENTER now commits the draft (matches every other cell type's edit-end gesture); SHIFT+ENTER keeps its prior native-newline behaviour so legacy multi-line workflows do not regress.
- The hard-break encoding renders through `react-markdown` as `<br>` without needing a `remark-breaks` plugin, so the committed value visibly wraps onto two lines in display mode.

## Implementation notes

- React `RichTextCell` (`packages/react/src/cells/RichTextCell/RichTextCell.tsx`): intercept Enter in `handleKeyDown`; on ALT+ENTER, splice `  \n` at the textarea's `selectionStart..End` via the existing `applyTransform` plumbing.
- MUI `MuiRichTextCell` (`packages/mui/src/cells/MuiRichTextCell/MuiRichTextCell.tsx`): same logic, but the cell carries two synchronised editing surfaces (contenteditable + textarea mirror) — both routed through the same handler. ALT+ENTER on the textarea uses a small helper that updates `.value` + caret + draft state; on the contenteditable it reuses the flat-text `applyTransform` path used by Ctrl+B/I/K.

## Coverage

- Unit tests (vitest): `packages/react/src/cells/RichTextCell/__tests__/alt-enter.test.tsx` and `packages/mui/src/cells/__tests__/MuiRichTextCell-alt-enter.test.tsx` cover ALT+ENTER (insert at caret, mid-string replace, idempotence across repeated presses), plain ENTER (commits the draft), and SHIFT+ENTER (does NOT commit — preserves prior multi-line behaviour). All 1952 tests pass.
- End-to-end (Playwright): `e2e/issue-97-richtext-alt-enter.spec.ts` drives the `AllCellTypes` story — enters edit mode, types `line1`, ALT+ENTERs, types `line2`, commits with ENTER, and asserts (a) the textarea mid-flight carries `line1  \nline2`, (b) the cell exits edit mode, (c) the rendered display contains both lines and at least one `<br>`.

## Test plan

- [x] `CAUSLJS_NPM_TOKEN=$(gh auth token) pnpm install`
- [x] `pnpm vitest run packages/` — 1952 passed
- [x] `pnpm exec playwright test e2e/issue-97-richtext-alt-enter.spec.ts` — passes
- [x] Related e2e (`rich-text-floating-menu`, `grid-xss`) — all pass
- [ ] Reviewer verifies on the AllCellTypes story: double-click any rich-text cell, type, ALT+ENTER, type, ENTER → cell shows both lines

Closes #97