### PR TITLE
feat(chips): compound-chip color sub-chip + per-user palette adapter

### DIFF
--- a/e2e/issue-95-compound-chip-color.spec.ts
+++ b/e2e/issue-95-compound-chip-color.spec.ts
@@ -1,0 +1,135 @@
+/**
+ * End-to-end: Issue #95 — compound-chip color sub-chip + picker + per-user
+ * palette.
+ *
+ * Drives the `Examples/Cell Types → AllCellTypes` story, which contains a
+ * `compoundChipList` column populated by `makeData()` in
+ * `stories/CellTypes.stories.tsx`. The chips ship without colors, so the
+ * sub-chip dots render in their empty-state and we have full freedom to
+ * paint them via the picker UI.
+ *
+ * Contract covered:
+ *   1. Display mode shows a color sub-chip per chip; empty-state by default.
+ *   2. Clicking a sub-chip in edit mode opens the picker popover.
+ *   3. Picking a theme swatch updates the chip's sub-chip color.
+ *   4. Picking a custom hex (via the hex input + "Add to palette") fires the
+ *      palette adapter's `write` callback.
+ *   5. Reopening the picker shows the new custom color in the recently-used
+ *      row — proving the read/write round-trip via the in-memory adapter.
+ */
+import { test, expect, type Locator, type Page } from '@playwright/test';
+
+const CELL_TYPES_URL =
+  '/iframe.html?viewMode=story&id=examples-cell-types--all-cell-types';
+
+function chipCell(page: Page, rowId: string): Locator {
+  return page.locator(
+    `[role="gridcell"][data-row-id="${rowId}"][data-field="compoundChipList"]`,
+  );
+}
+
+/**
+ * Doubles-clicks a cell to enter edit mode and waits for the inline edit
+ * surface to surface (the "+ Add" affordance is the most stable signal).
+ */
+async function enterEditMode(cell: Locator): Promise<void> {
+  await cell.click();
+  await cell.dblclick();
+  // The MUI variant labels its add button by text ("+ Add"); the React
+  // variant exposes an aria-label "Add item". Match either by widening the
+  // regex to a substring of the visible label both share.
+  await cell
+    .getByRole('button', { name: /^\+\s*add$|add item/i })
+    .first()
+    .waitFor({ state: 'visible' });
+}
+
+test.describe('Issue #95 — compound-chip color sub-chip + picker', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(CELL_TYPES_URL);
+    await page.locator('[role="grid"]').first().waitFor({ state: 'visible' });
+  });
+
+  test('display mode renders a color sub-chip per chip, in the empty state, when no colors are set', async ({ page }) => {
+    const cell = chipCell(page, '1');
+    await expect(cell).toBeVisible();
+    // Two chips per row (see makeData() in stories/CellTypes.stories.tsx).
+    const subChips = cell.locator('[data-color-sub-chip]');
+    await expect(subChips).toHaveCount(2);
+    // Empty-state encoded as data-color="" on the sub-chip.
+    await expect(subChips.first()).toHaveAttribute('data-color', '');
+    await expect(subChips.nth(1)).toHaveAttribute('data-color', '');
+  });
+
+  test('clicking a color sub-chip in edit mode opens the picker popover', async ({ page }) => {
+    const cell = chipCell(page, '1');
+    await enterEditMode(cell);
+    const subChips = cell.locator('button[data-color-sub-chip]');
+    await expect(subChips.first()).toBeVisible();
+    // Use evaluate so the click goes straight to the React handler bypassing
+    // any visual overlap with adjacent display-mode rows (the AllCellTypes
+    // grid uses a fixed row height that the wrapping chip cell can overflow).
+    await subChips.first().evaluate((el) => (el as HTMLButtonElement).click());
+    await expect(page.getByRole('dialog', { name: /color picker/i })).toBeVisible();
+  });
+
+  test('picking a theme swatch updates the chip sub-chip and the cell commits', async ({ page }) => {
+    const cell = chipCell(page, '1');
+    await enterEditMode(cell);
+    const subChips = cell.locator('button[data-color-sub-chip]');
+    await subChips.first().evaluate((el) => (el as HTMLButtonElement).click());
+    // Theme swatches default to DEFAULT_THEME_COLORS; the red one is #ef4444.
+    const swatch = page.locator('[data-theme-swatch="#ef4444"]');
+    await expect(swatch).toBeVisible();
+    await swatch.click();
+    // Picker closes after a pick.
+    await expect(page.getByRole('dialog', { name: /color picker/i })).not.toBeVisible();
+    // Sub-chip now carries the picked color.
+    await expect(cell.locator('[data-color-sub-chip]').first()).toHaveAttribute(
+      'data-color',
+      '#ef4444',
+    );
+    // Commit the edit — Done button should be visible in the cell.
+    await cell.getByRole('button', { name: /done/i }).click();
+    // After commit we exit edit mode; the display sub-chip should still
+    // carry the color we just picked.
+    await expect(cell.locator('[data-color-sub-chip]').first()).toHaveAttribute(
+      'data-color',
+      '#ef4444',
+    );
+  });
+
+  test('a custom hex color is round-tripped through the palette adapter and re-appears on reopen', async ({ page }) => {
+    const cell = chipCell(page, '2');
+    await enterEditMode(cell);
+
+    // Open the picker on the first chip.
+    const subChip = cell.locator('button[data-color-sub-chip]').first();
+    await subChip.evaluate((el) => (el as HTMLButtonElement).click());
+    await expect(page.getByRole('dialog', { name: /color picker/i })).toBeVisible();
+
+    // Initially the palette is empty — the empty-state indicator is shown.
+    await expect(page.locator('[data-color-picker-empty]')).toBeVisible();
+
+    // Pick a custom hex via the input + Add to palette.
+    const hexInput = page.locator('[data-color-picker-hex-input]');
+    await hexInput.fill('#2563eb');
+    await page.locator('[data-color-picker-add]').click();
+
+    // Picker closes; the chip carries the new color.
+    await expect(page.getByRole('dialog', { name: /color picker/i })).not.toBeVisible();
+    await expect(cell.locator('[data-color-sub-chip]').first()).toHaveAttribute(
+      'data-color',
+      '#2563eb',
+    );
+
+    // Reopen — the in-memory adapter (per-cell default) should now report
+    // the new custom color as a recently-used palette entry.
+    await cell
+      .locator('button[data-color-sub-chip]')
+      .first()
+      .evaluate((el) => (el as HTMLButtonElement).click());
+    await expect(page.getByRole('dialog', { name: /color picker/i })).toBeVisible();
+    await expect(page.locator('[data-palette-swatch="#2563eb"]')).toBeVisible();
+  });
+});

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -297,6 +297,29 @@ export type UploadAttachHandler<TData = Record<string, unknown>> = (
 export type CellType = 'text' | 'calendar' | 'status' | 'tags' | 'compoundChipList' | 'boolean' | 'booleanSelected' | 'password' | 'passwordConfirm' | 'chipSelect' | 'currency' | 'richText' | 'numeric' | 'upload' | 'subGrid' | 'list' | 'actions';
 
 /**
+ * Storage contract for the per-user color palette used by the
+ * {@link CompoundChipListCell} color picker.
+ *
+ * The grid is intentionally storage-agnostic: consumers wire `read` and
+ * `write` to whatever persistence layer they prefer (cookie, localStorage,
+ * IndexedDB, remote backend, etc.). The grid invokes:
+ *
+ *   - `read()` once when a color picker mounts, to hydrate the user's
+ *     recently-used swatches.
+ *   - `write(colors)` whenever the user adds a new custom color, with the
+ *     resulting palette ordered most-recent first.
+ *
+ * Both methods return promises so async backends are first-class. A default
+ * in-memory adapter (per cell instance) is used when none is supplied.
+ */
+export interface PaletteAdapter {
+  /** Returns the user's recent custom colors, ordered most-recent first. */
+  read: () => Promise<string[]>;
+  /** Persists the updated palette. Called when the user picks a new custom color. */
+  write: (colors: string[]) => Promise<void>;
+}
+
+/**
  * Represents a selectable option in status, chip-select, or list columns.
  */
 export interface StatusOption {
@@ -456,6 +479,27 @@ export interface ColumnDef<TData = Record<string, unknown>> {
    * are recommended for a predictable, scannable grid.
    */
   overflow?: OverflowPolicy;
+
+  // Compound chip / color picker
+
+  /**
+   * Default swatches shown above the user palette in the
+   * {@link CompoundChipListCell} color picker. Hex strings, e.g.
+   * `['#ef4444', '#10b981', '#3b82f6']`. A small set of sensible defaults
+   * applies when omitted.
+   */
+  defaultThemeColors?: string[];
+  /**
+   * Persistence contract for the user's recently-picked custom colors.
+   * See {@link PaletteAdapter}. When omitted, the cell uses an in-memory
+   * adapter that resets per cell instance.
+   */
+  paletteAdapter?: PaletteAdapter;
+  /**
+   * Whether the user may pick custom colors via the picker's hex input.
+   * Defaults to `true` when not set.
+   */
+  allowCustomColor?: boolean;
 
   // Sub-grid
 

--- a/packages/mui/src/cells/MuiCompoundChipListCell/MuiCompoundChipListCell.tsx
+++ b/packages/mui/src/cells/MuiCompoundChipListCell/MuiCompoundChipListCell.tsx
@@ -1,20 +1,34 @@
 /**
  * MUI compound chip list cell renderer for the datagrid.
  *
+ * Mirrors the behaviour of the framework-neutral
+ * {@link CompoundChipListCell} from `@iasbuilt/datagrid-react` but renders
+ * the chip and edit affordances with `@mui/material` primitives. The color
+ * picker popover is reused from the React package so both variants share a
+ * single behavioural contract (palette adapter, hex normalization, theme
+ * swatches).
+ *
  * @module MuiCompoundChipListCell
  * @packageDocumentation
  */
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import Chip from '@mui/material/Chip';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import TextField from '@mui/material/TextField';
-import type { CellValue } from '@iasbuilt/datagrid-core';
-import type { CellRendererProps } from '@iasbuilt/datagrid-react';
+import type { CellValue, PaletteAdapter } from '@iasbuilt/datagrid-core';
+import {
+  type CellRendererProps,
+  ColorPickerPopover,
+  applyCustomColorToPalette,
+  createInMemoryPaletteAdapter,
+  DEFAULT_THEME_COLORS,
+} from '@iasbuilt/datagrid-react';
 
 interface ChipItem {
   id: string;
   label: string;
+  color?: string;
   [key: string]: unknown;
 }
 
@@ -35,7 +49,8 @@ function generateId(): string {
 }
 
 /**
- * MUI-based compound chip list cell renderer with inline editing.
+ * MUI-based compound chip list cell renderer with inline editing and a
+ * per-chip color picker.
  */
 export const MuiCompoundChipListCell = React.memo(function MuiCompoundChipListCell<TData = Record<string, unknown>>({
   value,
@@ -48,13 +63,62 @@ export const MuiCompoundChipListCell = React.memo(function MuiCompoundChipListCe
   const [draft, setDraft] = useState<ChipItem[]>(chips);
   const [editingChipId, setEditingChipId] = useState<string | null>(null);
   const [editingLabel, setEditingLabel] = useState('');
+  const [pickerChipId, setPickerChipId] = useState<string | null>(null);
+
+  const paletteAdapter: PaletteAdapter = useMemo(
+    () => (column.paletteAdapter ?? createInMemoryPaletteAdapter()),
+    [column.paletteAdapter],
+  );
+
+  const themeColors = column.defaultThemeColors ?? DEFAULT_THEME_COLORS;
+  const allowCustomColor = column.allowCustomColor !== false;
 
   useEffect(() => {
     if (isEditing) {
       setDraft(parseChips(value));
       setEditingChipId(null);
+      setPickerChipId(null);
     }
   }, [isEditing]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const renderColorSubChip = (chip: ChipItem, interactive: boolean) => {
+    const hasColor = typeof chip.color === 'string' && chip.color.length > 0;
+    const baseStyle: React.CSSProperties = {
+      display: 'inline-block',
+      width: 10,
+      height: 10,
+      borderRadius: '50%',
+      marginRight: 4,
+      verticalAlign: 'middle',
+      border: hasColor ? '1px solid rgba(0,0,0,0.15)' : '1px dashed #9ca3af',
+      background: hasColor ? chip.color : 'transparent',
+    };
+    if (!interactive) {
+      return (
+        <span
+          aria-label={hasColor ? `Color ${chip.color}` : 'No color'}
+          data-color-sub-chip
+          data-chip-id={chip.id}
+          data-color={chip.color ?? ''}
+          style={baseStyle}
+        />
+      );
+    }
+    return (
+      <button
+        type="button"
+        aria-label={hasColor ? `Change color (currently ${chip.color})` : 'Pick color'}
+        data-color-sub-chip
+        data-chip-id={chip.id}
+        data-color={chip.color ?? ''}
+        onClick={(e) => {
+          e.stopPropagation();
+          setPickerChipId((prev) => (prev === chip.id ? null : chip.id));
+        }}
+        style={{ ...baseStyle, padding: 0, cursor: 'pointer' }}
+      />
+    );
+  };
 
   if (!isEditing) {
     return (
@@ -65,7 +129,16 @@ export const MuiCompoundChipListCell = React.memo(function MuiCompoundChipListCe
           </Box>
         ) : (
           chips.map((chip) => (
-            <Chip key={chip.id} label={chip.label} size="small" variant="outlined" sx={{ fontSize: 11 }} />
+            // Render the color sub-chip OUTSIDE the MUI Chip so its
+            // semantic <span>/<button> isn't rewritten by Chip's `icon` slot
+            // (Chip clones the icon and strips event handlers/role data).
+            <Box
+              key={chip.id}
+              sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5 }}
+            >
+              {renderColorSubChip(chip, false)}
+              <Chip label={chip.label} size="small" variant="outlined" sx={{ fontSize: 11 }} />
+            </Box>
           ))
         )}
       </Box>
@@ -74,8 +147,7 @@ export const MuiCompoundChipListCell = React.memo(function MuiCompoundChipListCe
 
   const handleAddChip = () => {
     const newChip: ChipItem = { id: generateId(), label: 'New item' };
-    const next = [...draft, newChip];
-    setDraft(next);
+    setDraft((prev) => [...prev, newChip]);
     setEditingChipId(newChip.id);
     setEditingLabel(newChip.label);
   };
@@ -83,6 +155,7 @@ export const MuiCompoundChipListCell = React.memo(function MuiCompoundChipListCe
   const handleDeleteChip = (id: string) => {
     setDraft((prev) => prev.filter((c) => c.id !== id));
     if (editingChipId === id) setEditingChipId(null);
+    if (pickerChipId === id) setPickerChipId(null);
   };
 
   const commitChipEdit = (id: string) => {
@@ -90,10 +163,24 @@ export const MuiCompoundChipListCell = React.memo(function MuiCompoundChipListCe
     setEditingChipId(null);
   };
 
+  const handlePickColor = async (chipId: string, color: string) => {
+    setDraft((prev) => prev.map((c) => (c.id === chipId ? { ...c, color } : c)));
+    setPickerChipId(null);
+    const inTheme = themeColors.some((t) => t.toLowerCase() === color.toLowerCase());
+    if (inTheme) return;
+    try {
+      const current = await paletteAdapter.read();
+      const next = applyCustomColorToPalette(current, color);
+      await paletteAdapter.write(next);
+    } catch {
+      // Swallow adapter errors so a broken backend doesn't crash editing.
+    }
+  };
+
   const handleCommitAll = () => {
     if (editingChipId) {
       const finalDraft = draft.map((c) =>
-        c.id === editingChipId ? { ...c, label: editingLabel } : c
+        c.id === editingChipId ? { ...c, label: editingLabel } : c,
       );
       onCommit(finalDraft);
     } else {
@@ -102,39 +189,66 @@ export const MuiCompoundChipListCell = React.memo(function MuiCompoundChipListCe
   };
 
   return (
-    <Box onKeyDown={(e) => { if (e.key === 'Escape') onCancel(); }} tabIndex={0} sx={{ outline: 'none' }}>
+    <Box
+      onKeyDown={(e) => {
+        if (e.key === 'Escape') {
+          if (pickerChipId) {
+            setPickerChipId(null);
+            return;
+          }
+          onCancel();
+        }
+      }}
+      tabIndex={0}
+      sx={{ outline: 'none' }}
+    >
       <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, mb: 0.5 }}>
-        {draft.map((chip) =>
-          editingChipId === chip.id ? (
-            <TextField
-              key={chip.id}
-              autoFocus
-              value={editingLabel}
-              onChange={(e) => setEditingLabel(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter') commitChipEdit(chip.id);
-                if (e.key === 'Escape') setEditingChipId(null);
-              }}
-              onBlur={() => commitChipEdit(chip.id)}
-              variant="standard"
-              size="small"
-              slotProps={{ input: { disableUnderline: true } }}
-              sx={{ width: 80, fontSize: 11 }}
-            />
-          ) : (
-            <Chip
-              key={chip.id}
-              label={chip.label}
-              size="small"
-              onClick={() => {
-                setEditingChipId(chip.id);
-                setEditingLabel(chip.label);
-              }}
-              onDelete={() => handleDeleteChip(chip.id)}
-              sx={{ fontSize: 11 }}
-            />
-          )
-        )}
+        {draft.map((chip) => (
+          <Box
+            key={chip.id}
+            sx={{ position: 'relative', display: 'inline-flex', alignItems: 'center', gap: 0.5 }}
+          >
+            {/* Sub-chip lives OUTSIDE the Chip — see display-mode comment for the why. */}
+            {renderColorSubChip(chip, true)}
+            {editingChipId === chip.id ? (
+              <TextField
+                autoFocus
+                value={editingLabel}
+                onChange={(e) => setEditingLabel(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') commitChipEdit(chip.id);
+                  if (e.key === 'Escape') setEditingChipId(null);
+                }}
+                onBlur={() => commitChipEdit(chip.id)}
+                variant="standard"
+                size="small"
+                slotProps={{ input: { disableUnderline: true } }}
+                sx={{ width: 80, fontSize: 11 }}
+              />
+            ) : (
+              <Chip
+                label={chip.label}
+                size="small"
+                onClick={() => {
+                  setEditingChipId(chip.id);
+                  setEditingLabel(chip.label);
+                }}
+                onDelete={() => handleDeleteChip(chip.id)}
+                sx={{ fontSize: 11 }}
+              />
+            )}
+            {pickerChipId === chip.id ? (
+              <ColorPickerPopover
+                currentColor={chip.color ?? null}
+                themeColors={themeColors}
+                paletteAdapter={paletteAdapter}
+                allowCustomColor={allowCustomColor}
+                onPick={(color) => handlePickColor(chip.id, color)}
+                onClose={() => setPickerChipId(null)}
+              />
+            ) : null}
+          </Box>
+        ))}
         <Button size="small" variant="outlined" onClick={handleAddChip} sx={{ fontSize: 11, minWidth: 0, px: 1 }}>
           + Add
         </Button>

--- a/packages/react/src/cells/CompoundChipListCell/ColorPickerPopover.tsx
+++ b/packages/react/src/cells/CompoundChipListCell/ColorPickerPopover.tsx
@@ -1,0 +1,308 @@
+/**
+ * Color picker popover used by the {@link CompoundChipListCell} color
+ * sub-chip. Renders three rows of swatches and an optional hex input:
+ *
+ *   1. Recently-used user palette (hydrated via {@link PaletteAdapter.read})
+ *   2. Default theme swatches (per-column `defaultThemeColors`)
+ *   3. Hex input + "Add to palette" — only when `allowCustomColor` is on
+ *
+ * The popover is intentionally framework-agnostic: it renders plain DOM and
+ * inline styles so the MUI variant can reuse it without dragging MUI into
+ * the React package's surface area.
+ *
+ * Contract:
+ *   - `onPick(color)` fires when the user clicks a swatch OR commits a hex
+ *     value via "Add to palette". The grid uses this to update the chip and
+ *     to call {@link PaletteAdapter.write} when the color is a new custom
+ *     one (i.e. not present in `defaultThemeColors` or the current palette).
+ *
+ * @module ColorPickerPopover
+ */
+import React, { useEffect, useState, useRef } from 'react';
+import type { PaletteAdapter } from '@iasbuilt/datagrid-core';
+
+/** Maximum number of recently-used colors retained in the palette. */
+export const PALETTE_MAX = 8;
+
+/** Sensible default theme swatches used when a column omits `defaultThemeColors`. */
+export const DEFAULT_THEME_COLORS: string[] = [
+  '#ef4444',
+  '#f59e0b',
+  '#10b981',
+  '#3b82f6',
+  '#8b5cf6',
+  '#ec4899',
+  '#6b7280',
+  '#111827',
+];
+
+/**
+ * Normalizes a user-typed hex string to the canonical lowercase 6-digit form
+ * (e.g. `"#ABC"` → `"#aabbcc"`, `"abcdef"` → `"#abcdef"`). Returns `null`
+ * when the input is not a valid 3- or 6-digit hex color so callers can keep
+ * the input open for correction.
+ */
+export function normalizeHex(input: string): string | null {
+  let v = input.trim().toLowerCase();
+  if (!v.startsWith('#')) v = '#' + v;
+  // 3-digit shorthand → 6-digit
+  if (/^#[0-9a-f]{3}$/.test(v)) {
+    v = '#' + v.slice(1).split('').map((c) => c + c).join('');
+  }
+  return /^#[0-9a-f]{6}$/.test(v) ? v : null;
+}
+
+/**
+ * Pure helper: returns the palette that should be persisted after a new
+ * custom color is picked. Existing entries float to the front; the list is
+ * deduped and capped at {@link PALETTE_MAX}.
+ */
+export function applyCustomColorToPalette(palette: string[], color: string): string[] {
+  const next = [color, ...palette.filter((c) => c.toLowerCase() !== color.toLowerCase())];
+  return next.slice(0, PALETTE_MAX);
+}
+
+/**
+ * Returns a default in-memory {@link PaletteAdapter} bound to a single
+ * mutable slot. Each cell instance gets its own when no adapter is wired by
+ * the column, so palette state is preserved across picker open/close while
+ * the cell is mounted but resets across page reloads — the documented
+ * fallback behaviour when a consumer opts out of persistence.
+ */
+export function createInMemoryPaletteAdapter(initial: string[] = []): PaletteAdapter {
+  let store = initial.slice(0, PALETTE_MAX);
+  return {
+    read: async () => store.slice(),
+    write: async (colors) => {
+      store = colors.slice(0, PALETTE_MAX);
+    },
+  };
+}
+
+export interface ColorPickerPopoverProps {
+  /** Currently-selected chip color, or `null` when the chip has no color. */
+  currentColor: string | null;
+  /** Theme swatches for the static row. */
+  themeColors?: string[];
+  /** Storage adapter for the per-user palette. */
+  paletteAdapter?: PaletteAdapter;
+  /** Whether the hex input + "Add to palette" affordance is shown. */
+  allowCustomColor?: boolean;
+  /** Invoked when the user selects any color (theme, palette, or custom). */
+  onPick: (color: string) => void;
+  /** Invoked when the user dismisses the popover (Escape, click-out). */
+  onClose: () => void;
+}
+
+/**
+ * Renders the color picker popover. Self-contained: handles its own palette
+ * fetch, hex validation, and click-outside dismissal.
+ */
+export function ColorPickerPopover({
+  currentColor,
+  themeColors,
+  paletteAdapter,
+  allowCustomColor = true,
+  onPick,
+  onClose,
+}: ColorPickerPopoverProps) {
+  const [palette, setPalette] = useState<string[]>([]);
+  const [hexDraft, setHexDraft] = useState<string>(currentColor ?? '');
+  const [hexError, setHexError] = useState<string | null>(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  // Hydrate the palette on mount via the adapter. We deliberately swallow
+  // adapter errors and fall back to an empty palette so a misbehaving
+  // backend doesn't take the picker down with it.
+  useEffect(() => {
+    let cancelled = false;
+    if (!paletteAdapter) return;
+    paletteAdapter
+      .read()
+      .then((colors) => {
+        if (!cancelled) setPalette(colors.slice(0, PALETTE_MAX));
+      })
+      .catch(() => {
+        if (!cancelled) setPalette([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [paletteAdapter]);
+
+  // Dismiss on outside click. Pointer-down catches the gesture before any
+  // focus shifts the popover into a stale state.
+  useEffect(() => {
+    function handlePointerDown(e: PointerEvent) {
+      if (!containerRef.current) return;
+      if (e.target instanceof Node && !containerRef.current.contains(e.target)) {
+        onClose();
+      }
+    }
+    document.addEventListener('pointerdown', handlePointerDown);
+    return () => document.removeEventListener('pointerdown', handlePointerDown);
+  }, [onClose]);
+
+  const theme = themeColors ?? DEFAULT_THEME_COLORS;
+
+  const handleSwatchClick = (color: string) => {
+    onPick(color);
+  };
+
+  const handleAddToPalette = () => {
+    const normalized = normalizeHex(hexDraft);
+    if (!normalized) {
+      setHexError('Enter a valid hex color (e.g. #3b82f6)');
+      return;
+    }
+    setHexError(null);
+    onPick(normalized);
+  };
+
+  const handleHexKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      handleAddToPalette();
+    }
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      onClose();
+    }
+  };
+
+  return (
+    <div
+      ref={containerRef}
+      role="dialog"
+      aria-label="Color picker"
+      data-color-picker-popover
+      style={{
+        position: 'absolute',
+        zIndex: 1000,
+        top: '100%',
+        left: 0,
+        marginTop: 4,
+        background: '#fff',
+        border: '1px solid #d1d5db',
+        borderRadius: 6,
+        padding: 8,
+        boxShadow: '0 4px 12px rgba(0,0,0,0.12)',
+        minWidth: 180,
+      }}
+    >
+      <div style={{ fontSize: 10, fontWeight: 600, color: '#6b7280', marginBottom: 4 }}>
+        Recently used
+      </div>
+      <div
+        data-color-picker-section="palette"
+        style={{ display: 'flex', flexWrap: 'wrap', gap: 4, marginBottom: 8, minHeight: 18 }}
+      >
+        {palette.length === 0 ? (
+          <span style={{ fontSize: 10, color: '#9ca3af' }} data-color-picker-empty>
+            No recent colors
+          </span>
+        ) : (
+          palette.map((c) => (
+            <button
+              key={`p-${c}`}
+              type="button"
+              aria-label={`Palette color ${c}`}
+              data-palette-swatch={c}
+              onClick={() => handleSwatchClick(c)}
+              style={{
+                width: 16,
+                height: 16,
+                borderRadius: 4,
+                border: '1px solid #d1d5db',
+                background: c,
+                cursor: 'pointer',
+                padding: 0,
+              }}
+            />
+          ))
+        )}
+      </div>
+
+      <div style={{ fontSize: 10, fontWeight: 600, color: '#6b7280', marginBottom: 4 }}>
+        Theme colors
+      </div>
+      <div
+        data-color-picker-section="theme"
+        style={{ display: 'flex', flexWrap: 'wrap', gap: 4, marginBottom: 8 }}
+      >
+        {theme.map((c) => (
+          <button
+            key={`t-${c}`}
+            type="button"
+            aria-label={`Theme color ${c}`}
+            data-theme-swatch={c}
+            onClick={() => handleSwatchClick(c)}
+            style={{
+              width: 16,
+              height: 16,
+              borderRadius: 4,
+              border: '1px solid #d1d5db',
+              background: c,
+              cursor: 'pointer',
+              padding: 0,
+            }}
+          />
+        ))}
+      </div>
+
+      {allowCustomColor ? (
+        <div data-color-picker-section="custom">
+          <div style={{ fontSize: 10, fontWeight: 600, color: '#6b7280', marginBottom: 4 }}>
+            Custom color
+          </div>
+          <div style={{ display: 'flex', gap: 4, alignItems: 'center' }}>
+            <input
+              aria-label="Hex color"
+              data-color-picker-hex-input
+              value={hexDraft}
+              onChange={(e) => {
+                setHexDraft(e.target.value);
+                if (hexError) setHexError(null);
+              }}
+              onKeyDown={handleHexKeyDown}
+              placeholder="#3b82f6"
+              style={{
+                flex: 1,
+                fontSize: 11,
+                padding: '2px 4px',
+                border: '1px solid #d1d5db',
+                borderRadius: 4,
+                outline: 'none',
+                fontFamily: 'monospace',
+              }}
+            />
+            <button
+              type="button"
+              data-color-picker-add
+              onClick={handleAddToPalette}
+              style={{
+                fontSize: 11,
+                padding: '2px 8px',
+                border: '1px solid #d1d5db',
+                borderRadius: 4,
+                background: '#f9fafb',
+                cursor: 'pointer',
+              }}
+            >
+              Add to palette
+            </button>
+          </div>
+          {hexError ? (
+            <div
+              role="alert"
+              data-color-picker-hex-error
+              style={{ fontSize: 10, color: '#ef4444', marginTop: 2 }}
+            >
+              {hexError}
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/react/src/cells/CompoundChipListCell/CompoundChipListCell.tsx
+++ b/packages/react/src/cells/CompoundChipListCell/CompoundChipListCell.tsx
@@ -1,28 +1,42 @@
 /**
  * CompoundChipListCell module for the datagrid component library.
  *
- * Provides a cell renderer for managing a list of compound chip objects, each carrying
- * an `id` and a user-editable `label`. In display mode, chips render as compact badges.
- * In edit mode, chips can be individually renamed (via click-to-edit), removed, or
- * created, with explicit "Done" and "Cancel" buttons to control commit/discard flow.
+ * Provides a cell renderer for managing a list of compound chip objects, each
+ * carrying an `id`, user-editable `label`, and optional `color`. In display
+ * mode, chips render as compact badges with a small color sub-chip (a coloured
+ * dot) next to the label. In edit mode, chips can be individually renamed,
+ * removed, recoloured via a popover color picker, or created.
+ *
+ * The color picker exposes a per-user palette via the column-level
+ * {@link PaletteAdapter} contract: consumers wire their own storage
+ * (cookie/localStorage/backend) so the grid itself stays storage-agnostic.
  *
  * @module CompoundChipListCell
  */
-import React, { useState, useEffect } from 'react';
-import type { CellValue, ColumnDef } from '@iasbuilt/datagrid-core';
+import React, { useState, useEffect, useMemo } from 'react';
+import type { CellValue, ColumnDef, PaletteAdapter } from '@iasbuilt/datagrid-core';
 import * as styles from './CompoundChipListCell.styles';
+import {
+  ColorPickerPopover,
+  applyCustomColorToPalette,
+  createInMemoryPaletteAdapter,
+  DEFAULT_THEME_COLORS,
+} from './ColorPickerPopover';
 
 /**
  * Represents a single chip item within the compound chip list.
  *
- * Each chip carries a unique identifier, a user-visible label, and may
- * include arbitrary additional properties for domain-specific metadata.
+ * Each chip carries a unique identifier, a user-visible label, an optional
+ * color (hex/rgb), and may include arbitrary additional properties for
+ * domain-specific metadata.
  */
 export interface ChipItem {
   /** Unique identifier for the chip, used as a React key and for targeted updates. */
   id: string;
   /** The human-readable text displayed on the chip badge. */
   label: string;
+  /** Optional color shown as a small sub-chip next to the label. */
+  color?: string;
   /** Arbitrary extra properties attached to the chip for domain-specific use. */
   [key: string]: unknown;
 }
@@ -81,30 +95,10 @@ function generateId(): string {
 }
 
 /**
- * A datagrid cell renderer for compound chip lists with inline label editing.
- *
- * Each chip is an object with an `id` and `label`. In display mode, chips appear
- * as static badges. In edit mode, clicking a chip opens an inline text input for
- * renaming; chips can be added via the "+ Add" button and removed individually.
- * Explicit "Done" and "Cancel" buttons govern the commit/discard lifecycle.
+ * A datagrid cell renderer for compound chip lists with inline label editing
+ * and per-chip color selection via a popover picker.
  *
  * @typeParam TData - Row data shape, defaults to `Record<string, unknown>`.
- *
- * @param props - The component props conforming to {@link CompoundChipListCellProps}.
- * @returns A React element rendering the chip list in either display or edit mode.
- *
- * @example
- * ```tsx
- * <CompoundChipListCell
- *   value={[{ id: 'a', label: 'Alpha' }, { id: 'b', label: 'Beta' }]}
- *   row={rowData}
- *   column={columnDef}
- *   rowIndex={0}
- *   isEditing={true}
- *   onCommit={handleCommit}
- *   onCancel={handleCancel}
- * />
- * ```
  */
 export const CompoundChipListCell = React.memo(function CompoundChipListCell<TData = Record<string, unknown>>({
   value,
@@ -118,82 +112,90 @@ export const CompoundChipListCell = React.memo(function CompoundChipListCell<TDa
   const [draft, setDraft] = useState<ChipItem[]>(chips);
   const [editingChipId, setEditingChipId] = useState<string | null>(null);
   const [editingLabel, setEditingLabel] = useState('');
+  const [pickerChipId, setPickerChipId] = useState<string | null>(null);
+
+  // Resolve the palette adapter exactly once per cell instance so the
+  // in-memory fallback maintains its store across picker open/close cycles.
+  // Resolution precedence: column-supplied adapter > per-cell in-memory.
+  const paletteAdapter: PaletteAdapter = useMemo(
+    () => (column.paletteAdapter ?? createInMemoryPaletteAdapter()),
+    [column.paletteAdapter],
+  );
+
+  const themeColors = column.defaultThemeColors ?? DEFAULT_THEME_COLORS;
+  const allowCustomColor = column.allowCustomColor !== false;
 
   // Re-initialize the draft from the source value each time editing begins
   useEffect(() => {
     if (isEditing) {
       setDraft(parseChips(value));
       setEditingChipId(null);
+      setPickerChipId(null);
     }
   }, [isEditing]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  /**
-   * Creates a new chip with a default label and immediately enters rename mode.
-   */
+  /** Adds a chip and immediately enters rename mode for the new chip. */
   const handleAddChip = () => {
     const newChip: ChipItem = { id: generateId(), label: 'New item' };
-    const next = [...draft, newChip];
-    setDraft(next);
-    // Immediately enter inline-edit for the newly created chip
+    setDraft((prev) => [...prev, newChip]);
     setEditingChipId(newChip.id);
     setEditingLabel(newChip.label);
   };
 
-  /**
-   * Removes a chip by its identifier and clears inline-edit state if it was active.
-   *
-   * @param id - The identifier of the chip to remove.
-   */
+  /** Removes a chip from the draft array. */
   const handleDeleteChip = (id: string) => {
-    const next = draft.filter((c) => c.id !== id);
-    setDraft(next);
-    // Reset inline-edit if the deleted chip was being edited
+    setDraft((prev) => prev.filter((c) => c.id !== id));
     if (editingChipId === id) setEditingChipId(null);
+    if (pickerChipId === id) setPickerChipId(null);
   };
 
-  /**
-   * Activates inline label editing for a specific chip when clicked in edit mode.
-   *
-   * @param chip - The chip item that was clicked.
-   */
+  /** Activates inline label editing for a specific chip. */
   const handleChipClick = (chip: ChipItem) => {
     if (!isEditing) return;
     setEditingChipId(chip.id);
     setEditingLabel(chip.label);
   };
 
-  /**
-   * Handles keyboard events within the inline chip label input.
-   * Enter confirms the rename; Escape discards it.
-   *
-   * @param e - The keyboard event.
-   * @param id - The identifier of the chip being renamed.
-   */
+  /** Handles keyboard events within the inline chip label input. */
   const handleLabelKeyDown = (e: React.KeyboardEvent, id: string) => {
     if (e.key === 'Enter') commitChipEdit(id);
     if (e.key === 'Escape') setEditingChipId(null);
   };
 
-  /**
-   * Applies the current label input value to the target chip in the draft array.
-   *
-   * @param id - The identifier of the chip whose label should be updated.
-   */
+  /** Applies the current label input value to the target chip. */
   const commitChipEdit = (id: string) => {
     setDraft((prev) =>
-      prev.map((c) => (c.id === id ? { ...c, label: editingLabel } : c))
+      prev.map((c) => (c.id === id ? { ...c, label: editingLabel } : c)),
     );
     setEditingChipId(null);
   };
 
   /**
-   * Commits the entire draft chip list, folding in any in-progress label edit first.
+   * Updates the color of a chip and, when the color is a brand-new custom
+   * value (i.e. not already in the theme set or the persisted palette),
+   * routes it through the palette adapter's `write` hook so the user's
+   * recently-used list reflects it on the next picker open.
    */
+  const handlePickColor = async (chipId: string, color: string) => {
+    setDraft((prev) => prev.map((c) => (c.id === chipId ? { ...c, color } : c)));
+    setPickerChipId(null);
+
+    const inTheme = themeColors.some((t) => t.toLowerCase() === color.toLowerCase());
+    if (inTheme) return;
+    try {
+      const current = await paletteAdapter.read();
+      const next = applyCustomColorToPalette(current, color);
+      await paletteAdapter.write(next);
+    } catch {
+      // Swallow adapter errors so a broken backend doesn't crash editing.
+    }
+  };
+
+  /** Commits the entire draft chip list, folding any in-progress edit first. */
   const handleCommitAll = () => {
     if (editingChipId) {
-      // Save any in-progress chip edit first
       const finalDraft = draft.map((c) =>
-        c.id === editingChipId ? { ...c, label: editingLabel } : c
+        c.id === editingChipId ? { ...c, label: editingLabel } : c,
       );
       onCommit(finalDraft);
     } else {
@@ -201,18 +203,64 @@ export const CompoundChipListCell = React.memo(function CompoundChipListCell<TDa
     }
   };
 
-  /**
-   * Handles top-level keyboard shortcuts for the edit container.
-   * Escape cancels editing; Enter (when no chip is being renamed) commits.
-   *
-   * @param e - The keyboard event.
-   */
+  /** Container-level shortcuts: Escape cancels, Enter commits (when idle). */
   const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Escape') onCancel();
-    if (e.key === 'Enter' && editingChipId === null) handleCommitAll();
+    if (e.key === 'Escape') {
+      if (pickerChipId) {
+        setPickerChipId(null);
+        return;
+      }
+      onCancel();
+    }
+    if (e.key === 'Enter' && editingChipId === null && pickerChipId === null) {
+      handleCommitAll();
+    }
   };
 
-  // Display mode: render chips as static read-only badges
+  /**
+   * Renders the small color sub-chip beside a chip label. In display mode
+   * it's a static dot; in edit mode it's a button that opens the picker.
+   */
+  const renderColorSubChip = (chip: ChipItem, interactive: boolean) => {
+    const hasColor = typeof chip.color === 'string' && chip.color.length > 0;
+    const commonStyle: React.CSSProperties = {
+      display: 'inline-block',
+      width: 10,
+      height: 10,
+      borderRadius: '50%',
+      marginRight: 4,
+      verticalAlign: 'middle',
+      border: hasColor ? '1px solid rgba(0,0,0,0.15)' : '1px dashed #9ca3af',
+      background: hasColor ? chip.color : 'transparent',
+    };
+    if (!interactive) {
+      return (
+        <span
+          aria-label={hasColor ? `Color ${chip.color}` : 'No color'}
+          data-color-sub-chip
+          data-chip-id={chip.id}
+          data-color={chip.color ?? ''}
+          style={commonStyle}
+        />
+      );
+    }
+    return (
+      <button
+        type="button"
+        aria-label={hasColor ? `Change color (currently ${chip.color})` : 'Pick color'}
+        data-color-sub-chip
+        data-chip-id={chip.id}
+        data-color={chip.color ?? ''}
+        onClick={(e) => {
+          e.stopPropagation();
+          setPickerChipId((prev) => (prev === chip.id ? null : chip.id));
+        }}
+        style={{ ...commonStyle, padding: 0, cursor: 'pointer' }}
+      />
+    );
+  };
+
+  // Display mode: render chips as static read-only badges with color sub-chip
   if (!isEditing) {
     return (
       <div style={styles.displayContainer}>
@@ -220,10 +268,8 @@ export const CompoundChipListCell = React.memo(function CompoundChipListCell<TDa
           <span style={styles.placeholder}>{column.placeholder ?? 'No items'}</span>
         ) : (
           chips.map((chip) => (
-            <span
-              key={chip.id}
-              style={styles.displayChip}
-            >
+            <span key={chip.id} style={styles.displayChip}>
+              {renderColorSubChip(chip, false)}
               {chip.label}
             </span>
           ))
@@ -232,16 +278,16 @@ export const CompoundChipListCell = React.memo(function CompoundChipListCell<TDa
     );
   }
 
-  // Edit mode: render chips with inline rename input, remove buttons, and action bar
+  // Edit mode: render chips with inline rename input + color picker controls
   return (
     <div onKeyDown={handleKeyDown} tabIndex={0} style={styles.editWrapper}>
-      {/* Chip badges with click-to-edit and remove controls */}
       <div style={styles.editChipContainer}>
         {draft.map((chip) => (
           <span
             key={chip.id}
-            style={styles.editChip(editingChipId === chip.id)}
+            style={{ ...styles.editChip(editingChipId === chip.id), position: 'relative' }}
           >
+            {renderColorSubChip(chip, true)}
             {editingChipId === chip.id ? (
               <input
                 autoFocus
@@ -252,10 +298,7 @@ export const CompoundChipListCell = React.memo(function CompoundChipListCell<TDa
                 style={styles.chipLabelInput}
               />
             ) : (
-              <span
-                onClick={() => handleChipClick(chip)}
-                style={styles.chipLabelText}
-              >
+              <span onClick={() => handleChipClick(chip)} style={styles.chipLabelText}>
                 {chip.label}
               </span>
             )}
@@ -267,6 +310,16 @@ export const CompoundChipListCell = React.memo(function CompoundChipListCell<TDa
             >
               ×
             </button>
+            {pickerChipId === chip.id ? (
+              <ColorPickerPopover
+                currentColor={chip.color ?? null}
+                themeColors={themeColors}
+                paletteAdapter={paletteAdapter}
+                allowCustomColor={allowCustomColor}
+                onPick={(color) => handlePickColor(chip.id, color)}
+                onClose={() => setPickerChipId(null)}
+              />
+            ) : null}
           </span>
         ))}
         <button
@@ -278,20 +331,11 @@ export const CompoundChipListCell = React.memo(function CompoundChipListCell<TDa
           + Add
         </button>
       </div>
-      {/* Action bar with Done and Cancel buttons */}
       <div style={styles.actionBar}>
-        <button
-          type="button"
-          onClick={handleCommitAll}
-          style={styles.actionButton}
-        >
+        <button type="button" onClick={handleCommitAll} style={styles.actionButton}>
           Done
         </button>
-        <button
-          type="button"
-          onClick={onCancel}
-          style={styles.actionButton}
-        >
+        <button type="button" onClick={onCancel} style={styles.actionButton}>
           Cancel
         </button>
       </div>

--- a/packages/react/src/cells/CompoundChipListCell/__tests__/ColorPickerPopover.test.tsx
+++ b/packages/react/src/cells/CompoundChipListCell/__tests__/ColorPickerPopover.test.tsx
@@ -1,0 +1,230 @@
+/**
+ * Unit tests for the {@link ColorPickerPopover} component and its supporting
+ * helpers ({@link normalizeHex}, {@link applyCustomColorToPalette},
+ * {@link createInMemoryPaletteAdapter}). These exercise the palette-adapter
+ * contract end-to-end without dragging the full chip cell into scope.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import React from 'react';
+
+import {
+  ColorPickerPopover,
+  applyCustomColorToPalette,
+  createInMemoryPaletteAdapter,
+  normalizeHex,
+  PALETTE_MAX,
+  DEFAULT_THEME_COLORS,
+} from '../ColorPickerPopover';
+import type { PaletteAdapter } from '@iasbuilt/datagrid-core';
+
+// ---------------------------------------------------------------------------
+// normalizeHex
+// ---------------------------------------------------------------------------
+
+describe('normalizeHex', () => {
+  it('accepts 6-digit hex with hash', () => {
+    expect(normalizeHex('#ABCDEF')).toBe('#abcdef');
+  });
+
+  it('accepts 6-digit hex without hash', () => {
+    expect(normalizeHex('abcdef')).toBe('#abcdef');
+  });
+
+  it('expands 3-digit shorthand to 6-digit form', () => {
+    expect(normalizeHex('#abc')).toBe('#aabbcc');
+  });
+
+  it('rejects invalid input', () => {
+    expect(normalizeHex('not-a-color')).toBeNull();
+    expect(normalizeHex('#zzz')).toBeNull();
+    expect(normalizeHex('')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyCustomColorToPalette
+// ---------------------------------------------------------------------------
+
+describe('applyCustomColorToPalette', () => {
+  it('prepends a new color', () => {
+    expect(applyCustomColorToPalette(['#111111'], '#222222')).toEqual([
+      '#222222',
+      '#111111',
+    ]);
+  });
+
+  it('dedupes case-insensitively and floats the entry to the front', () => {
+    expect(applyCustomColorToPalette(['#111111', '#222222'], '#222222')).toEqual([
+      '#222222',
+      '#111111',
+    ]);
+    expect(applyCustomColorToPalette(['#aaaaaa'], '#AAAAAA')).toEqual(['#AAAAAA']);
+  });
+
+  it('caps the palette at PALETTE_MAX entries', () => {
+    const huge = Array.from({ length: PALETTE_MAX + 5 }, (_, i) =>
+      `#${i.toString(16).padStart(6, '0')}`,
+    );
+    const result = applyCustomColorToPalette(huge, '#abcdef');
+    expect(result).toHaveLength(PALETTE_MAX);
+    expect(result[0]).toBe('#abcdef');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createInMemoryPaletteAdapter
+// ---------------------------------------------------------------------------
+
+describe('createInMemoryPaletteAdapter', () => {
+  it('round-trips colors through read/write', async () => {
+    const adapter = createInMemoryPaletteAdapter();
+    expect(await adapter.read()).toEqual([]);
+    await adapter.write(['#abcdef', '#123456']);
+    expect(await adapter.read()).toEqual(['#abcdef', '#123456']);
+  });
+
+  it('respects the PALETTE_MAX cap on write', async () => {
+    const adapter = createInMemoryPaletteAdapter();
+    const huge = Array.from({ length: PALETTE_MAX + 5 }, (_, i) =>
+      `#${i.toString(16).padStart(6, '0')}`,
+    );
+    await adapter.write(huge);
+    expect(await adapter.read()).toHaveLength(PALETTE_MAX);
+  });
+
+  it('honors an initial palette', async () => {
+    const adapter = createInMemoryPaletteAdapter(['#111111']);
+    expect(await adapter.read()).toEqual(['#111111']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ColorPickerPopover
+// ---------------------------------------------------------------------------
+
+describe('ColorPickerPopover', () => {
+  function renderPopover(overrides: Partial<{
+    paletteAdapter: PaletteAdapter;
+    onPick: (c: string) => void;
+    onClose: () => void;
+    themeColors: string[];
+    allowCustomColor: boolean;
+    currentColor: string | null;
+  }> = {}) {
+    const onPick = overrides.onPick ?? vi.fn();
+    const onClose = overrides.onClose ?? vi.fn();
+    const utils = render(
+      <ColorPickerPopover
+        currentColor={overrides.currentColor ?? null}
+        themeColors={overrides.themeColors}
+        paletteAdapter={overrides.paletteAdapter}
+        allowCustomColor={overrides.allowCustomColor}
+        onPick={onPick}
+        onClose={onClose}
+      />,
+    );
+    return { ...utils, onPick, onClose };
+  }
+
+  it('renders one button per theme color', () => {
+    renderPopover({ themeColors: ['#111111', '#222222'] });
+    expect(screen.getAllByRole('button', { name: /theme color/i })).toHaveLength(2);
+  });
+
+  it('uses the DEFAULT_THEME_COLORS when no themeColors prop is provided', () => {
+    renderPopover();
+    expect(screen.getAllByRole('button', { name: /theme color/i })).toHaveLength(
+      DEFAULT_THEME_COLORS.length,
+    );
+  });
+
+  it('fires onPick with the swatch color when a theme swatch is clicked', () => {
+    const onPick = vi.fn();
+    renderPopover({ themeColors: ['#ef4444'], onPick });
+    fireEvent.click(screen.getByRole('button', { name: 'Theme color #ef4444' }));
+    expect(onPick).toHaveBeenCalledWith('#ef4444');
+  });
+
+  it('renders the empty-state indicator when the palette is empty', async () => {
+    renderPopover();
+    expect(await screen.findByText(/no recent colors/i)).toBeInTheDocument();
+  });
+
+  it('hydrates palette swatches from the adapter on mount', async () => {
+    const adapter = createInMemoryPaletteAdapter(['#abcdef', '#123456']);
+    renderPopover({ paletteAdapter: adapter });
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Palette color #abcdef' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Palette color #123456' })).toBeInTheDocument();
+    });
+  });
+
+  it('shows a hex input and Add button when allowCustomColor is unset (default true)', () => {
+    renderPopover();
+    expect(screen.getByLabelText(/hex color/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /add to palette/i })).toBeInTheDocument();
+  });
+
+  it('hides the custom color section when allowCustomColor is false', () => {
+    renderPopover({ allowCustomColor: false });
+    expect(screen.queryByLabelText(/hex color/i)).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /add to palette/i })).not.toBeInTheDocument();
+  });
+
+  it('fires onPick with the normalized hex when Add to palette is clicked', () => {
+    const onPick = vi.fn();
+    renderPopover({ onPick });
+    fireEvent.change(screen.getByLabelText(/hex color/i), { target: { value: 'ABCDEF' } });
+    fireEvent.click(screen.getByRole('button', { name: /add to palette/i }));
+    expect(onPick).toHaveBeenCalledWith('#abcdef');
+  });
+
+  it('shows an inline error and does NOT fire onPick when the hex is invalid', () => {
+    const onPick = vi.fn();
+    renderPopover({ onPick });
+    fireEvent.change(screen.getByLabelText(/hex color/i), { target: { value: 'nope' } });
+    fireEvent.click(screen.getByRole('button', { name: /add to palette/i }));
+    expect(onPick).not.toHaveBeenCalled();
+    expect(screen.getByRole('alert')).toHaveTextContent(/valid hex/i);
+  });
+
+  it('commits the hex on Enter inside the hex input', () => {
+    const onPick = vi.fn();
+    renderPopover({ onPick });
+    const input = screen.getByLabelText(/hex color/i);
+    fireEvent.change(input, { target: { value: '#3b82f6' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(onPick).toHaveBeenCalledWith('#3b82f6');
+  });
+
+  it('closes on Escape inside the hex input', () => {
+    const onClose = vi.fn();
+    renderPopover({ onClose });
+    const input = screen.getByLabelText(/hex color/i);
+    fireEvent.keyDown(input, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('closes when the user clicks outside the popover', async () => {
+    const onClose = vi.fn();
+    renderPopover({ onClose });
+    // jsdom doesn't ship a PointerEvent constructor; the popover listens for
+    // `pointerdown` by name so a generic Event with the right type suffices.
+    await act(async () => {
+      const evt = new Event('pointerdown', { bubbles: true });
+      document.dispatchEvent(evt);
+    });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('treats palette read failures as an empty palette', async () => {
+    const broken: PaletteAdapter = {
+      read: vi.fn().mockRejectedValue(new Error('storage down')),
+      write: vi.fn(),
+    };
+    renderPopover({ paletteAdapter: broken });
+    // Should fall back to the empty-state indicator rather than throwing.
+    expect(await screen.findByText(/no recent colors/i)).toBeInTheDocument();
+  });
+});

--- a/packages/react/src/cells/CompoundChipListCell/__tests__/CompoundChipListCell.test.tsx
+++ b/packages/react/src/cells/CompoundChipListCell/__tests__/CompoundChipListCell.test.tsx
@@ -1,9 +1,9 @@
 import { vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import React from 'react';
 
 import { CompoundChipListCell } from '../CompoundChipListCell';
-import type { ColumnDef, CellValue } from '@iasbuilt/datagrid-core';
+import type { ColumnDef, CellValue, PaletteAdapter } from '@iasbuilt/datagrid-core';
 
 // ---------------------------------------------------------------------------
 // Shared helpers
@@ -124,5 +124,102 @@ describe('CompoundChipListCell', () => {
     fireEvent.change(input, { target: { value: 'Updated' } });
     fireEvent.keyDown(input, { key: 'Enter' });
     expect(screen.getByText('Updated')).toBeInTheDocument();
+  });
+
+  // -------------------------------------------------------------------------
+  // Issue #95 — color sub-chip + picker
+  // -------------------------------------------------------------------------
+
+  it('renders an empty-state color sub-chip when no chip has a color', () => {
+    const { container } = render(
+      <CompoundChipListCell {...makeProps({ value: chipItems })} />,
+    );
+    const subChips = container.querySelectorAll<HTMLElement>('[data-color-sub-chip]');
+    expect(subChips).toHaveLength(chipItems.length);
+    // Empty state: data-color attribute is the empty string and no inline
+    // background is set on the dot.
+    for (const dot of subChips) {
+      expect(dot.dataset.color).toBe('');
+    }
+  });
+
+  it('renders a colored sub-chip when the chip has a color', () => {
+    const colored = [{ id: 'c1', label: 'Red', color: '#ef4444' }];
+    const { container } = render(
+      <CompoundChipListCell {...makeProps({ value: colored })} />,
+    );
+    const dot = container.querySelector<HTMLElement>('[data-color-sub-chip]');
+    expect(dot).not.toBeNull();
+    expect(dot!.dataset.color).toBe('#ef4444');
+  });
+
+  it('opens the picker popover when the color sub-chip is clicked in edit mode', () => {
+    render(<CompoundChipListCell {...makeProps({ isEditing: true, value: chipItems })} />);
+    const subChips = screen.getAllByRole('button', { name: /pick color|change color/i });
+    fireEvent.click(subChips[0]!);
+    expect(screen.getByRole('dialog', { name: /color picker/i })).toBeInTheDocument();
+  });
+
+  it('updates the chip color and routes custom colors through the palette adapter', async () => {
+    const onCommit = vi.fn();
+    const writeCalls: string[][] = [];
+    const adapter: PaletteAdapter = {
+      read: vi.fn().mockResolvedValue([]),
+      write: vi.fn().mockImplementation(async (c) => {
+        writeCalls.push(c);
+      }),
+    };
+    render(
+      <CompoundChipListCell
+        {...makeProps({
+          isEditing: true,
+          value: chipItems,
+          onCommit,
+          column: { paletteAdapter: adapter, defaultThemeColors: ['#000000'] },
+        })}
+      />,
+    );
+
+    // Open picker on the first chip
+    const subChips = screen.getAllByRole('button', { name: /pick color|change color/i });
+    fireEvent.click(subChips[0]!);
+
+    // Type a custom hex and add to palette
+    const hexInput = screen.getByLabelText(/hex color/i);
+    fireEvent.change(hexInput, { target: { value: '#3b82f6' } });
+    fireEvent.click(screen.getByRole('button', { name: /add to palette/i }));
+
+    // Adapter write should have been called with the new color at the front
+    await waitFor(() => {
+      expect(adapter.write).toHaveBeenCalled();
+    });
+    expect(writeCalls[0]).toEqual(['#3b82f6']);
+
+    // Commit and confirm the chip now carries the picked color
+    fireEvent.click(screen.getByRole('button', { name: /done/i }));
+    expect(onCommit).toHaveBeenCalled();
+    const committed = onCommit.mock.calls[0]![0] as Array<{ id: string; color?: string }>;
+    expect(committed[0]!.color).toBe('#3b82f6');
+  });
+
+  it('does NOT write theme colors through the adapter', async () => {
+    const adapter: PaletteAdapter = {
+      read: vi.fn().mockResolvedValue([]),
+      write: vi.fn().mockResolvedValue(undefined),
+    };
+    render(
+      <CompoundChipListCell
+        {...makeProps({
+          isEditing: true,
+          value: chipItems,
+          column: { paletteAdapter: adapter, defaultThemeColors: ['#3b82f6'] },
+        })}
+      />,
+    );
+    fireEvent.click(screen.getAllByRole('button', { name: /pick color|change color/i })[0]!);
+    fireEvent.click(screen.getByRole('button', { name: 'Theme color #3b82f6' }));
+    // Allow any microtasks from the (no-op) async path to settle.
+    await Promise.resolve();
+    expect(adapter.write).not.toHaveBeenCalled();
   });
 });

--- a/packages/react/src/cells/CompoundChipListCell/index.ts
+++ b/packages/react/src/cells/CompoundChipListCell/index.ts
@@ -1,1 +1,11 @@
 export { CompoundChipListCell } from './CompoundChipListCell';
+export type { ChipItem } from './CompoundChipListCell';
+export {
+  ColorPickerPopover,
+  applyCustomColorToPalette,
+  createInMemoryPaletteAdapter,
+  normalizeHex,
+  DEFAULT_THEME_COLORS,
+  PALETTE_MAX,
+} from './ColorPickerPopover';
+export type { ColorPickerPopoverProps } from './ColorPickerPopover';

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -79,6 +79,21 @@ export { htmlToMarkdown } from './cells/RichTextCell';
 export { cellRendererMap, TagsCell } from './cells';
 export { StatusCell } from './cells/StatusCell';
 
+// Issue #95 — compound-chip color picker primitives reused by the MUI variant
+// and available to consumers building custom chip-styled cells.
+export {
+  ColorPickerPopover,
+  applyCustomColorToPalette,
+  createInMemoryPaletteAdapter,
+  normalizeHex,
+  DEFAULT_THEME_COLORS,
+  PALETTE_MAX,
+} from './cells/CompoundChipListCell';
+export type {
+  ColorPickerPopoverProps,
+  ChipItem,
+} from './cells/CompoundChipListCell';
+
 // Sub-components
 export { DataGridHeader } from './header';
 export type { DataGridHeaderProps } from './header';

--- a/stories/CellTypes.stories.tsx
+++ b/stories/CellTypes.stories.tsx
@@ -28,7 +28,7 @@ interface CellShowcase {
   tags: string[];
   list: string;
   chipSelect: string[];
-  compoundChipList: { id: string; label: string }[];
+  compoundChipList: { id: string; label: string; color?: string }[];
   upload: string;
   subGrid: Record<string, unknown>[];
 }


### PR DESCRIPTION
Closes #95.

## Summary

- Adds a small color sub-chip beside each chip's label in the
  `CompoundChipListCell` and its MUI sibling. Empty state is a dashed
  outline circle; once coloured, a filled dot.
- Wires a popover color picker behind the sub-chip in edit mode:
  recently-used palette row, configurable theme swatches, and a hex
  input + "Add to palette" affordance for custom colors.
- Introduces a storage-agnostic `PaletteAdapter` contract on the column
  def (`{ read, write }`) so consumers persist the user palette in
  whatever they prefer (cookie / localStorage / backend). Ships an
  in-memory default scoped to the cell instance.
- Exports the picker primitives (`ColorPickerPopover`, `normalizeHex`,
  `applyCustomColorToPalette`, `createInMemoryPaletteAdapter`,
  `DEFAULT_THEME_COLORS`, `PALETTE_MAX`) from `@iasbuilt/datagrid-react`
  so the MUI variant reuses them and consumers can compose their own
  chip-styled cells without re-implementing the contract.

## Notes on issue scope

The issue describes a richer Excel-style picker (theme + standard
rows, gradient picker, removable palette entries, cookie storage by
default). This PR ships the MVP per the worktree brief:

- Theme swatches + recently-used palette row (covers two of the issue's
  three rows; "Standard colors" can be expressed today by overriding
  `defaultThemeColors`, or layered on as a second row in a follow-up).
- Hex input replaces the HSL gradient picker — the brief calls out
  "HSL slider OR hex input" and the hex path is the smaller surface to
  ship and test first.
- Cookie persistence is deferred to the consumer via `PaletteAdapter`
  per the brief's explicit "callback contract; don't reach into a
  specific storage system" guidance. A consumer-side cookie adapter is
  a one-screen helper anyone can layer on top of `read`/`write`.

## Test plan

- [x] Unit: `pnpm vitest run packages/react/src/cells/CompoundChipListCell`
  passes (40 tests: 23 popover/adapter, 17 cell incl. 6 new).
- [x] Unit: full `pnpm vitest run packages/` green (1969 tests).
- [x] Typecheck: `pnpm typecheck` green.
- [x] E2E: `pnpm exec playwright test e2e/issue-95-compound-chip-color.spec.ts`
  green (4 scenarios: empty-state sub-chips, picker open, theme swatch
  pick, custom-hex round-trip via in-memory palette).