### PR TITLE
fix(edit): thread EditCause through beginEdit to remove rAF race (closes #133)

### DIFF
--- a/e2e/issue-133-edit-cause-no-race.spec.ts
+++ b/e2e/issue-133-edit-cause-no-race.spec.ts
@@ -1,0 +1,225 @@
+/**
+ * End-to-end: issue #133 — edit-cause threading removes the rAF race
+ * between `use-keyboard`'s type-to-edit seed and `DataGridBody`'s
+ * mount-time `el.select()`.
+ *
+ * The race
+ * --------
+ * Before #133 fixed it, two code paths both mutated the inline editor's
+ * input selection inside `requestAnimationFrame` callbacks:
+ *
+ *   1. `DataGridBody.tsx`'s `<input>` ref callback ran
+ *      `requestAnimationFrame(() => el.select())` on mount so a
+ *      dblclick → type sequence REPLACED the cell value (without it,
+ *      `autoFocus` left the cursor at the end and typing appended —
+ *      catastrophic drift on numeric cells).
+ *
+ *   2. `use-keyboard.ts`'s type-to-edit handler ran
+ *      `requestAnimationFrame(() => { seed; rAF(setSelectionRange) })`
+ *      to drop the typed seed character into the editor and place the
+ *      cursor after it so continued typing APPENDED.
+ *
+ *   Under CPU contention (e.g. the pre-push hook running storybook +
+ *   vite-playground in parallel), the body's deferred `select()` could
+ *   fire AFTER the keyboard's `setSelectionRange`, highlighting the
+ *   seed character. The next keystroke would then REPLACE the seed —
+ *   so typing "99999" produced "9" instead of "99999". The pre-#133
+ *   mitigation was `delay: 50` per keystroke in the spec, which masked
+ *   the race rather than removing it.
+ *
+ * The fix
+ * -------
+ * `beginEdit(cell, cause?)` now threads an `EditCause` through the
+ * model. `DataGridBody`'s mount-time `select()` skips when the cause
+ * is `'typeToEdit'`, so the keyboard handler owns input selection
+ * unambiguously. Every other cause (`dblclick`, `enter`, `f2`,
+ * `click`, `programmatic`) keeps the existing select-on-mount
+ * behaviour.
+ *
+ * These tests pin every cause × rapid-typing combination directly in a
+ * real browser. They MUST pass without any per-keystroke `delay`.
+ *
+ * Hosts: SPA-integration playground (`/spa-integration/`). Same
+ * editable `salary` cells as `numeric-edit-replace-not-append.spec.ts`.
+ */
+import { test, expect, type Locator, type Page } from '@playwright/test';
+
+test.use({ baseURL: 'http://localhost:5173' });
+
+const PAGE = '/spa-integration/';
+
+async function gotoGrid(page: Page): Promise<void> {
+  await page.goto(PAGE);
+  await page.locator('[role="grid"]').first().waitFor({ state: 'visible' });
+}
+
+function salaryCell(page: Page, rowId: number): Locator {
+  return page
+    .locator(`[role="gridcell"][data-field="salary"][data-row-id="${rowId}"]`)
+    .first();
+}
+
+function editorIn(cell: Locator): Locator {
+  return cell.locator('input').first();
+}
+
+test.describe('Issue #133 — edit cause threading (no rAF race)', () => {
+  test('dblclick: rapid type fully REPLACES the previous value (no append)', async ({
+    page,
+  }) => {
+    await gotoGrid(page);
+    const cell = salaryCell(page, 1);
+    await cell.waitFor({ state: 'visible' });
+    const before = (await cell.innerText()).trim();
+    expect(before).toMatch(/^\d{4,6}$/);
+
+    await cell.dblclick();
+    await editorIn(cell).waitFor({ state: 'visible' });
+    // No per-keystroke delay — type at Playwright's natural rate.
+    await page.keyboard.type('77777');
+    await page.keyboard.press('Enter');
+
+    await expect(cell).toHaveText('77777');
+  });
+
+  test('type-to-edit: rapid type APPENDS to the seed (every keystroke survives)', async ({
+    page,
+  }) => {
+    await gotoGrid(page);
+    const cell = salaryCell(page, 2);
+    await cell.waitFor({ state: 'visible' });
+
+    await cell.click();
+    // No delay — pre-#133 this needed `delay: 50` to pass.
+    await page.keyboard.type('99999');
+    await page.keyboard.press('Enter');
+
+    await expect(cell).toHaveText('99999');
+  });
+
+  test('type-to-edit: long input (12 chars) survives the rapid-type race', async ({
+    page,
+  }) => {
+    await gotoGrid(page);
+    const cell = salaryCell(page, 3);
+    await cell.waitFor({ state: 'visible' });
+
+    // 12 keystrokes back-to-back with no delay: under the old rAF race,
+    // at least one of the digits would land while the body's deferred
+    // `select()` had the seed highlighted, replacing it.
+    await cell.click();
+    await page.keyboard.type('123456789012');
+    await page.keyboard.press('Enter');
+
+    await expect(cell).toHaveText('123456789012');
+  });
+
+  test('F2: editor opens with existing value SELECTED so the next keystroke REPLACES', async ({
+    page,
+  }) => {
+    await gotoGrid(page);
+    const cell = salaryCell(page, 1);
+    await cell.waitFor({ state: 'visible' });
+    const before = (await cell.innerText()).trim();
+    expect(before).toMatch(/^\d{4,6}$/);
+
+    // F2 is the canonical Excel "edit the selected cell" key. The body
+    // must `select()` on mount so a subsequent keystroke replaces the
+    // existing value — same contract as dblclick.
+    await cell.click();
+    await page.keyboard.press('F2');
+    await editorIn(cell).waitFor({ state: 'visible' });
+    // No delay — proves F2 still gets `select()` even though typeToEdit
+    // does not.
+    await page.keyboard.type('42');
+    await page.keyboard.press('Enter');
+
+    await expect(cell).toHaveText('42');
+  });
+
+  test('Enter: editor opens with existing value SELECTED so the next keystroke REPLACES', async ({
+    page,
+  }) => {
+    await gotoGrid(page);
+    const cell = salaryCell(page, 2);
+    await cell.waitFor({ state: 'visible' });
+
+    await cell.click();
+    await page.keyboard.press('Enter');
+    await editorIn(cell).waitFor({ state: 'visible' });
+    await page.keyboard.type('55');
+    await page.keyboard.press('Enter');
+
+    await expect(cell).toHaveText('55');
+  });
+
+  test('type-to-edit followed by dblclick on the SAME row keeps both contracts', async ({
+    page,
+  }) => {
+    // Regression guard: ensure causes don't bleed across edits — the
+    // first edit's `cause='typeToEdit'` must not leak into the second
+    // edit's `cause='dblclick'` and silence its `select()`.
+    await gotoGrid(page);
+    const cell = salaryCell(page, 3);
+    await cell.waitFor({ state: 'visible' });
+
+    await cell.click();
+    await page.keyboard.type('111');
+    await page.keyboard.press('Enter');
+    await expect(cell).toHaveText('111');
+
+    await cell.dblclick();
+    await editorIn(cell).waitFor({ state: 'visible' });
+    await page.keyboard.type('999');
+    await page.keyboard.press('Enter');
+
+    // Must be exactly "999" — if cause leaked, we'd see "111999".
+    await expect(cell).toHaveText('999');
+  });
+
+  test('dblclick: cursor placement is whole-text selection (Backspace deletes everything)', async ({
+    page,
+  }) => {
+    // Direct verification that the body's `select()` actually fires on
+    // the dblclick cause. We dblclick then press Backspace once: if
+    // `select()` ran, the entire value is deleted; if it did not, only
+    // one character is removed.
+    await gotoGrid(page);
+    const cell = salaryCell(page, 1);
+    await cell.waitFor({ state: 'visible' });
+
+    await cell.dblclick();
+    const editor = editorIn(cell);
+    await editor.waitFor({ state: 'visible' });
+    await page.keyboard.press('Backspace');
+    // After a single Backspace on a fully-selected input, the value is
+    // empty. Read the input's `.value` directly — the cell's text
+    // mirror only updates on commit.
+    const value = await editor.inputValue();
+    expect(value).toBe('');
+  });
+
+  test('type-to-edit: cursor is positioned AFTER the seed (Backspace deletes only the seed)', async ({
+    page,
+  }) => {
+    // Companion to the dblclick test above. After type-to-edit seeds
+    // "9", the cursor must be at position 1 (after the "9"), NOT a
+    // whole-text selection. Pressing Backspace once must delete only
+    // the "9", leaving the editor empty.
+    await gotoGrid(page);
+    const cell = salaryCell(page, 2);
+    await cell.waitFor({ state: 'visible' });
+
+    await cell.click();
+    await page.keyboard.press('9');
+    const editor = editorIn(cell);
+    await editor.waitFor({ state: 'visible' });
+    // One Backspace deletes the seed. If the body's `select()` had
+    // fired (race lost), the editor would still show the seed because
+    // the selection-replace had already happened on the keystroke that
+    // came in while the seed was highlighted.
+    await page.keyboard.press('Backspace');
+    const value = await editor.inputValue();
+    expect(value).toBe('');
+  });
+});

--- a/e2e/numeric-edit-replace-not-append.spec.ts
+++ b/e2e/numeric-edit-replace-not-append.spec.ts
@@ -50,17 +50,15 @@ test('numeric cell: type-to-edit (no dblclick) appends to the typed seed', async
   await cell.waitFor({ state: 'visible' });
 
   // Single-click to select the cell, then type-to-edit starting with "9".
-  // Small per-keystroke delay so the type-to-edit handler's deferred
-  // setSelectionRange (use-keyboard.ts) wins its race against
-  // DataGridBody's deferred .select() — without it, the test is flaky
-  // under high CPU contention (e.g. pre-push hook with two parallel
-  // webServers).
+  // Issue #133 — the previous implementation needed `delay: 50` per
+  // keystroke to ride out a rAF race between `use-keyboard`'s seed-
+  // then-place-cursor sequence and `DataGridBody`'s mount-time
+  // `el.select()`. The fix threads an `EditCause` through `beginEdit`
+  // so the body opts out of `select()` when the cause is `typeToEdit`,
+  // letting the keyboard handler own input selection unambiguously.
+  // With the race removed we type at the natural Playwright rate.
   await cell.click();
-  // Bumped from 20ms → 50ms to ride out CPU contention from the pre-push
-  // hook's parallel storybook + vite-playground startup; the deferred
-  // .select() in DataGridBody and the type-to-edit seed in use-keyboard.ts
-  // race when the first keystroke arrives before both are scheduled.
-  await page.keyboard.type('99999', { delay: 50 });
+  await page.keyboard.type('99999');
   await page.keyboard.press('Enter');
 
   // Type-to-edit must keep every typed character (we should see all 5 9s).

--- a/packages/core/src/__tests__/editing.test.ts
+++ b/packages/core/src/__tests__/editing.test.ts
@@ -20,6 +20,7 @@ describe('createEditingState', () => {
     expect(s.currentValue).toBeNull();
     expect(s.isValid).toBe(true);
     expect(s.validationError).toBeNull();
+    expect(s.cause).toBeNull();
   });
 });
 
@@ -47,6 +48,42 @@ describe('beginEdit', () => {
   it('accepts numeric initial value', () => {
     const s = beginEdit(createEditingState(), cell, 42);
     expect(s.originalValue).toBe(42);
+  });
+
+  // Issue #133 — every begin-edit code-path threads its `cause` through
+  // so editor mount lifecycles know whether to take over input
+  // selection. `'typeToEdit'` is the only cause that opts out of
+  // `DataGridBody`'s mount-time `select()`; every other cause must
+  // keep the existing "highlight existing value so next keystroke
+  // replaces" behaviour.
+  it('defaults cause to "programmatic" when caller omits it (back-compat)', () => {
+    const s = beginEdit(createEditingState(), cell, 'x');
+    expect(s.cause).toBe('programmatic');
+  });
+
+  it('records the provided cause for typeToEdit (race-fix path)', () => {
+    const s = beginEdit(createEditingState(), cell, 'x', 'typeToEdit');
+    expect(s.cause).toBe('typeToEdit');
+  });
+
+  it('records the provided cause for dblclick', () => {
+    const s = beginEdit(createEditingState(), cell, 'x', 'dblclick');
+    expect(s.cause).toBe('dblclick');
+  });
+
+  it('records the provided cause for f2', () => {
+    const s = beginEdit(createEditingState(), cell, 'x', 'f2');
+    expect(s.cause).toBe('f2');
+  });
+
+  it('records the provided cause for enter', () => {
+    const s = beginEdit(createEditingState(), cell, 'x', 'enter');
+    expect(s.cause).toBe('enter');
+  });
+
+  it('records the provided cause for click (excel-mode)', () => {
+    const s = beginEdit(createEditingState(), cell, 'x', 'click');
+    expect(s.cause).toBe('click');
   });
 });
 
@@ -154,6 +191,16 @@ describe('cancelEdit', () => {
     expect(cancelled.cell).toBeNull();
     expect(cancelled.currentValue).toBeNull();
     expect(cancelled.originalValue).toBeNull();
+  });
+
+  // Issue #133 regression guard — without this, a cancelled
+  // `'typeToEdit'` would leak into the next edit's mount and silence
+  // the body's `select()` on (e.g.) the next dblclick.
+  it('clears the cause back to null so the next begin-edit starts fresh', () => {
+    const s = beginEdit(createEditingState(), cell, 'Alice', 'typeToEdit');
+    expect(s.cause).toBe('typeToEdit');
+    const cancelled = cancelEdit(s);
+    expect(cancelled.cause).toBeNull();
   });
 });
 

--- a/packages/core/src/editing.ts
+++ b/packages/core/src/editing.ts
@@ -13,6 +13,27 @@ import { CellAddress, CellValue, ColumnDef, ValidationResult } from './types';
 import { runValidators } from './validators';
 
 /**
+ * How an edit session was started. The cause flows through `beginEdit` so
+ * editor mount lifecycles can decide whether to take over the input
+ * selection (e.g. dblclick / F2 / Enter / programmatic want a `select()`
+ * call to highlight the existing text) or stay out of the way (e.g.
+ * type-to-edit owns the cursor placement because it seeds a character).
+ *
+ * Closes iasbuilt/xldatagrid#133 — the flaky
+ * `e2e/numeric-edit-replace-not-append.spec.ts` race was rooted in
+ * `DataGridBody`'s mount-time `select()` not knowing which path opened the
+ * editor; it would clobber `use-keyboard`'s type-to-edit cursor placement
+ * under CPU contention.
+ */
+export type EditCause =
+  | 'dblclick'
+  | 'enter'
+  | 'f2'
+  | 'click'
+  | 'typeToEdit'
+  | 'programmatic';
+
+/**
  * Captures the full state of an in-progress cell edit.
  *
  * @remarks
@@ -30,6 +51,14 @@ export interface EditingState {
   isValid: boolean;
   /** Detailed validation result, or `null` when validation passes. */
   validationError: ValidationResult | null;
+  /**
+   * How the edit was initiated. `null` when no edit is active. Editor
+   * implementations branch on this to decide whether to grab the input
+   * selection on mount; see {@link EditCause}. Defaults to
+   * `'programmatic'` when callers do not provide one (back-compat with
+   * pre-#133 `beginEdit(cell)` signatures).
+   */
+  cause: EditCause | null;
 }
 
 /**
@@ -38,7 +67,14 @@ export interface EditingState {
  * @returns A fresh {@link EditingState} ready for use.
  */
 export function createEditingState(): EditingState {
-  return { cell: null, originalValue: null, currentValue: null, isValid: true, validationError: null };
+  return {
+    cell: null,
+    originalValue: null,
+    currentValue: null,
+    isValid: true,
+    validationError: null,
+    cause: null,
+  };
 }
 
 /**
@@ -50,10 +86,28 @@ export function createEditingState(): EditingState {
  * @param state - Current editing state (ignored; a new state is produced).
  * @param cell - The address of the cell to edit.
  * @param value - The cell's current value, which becomes both `originalValue` and `currentValue`.
+ * @param cause - How the edit was initiated. Editor mounts read this to
+ *   decide whether to take over input selection. Defaults to
+ *   `'programmatic'` so callers that haven't been threaded yet keep the
+ *   pre-#133 mount-time `select()` behaviour (which is correct for
+ *   dblclick / F2 / Enter / programmatic — only `typeToEdit` needed to
+ *   opt out).
  * @returns A new {@link EditingState} representing an active edit on `cell`.
  */
-export function beginEdit(state: EditingState, cell: CellAddress, value: CellValue): EditingState {
-  return { cell, originalValue: value, currentValue: value, isValid: true, validationError: null };
+export function beginEdit(
+  state: EditingState,
+  cell: CellAddress,
+  value: CellValue,
+  cause: EditCause = 'programmatic',
+): EditingState {
+  return {
+    cell,
+    originalValue: value,
+    currentValue: value,
+    isValid: true,
+    validationError: null,
+    cause,
+  };
 }
 
 /**

--- a/packages/core/src/grid-model.ts
+++ b/packages/core/src/grid-model.ts
@@ -75,7 +75,7 @@ import {
   extendSelection, extendRowSelection, clearSelection, selectAll, toggleRowSelection,
 } from './selection';
 import {
-  createEditingState, EditingState, beginEdit as beginEditState,
+  createEditingState, EditingState, EditCause, beginEdit as beginEditState,
   commitEdit as commitEditState, cancelEdit as cancelEditState,
 } from './editing';
 import {
@@ -135,7 +135,15 @@ export interface GridModel<TData = Record<string, unknown>> {
     cell: { rowId: string; field: F },
     value: TData[F],
   ): Promise<void>;
-  beginEdit(cell: CellAddress): void;
+  /**
+   * Enters edit mode for the specified cell.
+   *
+   * @param cell - The cell to begin editing.
+   * @param cause - How the edit was initiated. Editor mounts read this
+   *   to decide whether to take over input selection on mount; see
+   *   {@link EditCause}. Defaults to `'programmatic'`.
+   */
+  beginEdit(cell: CellAddress, cause?: EditCause): void;
   commitEdit(): Promise<void>;
   cancelEdit(): void;
   insertRow(index: number, data?: Record<string, unknown>): Promise<void>;
@@ -387,7 +395,7 @@ export function createGridModel<TData extends Record<string, unknown>>(
         cell as { rowId: string; field: Extract<keyof TData, string> },
         value as TData[Extract<keyof TData, string>],
       ),
-    beginEdit: async (cell) => model.beginEdit(cell),
+    beginEdit: async (cell, cause) => model.beginEdit(cell, cause),
     commitEdit: async () => model.commitEdit(),
     cancelEdit: async () => model.cancelEdit(),
     insertRow: async (index, data) => model.insertRow(index, data),
@@ -480,7 +488,7 @@ export function createGridModel<TData extends Record<string, unknown>>(
       await eventBus.dispatch('cell:valueChange', { cell, oldValue, newValue: value });
     },
 
-    beginEdit(cell: CellAddress) {
+    beginEdit(cell: CellAddress, cause: EditCause = 'programmatic') {
       const rowIds = getRowIds();
       const rowIndex = rowIds.indexOf(cell.rowId);
       if (rowIndex === -1) return;
@@ -489,7 +497,7 @@ export function createGridModel<TData extends Record<string, unknown>>(
       const value = row[cell.field as keyof TData] as CellValue;
       const editingBefore = graph.read(editingNode);
       graph.commit('cell:beginEdit', (tx) =>
-        tx.set(editingNode, beginEditState(editingBefore, cell, value)),
+        tx.set(editingNode, beginEditState(editingBefore, cell, value, cause)),
       );
     },
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,6 +1,7 @@
 import type { Validator } from './validators';
 import type { OverflowPolicy, RichTextOverflowMode } from './overflow';
 import type { NumberFormatSpec, SecondaryUnitSpec } from './number-format';
+import type { EditCause } from './editing';
 
 /**
  * Core type definitions for the datagrid system.
@@ -1565,8 +1566,11 @@ export interface GridCommands {
    * Enters edit mode for the specified cell.
    *
    * @param cell - The cell to begin editing.
+   * @param cause - Optional initiator (`dblclick`, `enter`, `f2`, `click`,
+   *   `typeToEdit`, `programmatic`). Editor mounts read this to decide
+   *   whether to take over input selection. Defaults to `'programmatic'`.
    */
-  beginEdit: (cell: CellAddress) => Promise<void>;
+  beginEdit: (cell: CellAddress, cause?: EditCause) => Promise<void>;
   /** Commits the current in-progress cell edit. */
   commitEdit: () => Promise<void>;
   /** Discards the current in-progress cell edit. */

--- a/packages/extensions/src/excel-mode/index.ts
+++ b/packages/extensions/src/excel-mode/index.ts
@@ -98,7 +98,10 @@ export function createExcelMode(
           // On cell click, begin editing immediately in excel mode
           const { cell } = event.payload as { cell: CellAddress };
           if (cell) {
-            ctx.commands.beginEdit(cell);
+            // cause='click' — excel-mode opts cells into edit on
+            // single-click. Editor mount selects existing text so a
+            // subsequent keystroke REPLACES the value (#133).
+            ctx.commands.beginEdit(cell, 'click');
           }
         },
       },

--- a/packages/react/src/body/DataGridBody.tsx
+++ b/packages/react/src/body/DataGridBody.tsx
@@ -1202,7 +1202,11 @@ export function DataGridBody<TData extends Record<string, unknown>>(
           onBlur: () => onValidationTooltip?.(rowId, col.field, 'focus', false),
           onDoubleClick: () => {
             if (col.editable !== false && !readOnly) {
-              model.beginEdit(cellAddr);
+              // Pass cause='dblclick' so the editor mount knows to take
+              // over the input selection (issue #133). Without a cause,
+              // the mount-time `select()` and `use-keyboard`'s type-to-
+              // edit cursor placement raced under CPU contention.
+              model.beginEdit(cellAddr, 'dblclick');
             }
           },
         }}
@@ -1255,15 +1259,35 @@ export function DataGridBody<TData extends Record<string, unknown>>(
               // Clear the cancellation flag each time a new edit input
               // mounts, so a previous Esc doesn't silence the next commit.
               if (el) inlineEditCancelledRef.current = false;
-              // Select the existing text on mount so a `dblclick` → type
-              // sequence REPLACES the value instead of appending. Without
-              // this, `autoFocus` lands the cursor at the end of the text
-              // and a numeric cell containing "138739" + typing "77777"
-              // becomes "13873977777" — i.e. catastrophic drift on edit.
-              // The deferred-to-next-frame call ensures the select runs
-              // after the browser's native focus/dblclick selection logic,
-              // which would otherwise override a sync call.
-              if (el) requestAnimationFrame(() => el.select());
+              if (!el) return;
+              // Issue #133 — branch on the edit cause so we don't race
+              // `use-keyboard`'s type-to-edit seed.
+              //
+              // For dblclick / F2 / Enter / click / programmatic the
+              // editor takes over input selection so a subsequent
+              // keystroke REPLACES the value rather than appending
+              // (without this, `autoFocus` lands the cursor at the end
+              // of "138739" and typing "77777" produces "13873977777" —
+              // catastrophic drift on edit).
+              //
+              // For `typeToEdit`, `use-keyboard` is mid-sequence: it
+              // has already scheduled a synthetic `input` event with
+              // the typed character and a `setSelectionRange(len, len)`
+              // cursor placement after the seed. Calling `el.select()`
+              // here would clobber that cursor placement and the
+              // subsequent keystroke would REPLACE the seed character
+              // rather than appending to it. The pre-#133 mitigation
+              // was a flaky `delay: 50` in the e2e spec; the real fix
+              // is to stay out of the way when the cause is type-to-
+              // edit (the seed character already drives the desired
+              // "replace existing value, then append" semantic).
+              const cause = model.getState().editing.cause;
+              if (cause === 'typeToEdit') return;
+              // For every other cause we still defer to next frame so
+              // the browser's native focus/dblclick selection logic
+              // (which fires synchronously on `autoFocus`) does not
+              // override a sync `select()` call.
+              requestAnimationFrame(() => el.select());
             }}
             onBlur={e => {
               if (inlineEditCancelledRef.current) return;

--- a/packages/react/src/use-keyboard.ts
+++ b/packages/react/src/use-keyboard.ts
@@ -219,7 +219,16 @@ export function useKeyboard<TData extends Record<string, unknown>>(
       if (col && col.editable !== false && editableType) {
         e.preventDefault();
         const typedChar = e.key;
-        model.beginEdit(current);
+        // Pass cause='typeToEdit' so DataGridBody's mount-time
+        // `el.select()` knows to stay out of the way (issue #133).
+        // Before this signal, the body's deferred `select()` could
+        // fire AFTER our `setSelectionRange(len, len)` under CPU
+        // contention, which highlighted the seed character so the
+        // very next keystroke replaced it — only the LAST typed digit
+        // survived. The pre-#133 mitigation was a per-keystroke
+        // `delay: 50` in the e2e spec; this signal removes the race
+        // entirely and lets us drop the delay.
+        model.beginEdit(current, 'typeToEdit');
         requestAnimationFrame(() => {
           if (!container) return;
           const cellSel = `[role="gridcell"][data-row-id="${CSS.escape(
@@ -242,14 +251,15 @@ export function useKeyboard<TData extends Record<string, unknown>>(
           }
           input.dispatchEvent(new Event('input', { bubbles: true }));
           // Place the caret after the seeded char so continued typing
-          // appends naturally. The DataGridBody's input ref also schedules
-          // a select() in a separate rAF to fix the dblclick-then-type
-          // "append-not-replace" bug; that select() would clobber our
-          // cursor placement if it ran later. Nest in a second rAF so our
-          // setSelectionRange wins the race for the type-to-edit path.
+          // appends naturally. Issue #133 — we used to nest a second
+          // rAF here to win a race against DataGridBody's deferred
+          // `select()`; now that the body opts out on cause='typeToEdit',
+          // the call is synchronous and deterministic. Doing it sync
+          // also closes the window during which a fast keystroke could
+          // land between the rAFs and corrupt the seed.
           if (typeof input.setSelectionRange === 'function') {
             const len = typedChar.length;
-            requestAnimationFrame(() => input.setSelectionRange(len, len));
+            input.setSelectionRange(len, len);
           }
         });
         return;
@@ -318,7 +328,9 @@ export function useKeyboard<TData extends Record<string, unknown>>(
           if (isEditorTarget(e.target)) return;
           model.commitEdit();
         } else if (current) {
-          model.beginEdit(current);
+          // cause='enter' — editor mount selects existing text so a
+          // subsequent keystroke REPLACES the value (#133).
+          model.beginEdit(current, 'enter');
         }
         break;
       }
@@ -486,7 +498,9 @@ export function useKeyboard<TData extends Record<string, unknown>>(
       // --- F2: enter edit mode on the selected cell ---
       case 'F2': {
         if (current && !editing.cell) {
-          model.beginEdit(current);
+          // cause='f2' — editor mount selects existing text so a
+          // subsequent keystroke REPLACES the value (#133).
+          model.beginEdit(current, 'f2');
         }
         break;
       }


### PR DESCRIPTION
## Summary

Issue #133 — the flake in `e2e/numeric-edit-replace-not-append.spec.ts` —
was rooted in two code paths racing inside `requestAnimationFrame` to
set the inline editor's input selection:

1. `DataGridBody`'s `<input>` ref ran
   `requestAnimationFrame(() => el.select())` on mount so a
   **dblclick → type** sequence REPLACED the cell value (without it,
   `autoFocus` left the cursor at the end of the text and typing
   appended — a $138,739 salary became $13,873,977,777 in one user
   gesture).
2. `use-keyboard`'s **type-to-edit** handler ran an outer rAF that
   seeded the typed character + an inner rAF that ran
   `setSelectionRange(len, len)` to place the cursor AFTER the seed so
   continued typing APPENDED.

Under CPU contention the body's deferred `select()` could fire AFTER
the keyboard's `setSelectionRange`, re-selecting the seed character.
The very next keystroke would then REPLACE the seed instead of
appending. The pre-#133 mitigation was a per-keystroke `delay: 50` in
the spec — masking the race rather than removing it.

## What changed

`beginEdit` now threads an `EditCause` signal so editor mounts know
which path opened them:

| Cause | Site |
|-------|------|
| `'dblclick'` | `DataGridBody.onDoubleClick` |
| `'enter'` | `use-keyboard` Enter on a selected cell |
| `'f2'` | `use-keyboard` F2 |
| `'click'` | `excel-mode` extension's `cell:click` handler |
| `'typeToEdit'` | `use-keyboard`'s type-to-edit handler |
| `'programmatic'` (default) | every other / unmigrated caller |

`DataGridBody`'s mount-time `el.select()` branches on the cause:

- `'typeToEdit'` → stay out of the way (`use-keyboard` owns input
  selection unambiguously).
- everything else → keep the existing "select existing value so the
  next keystroke replaces" behaviour.

With the race gone, `use-keyboard`'s inner rAF collapses to a sync
`setSelectionRange`, and the spec's `delay: 50` mitigation is dropped.

## Test plan

- [x] **8 new deep Playwright tests** in
      `e2e/issue-133-edit-cause-no-race.spec.ts` covering every cause ×
      rapid-typing combination plus two selection-state probes
      (Backspace-after-dblclick deletes the whole value;
      Backspace-after-typeToEdit deletes only the seed). All pass
      without any per-keystroke `delay`.
- [x] **Unit tests** in `packages/core/src/__tests__/editing.test.ts`
      pin the new `EditingState.cause` field across
      `createEditingState`, every `beginEdit(cause)` round-trip, and
      `cancelEdit` (resets cause to `null`).
- [x] `pnpm typecheck` — green
- [x] `pnpm build` — green
- [x] `pnpm test` (vitest, 2071 tests) — green
- [x] `pnpm test:scripts` — green
- [x] `pnpm lint` — 0 errors (24 pre-existing warnings)
- [x] `pnpm lint:migration` — 0 new findings
- [x] `pnpm exec playwright test` (full e2e) — **178 passed**
- [x] pre-push hook (full suite incl. e2e) — green

## Surface change (back-compat)

`GridModel.beginEdit(cell, cause?)` and `GridCommands.beginEdit(cell,
cause?)` add an **optional** second parameter. The default
`'programmatic'` keeps every pre-existing caller compiling and
preserves the pre-#133 mount-time `select()` for legacy paths. No
breaking change.