### PR TITLE
docs: comprehensive README + doc-string sweep across the monorepo

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,9 @@ pnpm install
 
 ### End-to-end tests (Playwright)
 
-The `e2e/` directory contains Playwright specs that drive a real browser
-against the Storybook instance:
+The `e2e/` directory contains 43 Playwright specs that drive a real
+browser against the Storybook instance and the SPA-integration Vite
+playground. Highlights — the full list lives in `e2e/`:
 
 - `e2e/grid-keyboard.spec.ts` — arrow-key navigation, Enter/Tab commit,
   Escape cancel on an editable text cell.
@@ -107,6 +108,21 @@ against the Storybook instance:
 - `e2e/grid-xss.spec.ts` — hostile RichText payloads (raw HTML and
   markdown links) must not produce live `javascript:` hrefs or inline
   event handlers.
+- `e2e/issue-133-edit-cause-no-race.spec.ts` — pins every
+  `EditCause × rapid-typing` combination (dblclick / F2 / Enter /
+  click / typeToEdit) without any per-keystroke `delay` mitigation,
+  guarding the rAF race fix.
+- `e2e/edit-commit-nav.spec.ts` — Excel-365 commit-and-advance
+  contract (Enter → DOWN, Tab → RIGHT, Escape discards) across the
+  full editing story matrix.
+- `e2e/issue-71-type-to-enter-edit.spec.ts` + `e2e/type-to-edit.spec.ts`
+  — type-to-edit seeding semantics, non-printable-key guard.
+- `e2e/numeric-edit-replace-not-append.spec.ts` — the original $138,739
+  → $13,873,977,777 regression; now a tight contract test after #133.
+- `e2e/issue-107-causl-devtools-smoke.spec.ts` — Redux DevTools
+  bridge smoke test against the SPA-integration playground.
+- `e2e/spa-integration-byo-graph.spec.ts` — BYO-graph integration
+  proving external derivations land atomically with grid mutations.
 
 #### Running the suite
 
@@ -312,9 +328,19 @@ The playground is a Vite app at `playground/` with the Kitchen Sink demo:
 
 ### Storybook
 
-17 story files covering every feature:
+44 story files (29 grid feature stories + 15 MUI component reference
+stories under `stories/MuiComponents/`):
 
-- Introduction, Basic Grid, Cell Types, Chrome Columns, Column Operations, Context Menu, Editing, Extensions, Filtering, Ghost Row, Grouping, Keyboard Navigation, Kitchen Sink, Master-Detail, Selection, Sorting, Theming
+- **Grid features**: Introduction, Basic Grid, Cell Types, Cell
+  Overflow, Chrome Columns, Clipboard, Column Operations, Components,
+  Context Menu, Editable Dropdown, Editing, Excel Mode, Extensions,
+  Filtering, Formula Bar, Ghost Row, Grouping, Hover Tooltip,
+  Keyboard, Kitchen Sink, Master-Detail, Number-Format Presets, Rich
+  Text, Selection, Sorting, Sub-Grid, Theming, Transposed Grid,
+  Validation Tooltip.
+- **MUI primitives**: Accordion, Autocomplete, Box, Button, Checkbox,
+  Chip, IconButton, InputAdornment, LinearProgress, MenuItem,
+  Overview, Select, TextField, Tooltip, Typography.
 
 ### Project Structure
 
@@ -332,12 +358,25 @@ xldatagrid/
 
 ### Test Suite
 
-42 test files covering:
+**Unit + integration**: 116 vitest files (~2,070 tests). **End-to-end**:
+43 Playwright specs against Storybook + the SPA-integration playground.
 
-- **Core** (14 files): grid model, column model, sorting, filtering, selection, editing, clipboard, undo/redo, grouping, virtualization, events, plugins, transposed grid, sub-grid expansion
-- **React** (23 files): DataGrid rendering, cell types, chrome columns, ghost row, master-detail, context menu, keyboard navigation, drag-drop, theming, validation, JSON config, pivot modes, clipboard integration, column ops, selection, sort/filter, grouping, undo/redo, sub-grid, transposed grid, grid interaction state, grid store hook
-- **Extensions** (3 files): regex validation, export, cell comments
-- **MUI** (2 files): theme bridge, MUI cell renderers
+- **Core** (23 files): grid model, column model, sorting, filtering,
+  selection, editing (incl. `EditCause` race-fix contract for #133),
+  clipboard, undo/redo, grouping, virtualization, events, plugins,
+  transposed grid, sub-grid expansion, number-format presets, persistence
+  contract, search-index trie + column-index, validators, type-only
+  guards.
+- **React** (86 files): DataGrid rendering, every cell renderer, chrome
+  columns, ghost row, master-detail, context menu, keyboard navigation
+  (incl. type-to-edit + commit-and-advance), drag-drop, theming,
+  validation, JSON config, pivot modes, clipboard integration, column
+  ops, selection, sort/filter, grouping, undo/redo, sub-grid,
+  transposed grid, grid interaction state, grid store hook,
+  CauslDevtools bridge, migration-contract suite.
+- **Extensions** (3 files): regex validation, export, cell comments.
+- **MUI** (4 files): theme bridge, MUI cell renderers (incl. RichText
+  XSS + ALT+ENTER soft break).
 
 ### Tech Stack
 
@@ -368,7 +407,7 @@ xldatagrid/
 - **Filtering** — Predicate-based column filtering with configurable debounce; composite filters with AND/OR logic; operators: `eq`, `neq`, `gt`, `gte`, `lt`, `lte`, `contains`, `startsWith`, `endsWith`, `between`, `isNull`, `isNotNull`
 - **Selection** — Cell, row, and range selection modes with keyboard extension (Shift/Ctrl); column/row/all selection; multi-range support
 - **Grouping** — Row grouping (single/multi-level) with aggregates (sum, avg, count, min, max) and collapsible column groups
-- **Editing** — Inline cell editing with lifecycle management (`beginEdit` / `commitEdit` / `cancelEdit`), validation (sync + regex with error/warning/info severity), and commit/cancel semantics
+- **Editing** — Inline cell editing with lifecycle management (`beginEdit(cell, cause?)` / `commitEdit` / `cancelEdit`), validation (sync + regex with error/warning/info severity), and commit/cancel semantics. The optional `cause` parameter (`'dblclick'` / `'enter'` / `'f2'` / `'click'` / `'typeToEdit'` / `'programmatic'`) lets editor mounts decide whether to take over input selection — type-to-edit owns the cursor placement; every other cause selects existing text so the next keystroke replaces (closes #133)
 - **Clipboard** — Copy, cut, and paste integration for single cells and ranges; tab-separated text and HTML table serialization; paste from spreadsheets
 - **Undo/Redo** — Command-based undo/redo stack tracking cell edits, row inserts/deletes, row moves, and batch operations; configurable max history (default 100) and auto-batching timeout (300ms)
 - **Virtualization** — Row and column virtualization for datasets of 500+ rows with smooth scrolling and configurable overscan
@@ -566,10 +605,13 @@ interface CellRendererProps<TData> {
 
 | Extension | Factory | Description |
 |-----------|---------|-------------|
-| Regex Validation | `createRegexValidation()` | Pattern-based cell validation |
-| Cell Comments | `createCellComments()` | Threaded comments on individual cells |
-| Column Resize | `createColumnResize()` | Drag-to-resize column headers |
-| Export | `createExportExtension()` | CSV, JSON, and Excel export with header/footer customization |
+| Regex Validation | `createRegexValidation()` | Pattern-based cell validation with `error` / `warning` / `info` severity. |
+| Cell Comments | `createCellComments()` | Threaded comments on individual cells. |
+| Column Resize | `createColumnResize()` | Drag-to-resize column headers with min/max clamping and pointer-capture. |
+| Export | `createExportExtension()` | CSV, JSON, and Excel export with per-extension header/footer + page-config customization. |
+| Formula Bar | `createFormulaBar()` | Excel-style formula-bar wiring: tracks the editing cell, drives `commitEdit` / `cancelEdit`, exposes `FormulaBarApi` for consumers. |
+| Excel Mode | `createExcelMode()` | One-click cell editing + Excel-style commit-and-advance; pairs with the `EditCause = 'click'` signal (`#133`). |
+| Validation Tooltip | `createValidationTooltip()` | Portalled per-cell validation tooltip with severity-coloured styling. |
 
 ### MUI Theme Bridge
 

--- a/packages/core/src/grid-model.ts
+++ b/packages/core/src/grid-model.ts
@@ -35,6 +35,13 @@ function encodeColumnState<TData>(state: ColumnState<TData>): string {
     return v;
   });
 }
+/**
+ * Inverse of {@link encodeColumnState}. Reconstructs the `Set` values
+ * the column-state shape relies on (currently `hidden`) from the
+ * sentinel-tagged envelope they were serialised as, and back-fills
+ * any missing fields with `fallback` to defend against stored
+ * envelopes from older schema versions.
+ */
 function decodeColumnState<TData>(raw: string, fallback: ColumnState<TData>): ColumnState<TData> {
   try {
     const parsed = JSON.parse(raw, (_k, v) => {
@@ -107,6 +114,39 @@ export interface GridNodes<TData = Record<string, unknown>> {
   readonly visibleColumns: DerivedNode<ColumnDef<TData>[]>;
 }
 
+/**
+ * The framework-agnostic imperative façade returned by
+ * {@link createGridModel}.
+ *
+ * Every public mutation in the grid (cell edits, sort / filter / select,
+ * row insertion, column reorders, undo / redo, sub-grid expansion,
+ * extension registration) lands here and translates into a single
+ * `graph.commit('intent', tx => ...)` against the underlying causl graph.
+ * Adopters get atomic transitions for free: subscribers see exactly one
+ * new value per user-level action, never an intermediate state.
+ *
+ * The model is **framework-agnostic** — it has zero React imports and is
+ * consumed identically by the React adapter (`useGrid`), the MUI wrapper
+ * (`MuiDataGrid`), and any future Vue / Svelte / vanilla binding.
+ *
+ * Two access patterns are supported:
+ *
+ *   - **Method-based** — call `model.setCellValue(...)`, `model.sort(...)`,
+ *     etc. for the standard imperative API. Each method internally runs
+ *     one `graph.commit` and dispatches the matching `GridEvent` through
+ *     the {@link EventBus}.
+ *   - **Graph-based (BYO-graph)** — read or layer derived nodes directly
+ *     on top of `model.graph` and `model.nodes.*`. Useful when an SPA
+ *     wants its own derived state (pivot panel, URL bar, analytics) to
+ *     land atomically alongside grid mutations. See
+ *     `playground/spa-integration/` for the canonical example.
+ *
+ * @typeParam TData - The row data shape. Defaults to a loose
+ *   `Record<string, unknown>` for adopters that don't yet model their
+ *   rows; tighten it to your row type so `setCellValue` becomes
+ *   compile-time-checked against the column field's value type
+ *   (closes #104).
+ */
 export interface GridModel<TData = Record<string, unknown>> {
   /**
    * Underlying causl graph (consumer-supplied via `config.graph` or
@@ -174,6 +214,20 @@ export interface GridModel<TData = Record<string, unknown>> {
   destroy(): Promise<void>;
 }
 
+/**
+ * Plain-object snapshot of every reactive grid state slice at a single
+ * point in time, returned by `model.getState()` and by
+ * `useGridStore(model)` in the React adapter.
+ *
+ * Each field mirrors the value of an input or derived causl node — see
+ * {@link GridNodes}. The snapshot is **immutable** by convention:
+ * mutating it does NOT update the underlying graph. Callers that want
+ * to mutate state must go through a `GridModel` method (which runs a
+ * `graph.commit` for atomicity) or compose a `tx.set(node, value)`
+ * inside their own commit when working with BYO-graph composition.
+ *
+ * @typeParam TData - Row data shape, propagated from {@link GridModel}.
+ */
 export interface GridModelState<TData = Record<string, unknown>> {
   data: TData[];
   columns: ColumnState<TData>;
@@ -190,9 +244,48 @@ export interface GridModelState<TData = Record<string, unknown>> {
   config: GridConfig<TData>;
 }
 
+/**
+ * Constructs a fresh {@link GridModel} bound to a causl graph.
+ *
+ * The factory accepts the full {@link GridConfig} adopters pass to
+ * `<DataGrid>` (or to `useGrid` in the React adapter). It is the single
+ * entry point for instantiating the grid's reactive substrate;
+ * everything downstream — including `useGrid`'s React lifecycle —
+ * delegates to this function.
+ *
+ * Two graph-ownership modes are supported:
+ *
+ *   - **Grid-owned** (default): omit `config.graph` and the factory
+ *     creates an internal graph via `createCausl()`. This is the
+ *     standalone-component path used by adopters who don't need
+ *     SPA-wide state composition.
+ *   - **BYO-graph**: pass `config.graph` and an optional
+ *     `config.graphNamespace` (defaults to `'grid'`). All grid nodes
+ *     register under `${namespace}:<slice>` so multiple grids — and
+ *     other SPA state — coexist on a single graph without id
+ *     collisions. External `graph.derived(...)` nodes that read from
+ *     `model.nodes.*` update atomically inside the same commit that
+ *     produced the grid mutation.
+ *
+ * Row identity is resolved through `config.rowKey`, which may be a
+ * string key into `TData` or a `(row) => string` function. The resolved
+ * resolver is closed over the model lifetime so row-keyed methods
+ * (`selectRowByKey`, `toggleSubGridExpansion`, ...) stay consistent
+ * even as `data` changes.
+ *
+ * @typeParam TData - Row data shape.
+ * @param config - Top-level grid configuration object — same shape
+ *   `<DataGrid>` accepts.
+ * @returns A fully-wired imperative model whose lifetime is owned by
+ *   the caller. Call `model.destroy()` on teardown.
+ */
 export function createGridModel<TData extends Record<string, unknown>>(
   config: GridConfig<TData>
 ): GridModel<TData> {
+  // Normalise the row-key resolver. Adopters may pass either a string
+  // field name (cheaper, declarative) or a function (more flexible,
+  // e.g. composite keys); the factory closes over a single resolver
+  // shape so the rest of the model never re-runs this branch.
   const resolveRowKey: RowKeyResolver<TData> = typeof config.rowKey === 'function'
     ? config.rowKey
     : (row: TData) => String(row[config.rowKey as keyof TData]);

--- a/packages/core/src/selection.ts
+++ b/packages/core/src/selection.ts
@@ -458,11 +458,29 @@ export function createSelectionChecker(
   };
 }
 
+/**
+ * Resolves the address one step counter to reading order from
+ * `current` — left within the same row when a left neighbour exists,
+ * otherwise wrapping to the rightmost cell of the previous row. Returns
+ * `null` from the top-left corner, signalling "no further-back cell".
+ *
+ * Used by the Shift+Tab / reverse-direction navigation arms in
+ * `use-keyboard.ts`; the mirror of {@link getNextCellInRow}.
+ *
+ * @param current - Address of the cell that has focus today.
+ * @param columns - Full column list; the function filters to
+ *   `visible !== false` internally so callers may pass the raw config.
+ * @param rowIds - Ordered row identifiers, used to compute the
+ *   previous-row jump when wrapping.
+ */
 export function getPrevCellInRow(current: CellAddress, columns: ColumnDef<any>[], rowIds: string[]): CellAddress | null {
-  // Try moving left within the same row first
+  // Step one cell left inside the current row when possible — the
+  // common Tab-back case.
   const prev = getNextCell(current, 'left', columns, rowIds);
   if (prev) return prev;
-  // Wrap to last cell of previous row
+  // Edge case: at the leftmost visible column. Wrap to the rightmost
+  // visible cell of the row above (matching Excel's "shift-tab off
+  // column 0" behaviour). Returns null from the top-left corner.
   const rowIdx = rowIds.indexOf(current.rowId);
   const visibleCols = columns.filter(c => c.visible !== false);
   const prevRowId = rowIdx > 0 ? rowIds[rowIdx - 1] : undefined;

--- a/packages/core/src/sorting.ts
+++ b/packages/core/src/sorting.ts
@@ -109,8 +109,10 @@ export function applySorting<T extends Record<string, unknown>>(data: T[], sort:
  * state = toggleSort(state, 'name', false);     // []
  * ```
  */
-// Toggle sort direction: null -> asc -> desc -> null
 export function toggleSort(current: SortState, field: string, multi: boolean): SortState {
+  // The three-state machine: unsorted → asc → desc → unsorted again.
+  // Single-column mode collapses other descriptors; multi-column mode
+  // preserves them so Excel-style shift-click stacking works.
   // Check if the field already has a sort descriptor
   const existing = current.find(s => s.field === field);
   if (!existing) {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,22 +1,29 @@
+/**
+ * Core type definitions for the datagrid system.
+ *
+ * Every shared interface, type alias, and enumeration consumed across the
+ * datagrid packages is declared here — cell values, sort / filter / selection
+ * descriptors, column configuration, validation result shapes, grouping
+ * state, the plugin / extension contract, undo / redo commands, and the
+ * top-level {@link GridConfig} that adopters pass to instantiate a grid.
+ * Every rendering adapter and extension imports from this module to stay in
+ * lockstep with the canonical contracts and to share a single source of
+ * truth for type safety across the stack.
+ *
+ * The module is **types-only** at runtime: nothing is exported as a value
+ * (constants and helpers live in their per-feature siblings, e.g.
+ * `events.ts`, `selection.ts`, `validators.ts`). The handful of
+ * `import type` clauses below stitch together the cross-module type graph
+ * without introducing runtime cycles — `editing.ts`'s `EditCause`,
+ * `validators.ts`'s `Validator`, and so on.
+ *
+ * @module types
+ */
+
 import type { Validator } from './validators';
 import type { OverflowPolicy, RichTextOverflowMode } from './overflow';
 import type { NumberFormatSpec, SecondaryUnitSpec } from './number-format';
 import type { EditCause } from './editing';
-
-/**
- * Core type definitions for the datagrid system.
- *
- * This module declares all shared interfaces, type aliases, and enumerations used
- * across the datagrid packages — covering cell values, sorting, filtering,
- * selection, column configuration, validation, grouping, plugin/extension
- * contracts, undo/redo commands, and the top-level {@link GridConfig} that
- * consumers pass to instantiate a grid.
- *
- * Every rendering adapter and extension relies on these canonical types to
- * ensure consistent behavior and type safety throughout the stack.
- *
- * @module types
- */
 
 // ---------------------------------------------------------------------------
 // Cell value primitives
@@ -1415,6 +1422,15 @@ export type GridEventTypeBase =
   | 'subGrid:expand' | 'subGrid:collapse'
   | 'grid:mount' | 'grid:unmount' | 'grid:dataChange' | 'grid:stateChange';
 
+/**
+ * Full event-type vocabulary including the `before:` prefix used by
+ * `before`-phase hooks to subscribe to the pre-dispatch slot.
+ *
+ * Hooks registered with phase `'before'` may also subscribe to the
+ * literal `before:<base>` form to receive a separate, dedicated
+ * pre-dispatch notification — handy when an extension wants to observe
+ * cancellable events without participating in the cancellation chain.
+ */
 export type GridEventType = GridEventTypeBase | `before:${GridEventTypeBase}`;
 
 /**

--- a/packages/extensions/src/index.ts
+++ b/packages/extensions/src/index.ts
@@ -1,20 +1,74 @@
 /**
- * Barrel re-export module for all datagrid extension factories and their
- * associated types. Each extension is a self-contained plugin that adds
- * capabilities — such as validation, commenting, column resizing, or data
- * export — to a datagrid instance via the extension registration API.
+ * Public entry point for `@iasbuilt/datagrid-extensions`.
+ *
+ * Each export below is a **factory function** that returns an
+ * `ExtensionDefinition` (defined in `@iasbuilt/datagrid-core`'s
+ * `types.ts`). Adopters register the returned definition through
+ * `model.registerExtension(ext)` (or, in the React adapter, by passing
+ * the array to `<DataGrid extensions={[...]} />`); the plugin host
+ * orchestrates lifecycle (`init` → hook wiring → `destroy`), enforces
+ * declared dependencies, and tears down in reverse order on unmount.
+ *
+ * The accompanying `type` re-exports surface the per-extension config
+ * and API shapes so TypeScript consumers can statically reference them
+ * without reaching into deep import paths.
+ *
+ * Extensions shipped here:
+ *
+ *   - **regex-validation** — pattern-based cell validation with
+ *     `error` / `warning` / `info` severities.
+ *   - **cell-comments** — threaded comments on individual cells.
+ *   - **column-resize** — drag-to-resize column headers with min/max
+ *     clamping and pointer-capture for cross-row drag.
+ *   - **export** — CSV / JSON / Excel export with per-extension
+ *     header/footer + page-config customisation.
+ *   - **formula-bar** — Excel-style formula-bar wiring on top of the
+ *     editing lifecycle (tracks the editing cell, drives
+ *     `commitEdit` / `cancelEdit`, exposes `FormulaBarApi`).
+ *   - **excel-mode** — single-click edit + Excel-style
+ *     commit-and-advance. Pairs with the `EditCause = 'click'` signal
+ *     so the editor mount selects existing text on cell entry
+ *     (closes #133's race).
+ *   - **validation-tooltip** — portalled per-cell validation tooltip
+ *     with severity-coloured styling.
  *
  * @packageDocumentation
  */
 
+// Pattern-validation extension — adds `validate(value)` hooks driven
+// by RegExp objects, with multi-severity surfacing.
 export { createRegexValidation } from './regex-validation';
+
+// Threaded cell-comment overlays with per-cell anchoring and storage.
 export { createCellComments } from './cell-comments';
+
+// Drag-to-resize header gutters with pointer capture so the drag
+// survives the cursor leaving the original header cell.
 export { createColumnResize } from './column-resize';
+
+// Format-agnostic export pipeline: shared traversal of visible rows /
+// columns, with format-specific serialisers (CSV / JSON / Excel-XML).
+// Header + footer + page-config knobs let consumers brand the output.
 export { createExportExtension } from './export';
 export type { ExportConfig, ExportResult, ExportFormat, ExportApi, ExportPageConfig, ExportHeaderFooter } from './export';
+
+// Excel-style formula bar wired to the editing lifecycle. The
+// extension owns the bar's tracked-cell state; `FormulaBarApi` is
+// surfaced for adopters that render their own bar UI.
 export { createFormulaBar } from './formula-bar';
 export type { FormulaBarConfig, FormulaBarState, FormulaBarApi } from './formula-bar';
+
+// Single-click edit + commit-and-advance. The hook on `cell:click`
+// threads `cause='click'` through `beginEdit` so the body's editor
+// mount selects existing text (closes #133 — the same race-fix lane
+// dblclick / F2 / Enter use).
 export { createExcelMode } from './excel-mode';
 export type { ExcelModeConfig, ExcelModeApi } from './excel-mode';
+
+// Portalled validation tooltip with severity-coloured styling
+// (red = error, amber = warning, blue = info). Adopters can opt in
+// per-cell or globally; the extension lives outside `DataGridBody`'s
+// per-cell render so portal/measurement costs amortise across the
+// grid.
 export { createValidationTooltip } from './validation-tooltip';
 export type { ValidationTooltipConfig, ValidationTooltipApi, ValidationTooltipEntry } from './validation-tooltip';

--- a/packages/mui/src/components/DisplayTypography.tsx
+++ b/packages/mui/src/components/DisplayTypography.tsx
@@ -6,6 +6,12 @@
 import React from 'react';
 import Typography from '@mui/material/Typography';
 
+/**
+ * Props accepted by {@link DisplayTypography}. The component renders the
+ * cell's display-mode value through MUI's `<Typography variant="body2">`
+ * and falls back to the placeholder (rendered in `text.secondary`) when
+ * the value is empty.
+ */
 export interface DisplayTypographyProps {
   value: string;
   placeholder?: string;

--- a/packages/mui/src/components/EditableAutocomplete.tsx
+++ b/packages/mui/src/components/EditableAutocomplete.tsx
@@ -7,6 +7,12 @@ import React from 'react';
 import Autocomplete from '@mui/material/Autocomplete';
 import TextField from '@mui/material/TextField';
 
+/**
+ * Props accepted by {@link EditableAutocomplete}. The component is a
+ * thin pass-through to MUI's `<Autocomplete>` with sensible defaults
+ * for in-cell editing (small density, no clear button, multi-select
+ * always on).
+ */
 export interface EditableAutocompleteProps<T = string> {
   multiple: true;
   freeSolo?: boolean;

--- a/packages/mui/src/components/EditableSelect.tsx
+++ b/packages/mui/src/components/EditableSelect.tsx
@@ -7,6 +7,13 @@ import React from 'react';
 import Select from '@mui/material/Select';
 import type { SelectChangeEvent } from '@mui/material/Select';
 
+/**
+ * Props accepted by {@link EditableSelect}. The wrapper preconfigures
+ * the MUI Select to render flush against the cell padding and to
+ * honour the parent grid's blur-on-commit lifecycle; consumers supply
+ * only the value, the controlled-open flag, and the change/blur
+ * callbacks.
+ */
 export interface EditableSelectProps {
   value: string;
   open: boolean;

--- a/packages/mui/src/components/EditableTextField.tsx
+++ b/packages/mui/src/components/EditableTextField.tsx
@@ -6,6 +6,14 @@
 import React from 'react';
 import TextField from '@mui/material/TextField';
 
+/**
+ * Props accepted by {@link EditableTextField}. The component is a
+ * pre-configured MUI `<TextField variant="standard">` tuned for in-cell
+ * editing: no label, no underline, density to match the surrounding row
+ * height. Use the `inputSlotProps` and `htmlInputSlotProps` escape
+ * hatches for one-off overrides; for repeated patterns prefer adding a
+ * named field to the props.
+ */
 export interface EditableTextFieldProps {
   inputRef?: React.Ref<HTMLInputElement>;
   value: string;

--- a/packages/mui/src/index.ts
+++ b/packages/mui/src/index.ts
@@ -1,8 +1,25 @@
 /**
- * Public API barrel file for the `@iasbuilt/datagrid-mui` package.
+ * Public entry point for `@iasbuilt/datagrid-mui`.
  *
- * Re-exports all MUI cell renderers, the theme bridge, the convenience
- * wrapper, and the renderer map for drop-in use.
+ * The package layers Material UI styling on top of the framework-
+ * agnostic core. Three subsystems live here:
+ *
+ *   - **`<MuiDataGrid>`** — a thin wrapper around `<DataGrid>` from
+ *     `@iasbuilt/datagrid-react` that pre-wires the MUI cell renderers
+ *     and the theme bridge. Adopters drop it in instead of `<DataGrid>`
+ *     and get an MUI-styled grid that respects their MUI theme.
+ *   - **`theme/`** — the `bridgeMuiTheme(muiTheme)` mapper and the
+ *     `<MuiDataGridThemeProvider>` that pipes MUI palette values into
+ *     the grid's `--dg-*` CSS variables.
+ *   - **`cells/`** — one MUI-styled cell renderer per `cellType`. Each
+ *     renderer matches the `CellRendererProps<TData>` contract from
+ *     the core package and can be used standalone (passed via
+ *     `cellRenderers` on a plain `<DataGrid>`) or transitively via
+ *     `<MuiDataGrid>`.
+ *   - **`components/`** — shared MUI building blocks
+ *     (`<EditableTextField>`, `<EditableSelect>`,
+ *     `<EditableAutocomplete>`, `<DisplayTypography>`) the cell
+ *     renderers compose with.
  *
  * @module index
  */

--- a/packages/mui/src/theme/index.ts
+++ b/packages/mui/src/theme/index.ts
@@ -1,3 +1,13 @@
+/**
+ * Theme bridge barrel for `@iasbuilt/datagrid-mui`.
+ *
+ * `bridgeMuiTheme` maps a Material UI theme object into the
+ * `--dg-*` CSS-variable map the grid consumes; the
+ * `<MuiDataGridThemeProvider>` component wires that mapping into the
+ * React tree so adopters get a single `theme={muiTheme}` prop on
+ * `<MuiDataGrid>` and the rest of the colour token plumbing happens
+ * automatically.
+ */
 export { bridgeMuiTheme } from './theme-bridge';
 export type { MuiThemeShape } from './theme-bridge';
 export { MuiDataGridThemeProvider } from './MuiDataGridThemeProvider';

--- a/packages/react/src/DataGrid.tsx
+++ b/packages/react/src/DataGrid.tsx
@@ -221,6 +221,33 @@ const LIGHT_THEME: CSSVariableMap = lightThemeTokens as CSSVariableMap;
 
 const DARK_THEME: CSSVariableMap = darkThemeTokens as CSSVariableMap;
 
+/**
+ * Resolves the `theme` prop passed to `<DataGrid>` (or `<MuiDataGrid>`)
+ * into a React-friendly `CSSProperties` bag of CSS-variable
+ * assignments suitable for spreading into `style={{ ... }}`.
+ *
+ * Three input shapes are accepted:
+ *
+ *   - `'light'` — returns a shallow copy of the built-in light-theme
+ *     token map so callers can layer their own per-instance overrides
+ *     on top without mutating the shared object.
+ *   - `'dark'` — same as above for the dark preset.
+ *   - `Record<string, string>` — a custom token map. Keys not matching
+ *     `--*` flow through unchanged; React DOM will emit the usual
+ *     dev-time warning for non-variable keys but does not throw.
+ *
+ * An unrecognised string preset (e.g. `'excel365'`) is intentionally
+ * resolved to `{}` because the theme tokens for that preset live in CSS
+ * and are activated by the matching `data-theme` attribute the grid
+ * writes to its root container.
+ *
+ * @param theme - The `theme` prop value supplied by the caller, or
+ *   `undefined` when no theme is requested (the grid uses its
+ *   default CSS variables).
+ * @returns A plain object suitable for spreading into a `style` prop.
+ *   Always a fresh object — never the frozen token-map constants — so
+ *   callers may mutate the result if they need to.
+ */
 export function resolveThemeStyle(
   theme: 'light' | 'dark' | Record<string, string> | undefined,
 ): React.CSSProperties {

--- a/packages/react/src/ValidationTooltip.tsx
+++ b/packages/react/src/ValidationTooltip.tsx
@@ -42,6 +42,16 @@ import React from 'react';
 import { createPortal } from 'react-dom';
 import type { ValidationResult, ValidationSeverity } from '@iasbuilt/datagrid-core';
 
+/**
+ * Props accepted by the `<ValidationTooltip>` portal.
+ *
+ * The component is intentionally pull-shaped: the caller (typically
+ * `<DataGridBody>`) computes the cell address, the ordered result list,
+ * and the `open` flag (hover / focus) and the tooltip simply renders
+ * the corresponding portal node. Closing the tooltip is a matter of
+ * passing `open={false}` — the component does not own its own
+ * open-state.
+ */
 export interface ValidationTooltipProps {
   /** Id of the row the tooltip describes. */
   rowId: string;

--- a/packages/react/src/__tests__/migration-contract/README.md
+++ b/packages/react/src/__tests__/migration-contract/README.md
@@ -1,22 +1,46 @@
 # Migration contract tests
 
-These specs pin the **observable public behavior** of the React package so a
-state-library migration (Jotai → causl) can be done with confidence. Tests in
-this directory:
+These specs pin the **observable public behavior** of the React package
+across a state-substrate migration. They were originally written to
+guard the Jotai → causl swap (now landed: every commit after
+[`f109567`](../../../../../README.md) — *"feat: causl state foundation
+(Phases 1-3 + interaction lift + devtools)"* — runs on causl); they
+remain checked-in so any future substrate change has a ready-made
+regression net.
 
-1. Do not import `jotai` or `@causl/*` directly.
-2. Assert only on the public surface exposed from `@iasbuilt/datagrid-react`
-   (`useGrid`, `GridContext`) and on the `GridModel` interface from
-   `@iasbuilt/datagrid-core`. (The historical `useGridWithAtoms` and
-   `createAtomicGridModel` exports were removed in the post-`v0.1.0` major.)
-3. Cover the behaviors that have the highest risk of breaking during the swap:
-   bundle return-shape, lifecycle (mount/unmount/destroy), mutation semantics
-   (each action atom becomes a causl `commit`), and the EventBus dispatch
-   contract (the bridge between atom changes and core events).
+Tests in this directory deliberately:
 
-Tests must stay GREEN on the current Jotai backend and must stay GREEN on the
-post-migration causl backend. If a test fails on either, either the production
-code is wrong or the test was too tightly coupled to one library — fix the
-test, not the contract.
+1. Do **not** import `jotai`, `@causl/*`, or any other state-library
+   namespace directly. The point is to assert against the public
+   surface, not the internal substrate.
+2. Assert only on the public surface exposed from
+   `@iasbuilt/datagrid-react` (`useGrid`, `GridContext`,
+   `useGridStore`, `useGridInteraction`) and on the `GridModel`
+   interface from `@iasbuilt/datagrid-core`. The historical
+   `useGridWithAtoms` and `createAtomicGridModel` exports were
+   removed in the post-`v0.1.0` consolidation; do not re-add them
+   here.
+3. Cover the behaviors with the highest swap-risk: bundle return-shape,
+   lifecycle (mount / unmount / destroy / dispose cleanup), mutation
+   semantics (each action becomes exactly one `graph.commit` with the
+   right intent string), and the EventBus dispatch contract (causl
+   commits drive `cell:valueChange` / `cell:beginEdit` / etc.).
+4. Stay GREEN on every commit on `main`. If one of these tests breaks
+   after a refactor, the **public contract regressed** — fix the
+   production code, not the test. The only acceptable test edit is
+   when the contract itself is being intentionally evolved, and that
+   should land as a single PR labelled `contract-change` so reviewers
+   can spot it.
 
-See `PLAN_CAUSL_MIGRATION.md` at the repo root for the full migration plan.
+## How they relate to the rest of the suite
+
+| Layer | Lives in | Scope |
+|---|---|---|
+| Migration contract | `migration-contract/` *(this dir)* | Public-surface invariants — substrate-agnostic. |
+| Unit / integration | sibling `__tests__/` directories | Behaviour of a single hook / component / module. |
+| End-to-end | `e2e/` | Real browser, real DOM, real keyboard / mouse. |
+
+A new feature usually needs unit + e2e coverage; a migration contract
+test is only worth adding when the feature exposes a **shape** that an
+adopter could write against (e.g. `useGrid` return type, `GridModel`
+methods) and that we want to freeze across future substrate work.

--- a/packages/react/src/body/DataGridBody.tsx
+++ b/packages/react/src/body/DataGridBody.tsx
@@ -69,10 +69,20 @@ import { GhostRow } from '../GhostRow';
 import { useHoverTooltip } from '../HoverTooltip';
 import * as styles from './DataGridBody.styles';
 
-// ---------------------------------------------------------------------------
-// Helper: format cell value for display
-// ---------------------------------------------------------------------------
+// Helper: lightweight display formatter used when no custom cell
+// renderer is registered for a given cellType. The full cell-renderer
+// pipeline kicks in when an entry exists in `cellRenderers`; this
+// fallback covers the bare-grid case so a `<DataGrid>` with no
+// `cellRenderers` prop still shows sensible defaults for the common
+// primitive types (boolean check / cross, currency with $-prefix,
+// dates via `toLocaleDateString`).
 
+/**
+ * Coerces a {@link CellValue} into the string the bare-grid path
+ * renders inside a `<td>`. Falls through to `String(value)` for
+ * unrecognised types so adopters who pass exotic shapes see at least
+ * an attempt at a sensible label rather than `[object Object]`.
+ */
 function renderCellValue(value: CellValue, cellType: CellType): string {
   if (value == null) return '';
   if (cellType === 'boolean') return value ? '\u2611' : '\u2610';
@@ -81,9 +91,9 @@ function renderCellValue(value: CellValue, cellType: CellType): string {
   return String(value);
 }
 
-// ---------------------------------------------------------------------------
-// Helper: validation key
-// ---------------------------------------------------------------------------
+// Helper: coerce inline-editor input strings back to the column's
+// storage type. See the doc-comment on `coerceCellValueForColumn`
+// for the catastrophic-drift bug this guards against.
 
 /**
  * Coerce the raw `<input>` string value into the storage type the column
@@ -112,6 +122,12 @@ function coerceCellValueForColumn(
   return raw;
 }
 
+/**
+ * Composite map key for the per-cell validation-error store. Kept
+ * standalone so the encoding lives in one place — if we ever need to
+ * escape the separator (a `:` inside a field name) or switch to a
+ * tuple-keyed `Map`, every consumer flows through this function.
+ */
 function getValidationKey(rowId: string, field: string): string {
   return `${rowId}:${field}`;
 }
@@ -187,10 +203,18 @@ function overflowStyleFor(policy: OverflowPolicy): React.CSSProperties {
  */
 const TRUNCATE_MAX_CHARS = 24;
 
-// ---------------------------------------------------------------------------
-// Helper: resolve ghost row position from config
-// ---------------------------------------------------------------------------
+// Helper: normalise the polymorphic `ghostRow` prop into a concrete
+// `GhostRowPosition`. The prop accepts `boolean | GhostRowConfig` so
+// adopters can write `ghostRow` as a shorthand for default behaviour,
+// or pass a config object when they need to override position /
+// defaults / validation; this resolver collapses both forms to a
+// single value the renderer can consume directly.
 
+/**
+ * Resolves the `ghostRow` prop to a concrete {@link GhostRowPosition}.
+ * Defaults to `'bottom'` when the prop is omitted, `true`, or supplies
+ * a config without an explicit position.
+ */
 function resolveGhostPosition<T extends Record<string, unknown> = Record<string, unknown>>(config: boolean | GhostRowConfig<T> | undefined): GhostRowPosition {
   if (typeof config === 'object' && config.position) return config.position;
   return 'bottom';
@@ -451,11 +475,22 @@ export interface DataGridBodyProps<TData extends Record<string, unknown>> {
 // The raw text itself is intentionally rendered so screen readers still read
 // it without depending on the hover tooltip.
 
+/**
+ * Props for the {@link CellTextDisplay} text-overflow renderer.
+ */
 interface CellTextDisplayProps {
   rawText: string;
   policy: OverflowPolicy;
 }
 
+/**
+ * Per-cell text-overflow renderer. Applies the requested
+ * {@link OverflowPolicy} (`truncate-end`, `truncate-middle`,
+ * `clamp-2`, `clamp-3`, `wrap`, `reveal-only`, `none`) using vendor-
+ * prefixed CSS line-clamp rules and DOM-level truncation; see the
+ * surrounding block-comment for the design rationale and the
+ * accessibility / screen-reader contract.
+ */
 function CellTextDisplay({ rawText, policy }: CellTextDisplayProps) {
   const ref = useRef<HTMLSpanElement | null>(null);
 
@@ -523,6 +558,15 @@ function CellTextDisplay({ rawText, policy }: CellTextDisplayProps) {
 // The component is intentionally generic over the row shape so the resolver
 // signature can match `ColumnDef<TData>['note']` precisely.
 
+/**
+ * Props for the {@link BodyCell} per-cell renderer.
+ *
+ * Each `<DataGridBody>` cell delegates to `<BodyCell>` so the hover-
+ * tooltip hook (`useHoverTooltip`) can live at a stable position in
+ * the rules-of-hooks ordering. The component is generic over `TData`
+ * so the column-level `note` resolver can match
+ * `ColumnDef<TData>['note']` exactly.
+ */
 interface BodyCellProps<TData> {
   col: ColumnDef<TData>;
   colIdx: number;
@@ -591,6 +635,13 @@ function isMeasuredTruncated(
   return scrollWidth > clientWidth;
 }
 
+/**
+ * Per-cell renderer extracted from `<DataGridBody>` so each cell can
+ * legally invoke React hooks (`useHoverTooltip`, the truncation
+ * `useLayoutEffect`) at a stable position in the hooks ordering.
+ * See {@link BodyCellProps} for the input contract and the block-
+ * comment above `BodyCellProps` for the rationale of the extraction.
+ */
 function BodyCell<TData extends Record<string, unknown>>(
   props: BodyCellProps<TData>,
 ) {
@@ -710,10 +761,39 @@ function BodyCell<TData extends Record<string, unknown>>(
   );
 }
 
-// ---------------------------------------------------------------------------
-// Component
-// ---------------------------------------------------------------------------
+// Component — the load-bearing body renderer.
+//
+// `DataGridBody` is the largest single component in the package and
+// owns the most performance-sensitive code paths (per-row rendering,
+// per-cell range tinting, virtualisation slice, drag-drop overlays,
+// inline editor mount/unmount). It is split into the props object,
+// the helper closures defined above this comment, and the JSX tree
+// the function emits below.
 
+/**
+ * Body half of the grid: renders every row × column intersection
+ * inside the virtualisation window, paints range / row-selection /
+ * chrome tints, hosts the inline cell editor, dispatches click /
+ * keyboard / drag interactions to the parent `<DataGrid>`, and
+ * surfaces validation tooltips.
+ *
+ * The component is **presentational with side effects** — it owns
+ * very little local state (only the validation-tooltip hover/focus
+ * latches and a couple of refs for editor mount); every mutation goes
+ * back to the caller through the prop callbacks the parent grid
+ * supplies. The canonical state stays in the {@link GridModel}.
+ *
+ * Editor mount lifecycle: when `isEditingCell(rowId, field)` is `true`
+ * the body mounts an inline `<input>` for built-in cell types (text /
+ * numeric / currency / password). The input's `ref` callback branches
+ * on `editing.cause` from the grid model — see issue #133's race-fix
+ * for the full rationale — so `'typeToEdit'` opts out of the
+ * mount-time `el.select()` and every other cause keeps the
+ * "highlight existing value so the next keystroke replaces"
+ * behaviour.
+ *
+ * @typeParam TData - Row data shape, propagated from the parent grid.
+ */
 export function DataGridBody<TData extends Record<string, unknown>>(
   props: DataGridBodyProps<TData>,
 ) {

--- a/packages/react/src/chrome/ChromeControlsCell.tsx
+++ b/packages/react/src/chrome/ChromeControlsCell.tsx
@@ -1,8 +1,27 @@
+/**
+ * Per-row controls cell rendered inside the optional chrome controls
+ * column (the leftmost "actions" gutter).
+ *
+ * Each {@link ControlAction} declared in the grid's `chrome.controls`
+ * config renders as a button whose icon / label comes from the action
+ * itself; `onClick` is invoked with the row id + row index so the
+ * consumer can route to row-scoped operations (delete, expand,
+ * inspect, …). The cell stops event propagation on the button so a
+ * row-level `onClick` (selection, master-detail) does not also fire.
+ *
+ * @module ChromeControlsCell
+ */
 import React from 'react';
 import type { CSSProperties } from 'react';
 import type { ControlAction } from '@iasbuilt/datagrid-core';
 import * as styles from './ChromeColumn.styles';
 
+/**
+ * Props accepted by {@link ChromeControlsCell}. The width / height
+ * dimensions are passed down from the parent grid so the cell can
+ * resize alongside the rest of the chrome layout without measuring
+ * the DOM.
+ */
 export interface ChromeControlsCellProps {
   actions: ControlAction[];
   rowId: string;
@@ -21,6 +40,10 @@ const containerStyle: CSSProperties = {
   width: '100%',
 };
 
+/**
+ * Renders the controls gutter for a single row. See
+ * {@link ChromeControlsCellProps} for the contract.
+ */
 export function ChromeControlsCell(props: ChromeControlsCellProps) {
   const { actions, rowId, rowIndex, width, height } = props;
 

--- a/packages/react/src/header/DataGridColumnGroupHeader.tsx
+++ b/packages/react/src/header/DataGridColumnGroupHeader.tsx
@@ -1,8 +1,24 @@
+/**
+ * Optional banner row rendered above the per-column header when the
+ * grid's `columnGroups` config is non-empty. Each group spans the
+ * columns assigned to it, supports drag-to-reorder at the group
+ * granularity, and can be collapsed to hide every member column at
+ * once.
+ *
+ * @module DataGridColumnGroupHeader
+ */
 import React from 'react';
 import type { ColumnDef, ColumnGroupConfig } from '@iasbuilt/datagrid-core';
 import type { ColumnGroupDragState } from '../state';
 import * as styles from './DataGridColumnGroupHeader.styles';
 
+/**
+ * Props accepted by {@link DataGridColumnGroupHeader}. Width
+ * resolution is left to the parent: the component receives the
+ * already-ordered visible columns plus the matching `columnWidths`
+ * array so each group banner can compute its `width: sum(member
+ * column widths)` without re-walking the grid model.
+ */
 export interface DataGridColumnGroupHeaderProps {
   columnGroupConfig: ColumnGroupConfig;
   effectiveGroupOrder: string[];
@@ -17,6 +33,10 @@ export interface DataGridColumnGroupHeaderProps {
   onCollapseToggle: (groupId: string) => void;
 }
 
+/**
+ * Renders the column-group banner row. See
+ * {@link DataGridColumnGroupHeaderProps} for the per-field contract.
+ */
 export function DataGridColumnGroupHeader(props: DataGridColumnGroupHeaderProps) {
   const {
     columnGroupConfig,

--- a/packages/react/src/header/DataGridColumnMenu.tsx
+++ b/packages/react/src/header/DataGridColumnMenu.tsx
@@ -1,7 +1,30 @@
+/**
+ * Per-column dropdown menu surfaced when the user clicks the column-
+ * header chevron. Houses the hide / freeze / unfreeze affordances; the
+ * column-filter dropdown lives in its own sibling component
+ * (`DataGridColumnFilterMenu`) so this file stays scoped to layout
+ * actions.
+ *
+ * The component is purely presentational — `menuState` from
+ * `useGridInteraction` controls open/closed; clicks bubble back to the
+ * parent via the callback props. Open state is gated on
+ * `menuState.type === 'column'`, so opening any other menu type
+ * automatically dismisses this one without bookkeeping code.
+ *
+ * @module DataGridColumnMenu
+ */
 import React from 'react';
 import type { MenuState } from '../state';
 import * as styles from './DataGridColumnMenu.styles';
 
+/**
+ * Props accepted by {@link DataGridColumnMenu}.
+ *
+ * `getColumnFrozen` is a pull-shaped resolver rather than a direct
+ * `frozen` flag because the menu may be invoked on any column at any
+ * time — passing the resolver lets the menu look up the live freeze
+ * state at render rather than relying on a stale value snapshot.
+ */
 export interface DataGridColumnMenuProps {
   menuState: MenuState;
   headerHeight: number;
@@ -13,6 +36,11 @@ export interface DataGridColumnMenuProps {
   onClose: () => void;
 }
 
+/**
+ * Column menu component — short-circuits to `null` unless the
+ * interaction state has the column menu open. See
+ * {@link DataGridColumnMenuProps} for the contract.
+ */
 export function DataGridColumnMenu(props: DataGridColumnMenuProps) {
   const {
     menuState,

--- a/packages/react/src/header/DataGridHeader.tsx
+++ b/packages/react/src/header/DataGridHeader.tsx
@@ -173,6 +173,17 @@ interface HeaderCellProps<TData> {
   activeFilterFields?: ReadonlySet<string>;
 }
 
+/**
+ * Per-column header cell. Houses the title, sort indicator (arrow +
+ * priority badge for multi-column sorts), the filter trigger, the
+ * column-menu chevron, the resize handle, and the drop indicator for
+ * column-reorder drag.
+ *
+ * Extracted from the body of `<DataGridHeader>` so each header cell
+ * can register hooks (drag listeners, focus capture, tooltip state)
+ * at a stable position in the rules-of-hooks ordering — the same
+ * extraction pattern the body uses for `<BodyCell>`.
+ */
 function HeaderCell<TData>(props: HeaderCellProps<TData>) {
   const {
     col,

--- a/packages/react/src/header/column-filter-menu/FilterConditionDialog.tsx
+++ b/packages/react/src/header/column-filter-menu/FilterConditionDialog.tsx
@@ -79,6 +79,14 @@ interface OperatorOption {
   between?: boolean;
 }
 
+// Operator vocabularies — three flavours keyed by the column's data
+// kind. Each option carries a human-readable label, the canonical
+// `FilterOperator` token consumed by the core filtering engine, and
+// per-operator UI flags (`noValue` hides the value input,
+// `between` reveals the second-value input). Order is deliberate:
+// the most common operators come first so the dropdown is fast to
+// scan with the keyboard.
+
 const TEXT_OPERATORS: OperatorOption[] = [
   { label: 'equals', operator: 'eq' },
   { label: 'does not equal', operator: 'neq' },

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,9 +1,51 @@
 /**
- * Public API barrel file for the `@iasbuilt/datagrid-react` package.
+ * Public entry point for `@iasbuilt/datagrid-react`.
  *
- * Re-exports all user-facing components, hooks, factory functions, type
- * aliases, and slot components so consumers can import everything from
- * a single entry point.
+ * Everything reachable from this barrel is part of the stable surface
+ * adopters may depend on; everything else under `src/` is internal and
+ * subject to change without a semver bump. Imports stay shallow:
+ *
+ * ```tsx
+ * import { DataGrid, useGrid, useGridStore } from '@iasbuilt/datagrid-react';
+ * ```
+ *
+ * Surface tour:
+ *
+ *   - **Top-level components** — `<DataGrid>` (primary grid),
+ *     `<MasterDetail>` (expandable row detail panels),
+ *     `<TransposedGrid>` (entity-per-column form-mode grid),
+ *     `<GhostRow>` (inline new-row entry).
+ *   - **Sub-components** — `<DataGridHeader>` / `<DataGridBody>` /
+ *     `<DataGridToolbar>` etc. for adopters that compose their own grid
+ *     layout.
+ *   - **Slots** — `<Toolbar>`, `<FormulaBar>`, `<StatusBar>`,
+ *     `<EmptyState>` — drop into a `<DataGrid>`'s slot props.
+ *   - **Chrome cells** — `<ChromeControlsCell>` / `<ChromeRowNumberCell>`
+ *     and their header counterparts power the optional UI chrome
+ *     columns (controls on the left, row numbers on the right).
+ *   - **Cell renderers** — `cellRendererMap`, plus standalone exports
+ *     for the renderers a typical app composes directly
+ *     (`TagsCell`, `StatusCell`, `UploadCell`,
+ *     `BooleanSelectedCell`, `PasswordConfirmCell`).
+ *   - **Compound-chip primitives** — `ColorPickerPopover`,
+ *     `applyCustomColorToPalette`, `createInMemoryPaletteAdapter`,
+ *     `normalizeHex`, `DEFAULT_THEME_COLORS`, `PALETTE_MAX` — reused
+ *     by the MUI variant and available to consumers building custom
+ *     chip-styled cells.
+ *   - **Hooks** — `useGrid(config)` (imperative model),
+ *     `useGridStore(model, selector?)` (React state binding),
+ *     `useGridInteraction({ graph?, namespace? })` (causl-backed UI
+ *     interaction state), `useGridContext()`,
+ *     `useCauslDevtools(model)` /
+ *     `useCauslDevtoolsForGraph(graph)` (Redux DevTools bridge),
+ *     `useDragDrop`, and the shared cell-editor hooks under
+ *     `cells/hooks`.
+ *   - **Theme tokens** — `LIGHT_THEME` / `DARK_THEME` /
+ *     `lightThemeTokens` / `darkThemeTokens` /
+ *     `toDatagridThemeTokens`, plus `resolveThemeStyle` to flatten
+ *     a `theme` prop into a CSS-variable map.
+ *   - **Migration helpers** — `htmlToMarkdown` for adopters moving
+ *     off the legacy HTML-backed RichTextCell.
  *
  * @module index
  */

--- a/packages/react/src/state/grid-interaction-state.ts
+++ b/packages/react/src/state/grid-interaction-state.ts
@@ -1,28 +1,82 @@
-// ---------------------------------------------------------------------------
-// Grid Interaction State — replaces 12 individual useState calls in DataGrid
-// with a single useReducer backed by a pure reducer function.
-// ---------------------------------------------------------------------------
+/**
+ * Pure, reducer-friendly state model for every piece of transient UI
+ * interaction state the grid tracks in React.
+ *
+ * Originally the grid carried twelve individual `useState` hooks
+ * scattered across `DataGrid.tsx` (menu open / closed, drag sources,
+ * resize anchors, hidden-column sets, freeze overrides, ...); those
+ * are consolidated here into one discriminated-union state so:
+ *
+ *   - The grid's interaction layer is unit-testable as a pure
+ *     reducer (`gridInteractionReducer`).
+ *   - SPA adopters using the BYO-graph pattern can observe the
+ *     interaction node atomically alongside data / column / selection
+ *     state in a single causl commit. The `useGridInteraction` hook
+ *     wraps the reducer with optional causl persistence; see
+ *     `use-grid-interaction.ts` for the runtime adapter.
+ *   - Phase-3 follow-up (#106): the `rowGroupExpanded`, `rowDrag`,
+ *     `filterMenu`, and `conditionDialog` slices were lifted off
+ *     ad-hoc `useState` holders onto this same node so SPA-side
+ *     derivations can read them in lockstep with the rest.
+ *
+ * All sub-state types use a `type:` tag so callers can pattern-match
+ * exhaustively in TypeScript (the union narrows automatically inside a
+ * `switch`). Adding a new variant therefore surfaces as a compile
+ * error at every consumer until they handle it.
+ *
+ * @module grid-interaction-state
+ */
 
-// ---- Discriminated union types for sub-states ----
+// Discriminated union types for the individual interaction sub-states.
+// Each variant carries only the data the active branch needs (no
+// "everything optional" structs); idle/closed forms are sentinel values
+// with no payload so the reducer can free transient fields in one step.
 
+/**
+ * Column-reorder drag session. Captures the field being dragged and the
+ * field currently under the cursor (or `null` between targets) so the
+ * header can paint the drop-indicator at the right gutter.
+ */
 export type ColumnDragState =
   | { type: 'idle' }
   | { type: 'dragging'; field: string; overField: string | null };
 
+/**
+ * Same shape as {@link ColumnDragState} but keyed on column-group
+ * identifiers — drives the column-group banner's drag-to-reorder.
+ */
 export type ColumnGroupDragState =
   | { type: 'idle' }
   | { type: 'dragging'; groupId: string; overGroupId: string | null };
 
+/**
+ * Active column resize. `startX` + `startWidth` capture the pointer
+ * anchor and column-at-grab width so pointer-move deltas resolve to
+ * the new width with one subtraction. The pointer-capture set on the
+ * resize handle survives the cursor leaving the gutter cell, so this
+ * state stays `resizing` until pointer-up.
+ */
 export type ResizeState =
   | { type: 'idle' }
   | { type: 'resizing'; field: string; startX: number; startWidth: number };
 
+/**
+ * Tagged union covering every menu the grid can render. The single
+ * union ensures only one menu is open at a time without bookkeeping
+ * code: opening any variant displaces the previous one.
+ */
 export type MenuState =
   | { type: 'closed' }
   | { type: 'context'; x: number; y: number; rowId: string | null; field: string | null }
   | { type: 'column'; field: string }
   | { type: 'columnVisibility' };
 
+/**
+ * Row-reorder drag session, kicked off from the row-number chrome
+ * cell's drag handle (issue #68). `sourceIndex` is captured at the
+ * start so the drop target can compute the move delta against the
+ * current row list without a re-lookup.
+ */
 export type RowDragState =
   | { type: 'idle' }
   | { type: 'dragging'; sourceRowId: string; sourceIndex: number };
@@ -39,16 +93,37 @@ export interface FilterMenuAnchor {
   right: number;
 }
 
+/**
+ * Excel-style column filter dropdown state. `anchor` is snapshotted at
+ * open-time so the popup positioning is decoupled from the header
+ * button's layout lifecycle — the button can re-render, scroll, or
+ * detach without dragging the popup with it.
+ */
 export type FilterMenuState =
   | { type: 'closed' }
   | { type: 'open'; field: string; anchor: FilterMenuAnchor };
 
+/**
+ * Conditional-formatting / filter dialog state. Single field at a time;
+ * opening another field swaps the dialog rather than stacking.
+ */
 export type ConditionDialogState =
   | { type: 'closed' }
   | { type: 'open'; field: string };
 
-// ---- Combined state ----
+// Combined top-level state — what `useGridInteraction` returns from
+// `state` and what `gridInteractionReducer` operates over.
 
+/**
+ * Snapshot of every transient UI interaction state slice the grid
+ * tracks in React (menu open/closed, drag/resize sessions, per-column
+ * width / order / visibility / freeze overrides, expanded row groups,
+ * row drag, filter menu, condition dialog).
+ *
+ * This shape is stable across renders and serialisable — when the
+ * BYO-graph wiring is on, the entire object is the value of a causl
+ * input node.
+ */
 export interface GridInteractionState {
   menu: MenuState;
   columnDrag: ColumnDragState;
@@ -70,6 +145,11 @@ export interface GridInteractionState {
   conditionDialog: ConditionDialogState;
 }
 
+/**
+ * The grid's pre-render baseline — every menu closed, every drag idle,
+ * every override empty. The reducer treats this value as a constant
+ * sentinel; do not mutate it in place.
+ */
 export const initialGridInteractionState: GridInteractionState = {
   menu: { type: 'closed' },
   columnDrag: { type: 'idle' },
@@ -87,8 +167,17 @@ export const initialGridInteractionState: GridInteractionState = {
   conditionDialog: { type: 'closed' },
 };
 
-// ---- Action union ----
+// Action union — every mutation the reducer accepts. Pattern-matched
+// exhaustively in `gridInteractionReducer`; adding a new variant
+// surfaces as a compile error there until handled.
 
+/**
+ * Discriminated union of every action the
+ * {@link gridInteractionReducer} accepts. Action shapes are
+ * deliberately flat (no nested `payload` object) so call sites read
+ * naturally and TypeScript's literal-type narrowing applies on the
+ * `type` discriminant without extra unwrapping.
+ */
 export type GridInteractionAction =
   | { type: 'open-context-menu'; x: number; y: number; rowId: string | null; field: string | null }
   | { type: 'open-column-menu'; field: string }
@@ -125,8 +214,12 @@ export type GridInteractionAction =
   | { type: 'open-condition-dialog'; field: string }
   | { type: 'close-condition-dialog' };
 
-// ---- Helpers ----
-
+/**
+ * Pure helper: moves `from` to the slot immediately preceding `to`
+ * in a deterministic, alloc-once way. Used by the drop-column and
+ * drop-column-group actions so the reducer stays a pure function of
+ * `(state, action)`.
+ */
 function reorder(list: string[], from: string, to: string): string[] {
   const next = list.filter((item) => item !== from);
   const targetIdx = next.indexOf(to);
@@ -135,8 +228,24 @@ function reorder(list: string[], from: string, to: string): string[] {
   return next;
 }
 
-// ---- Reducer ----
-
+/**
+ * Pure reducer that drives every {@link GridInteractionState}
+ * transition.
+ *
+ * The function is **referentially honest**: identical
+ * `(state, action)` inputs always yield the same output object (no
+ * `Date.now()`, no random ids, no DOM lookups inside the reducer).
+ * That property is what `useGridInteraction` relies on when it wires
+ * the reducer into a causl input node: the same action runs through
+ * the same `tx.set(node, reducer(prev, action))` regardless of where
+ * the action originated (React event, programmatic call, time-travel
+ * replay from Redux DevTools).
+ *
+ * Unhandled action types fall through to the default branch and
+ * return state unchanged — TypeScript's exhaustiveness check warns
+ * about missing arms at compile time, so the default exists only as
+ * a runtime safety net.
+ */
 export function gridInteractionReducer(
   state: GridInteractionState,
   action: GridInteractionAction,

--- a/packages/react/src/state/use-grid-interaction.ts
+++ b/packages/react/src/state/use-grid-interaction.ts
@@ -33,6 +33,12 @@ import {
   type FilterMenuAnchor,
 } from './grid-interaction-state';
 
+/**
+ * Configuration passed to {@link useGridInteraction}. All fields are
+ * optional; the bare-call form `useGridInteraction()` runs against an
+ * internally-constructed private graph and is the default for adopters
+ * that don't need SPA-wide state composition.
+ */
 export interface UseGridInteractionOptions {
   /**
    * Optional causl graph the hook should register its state node on.
@@ -49,6 +55,17 @@ export interface UseGridInteractionOptions {
   namespace?: string;
 }
 
+/**
+ * Return shape of {@link useGridInteraction}.
+ *
+ * The reactive `state` is the read side; `dispatch` is the generic
+ * write side; every other field is a pre-bound action creator that
+ * dispatches a single typed action against the underlying reducer.
+ *
+ * The action creators are stable across renders (memoised against the
+ * graph node), so consumers may include them in `useEffect`
+ * dependency arrays without triggering re-runs on every dispatch.
+ */
 export interface UseGridInteractionReturn {
   state: GridInteractionState;
   dispatch: (action: GridInteractionAction) => void;
@@ -85,6 +102,31 @@ export interface UseGridInteractionReturn {
   closeConditionDialog: () => void;
 }
 
+/**
+ * React hook binding the pure {@link gridInteractionReducer} to a
+ * causl input node so React components can read interaction state
+ * through `useSyncExternalStore` while SPA-side derivations on the
+ * same graph see the same atomic transitions.
+ *
+ * Behaviour:
+ *
+ *   1. On first render the hook resolves a graph: caller-supplied
+ *      `options.graph` (BYO-graph composition) or a private graph
+ *      created with `createCausl({ name: 'grid-interaction-<ns>' })`.
+ *      The choice is memoised in a ref so subsequent renders never
+ *      re-bind state to a different graph mid-flight.
+ *   2. It registers a single input node at `<namespace>:state`
+ *      (default namespace `'interaction'`) carrying the full
+ *      {@link GridInteractionState}. Multiple grids on the same
+ *      graph must pass distinct namespaces to avoid collisions.
+ *   3. Every dispatch runs `graph.commit('interaction:<action.type>',
+ *      tx => tx.set(node, reducer(prev, action)))`, so observers see
+ *      exactly one new state per action.
+ *
+ * The hook is safe to call without `options` — the default arguments
+ * preserve the pre-Phase-3 behaviour of an isolated, ephemeral
+ * interaction state.
+ */
 export function useGridInteraction(
   options: UseGridInteractionOptions = {},
 ): UseGridInteractionReturn {

--- a/packages/react/src/toolbar/DataGridToolbar.tsx
+++ b/packages/react/src/toolbar/DataGridToolbar.tsx
@@ -1,7 +1,33 @@
+/**
+ * Toolbar above the grid header.
+ *
+ * Renders the column-visibility menu trigger and (when row grouping
+ * is active) the expand / collapse-all controls. Two completely
+ * independent feature toggles drive the toolbar's visibility — both
+ * may be off, in which case the component short-circuits to `null`
+ * and the grid renders with no toolbar gutter at all.
+ *
+ * The toolbar is presentational: every mutation goes back to the
+ * parent through a callback prop so the canonical state continues
+ * to live in the {@link GridModel} / `useGridInteraction` reducer.
+ *
+ * @module DataGridToolbar
+ */
 import type { ColumnDef, RowGroupConfig, RowGroup } from '@iasbuilt/datagrid-core';
 import type { MenuState } from '../state';
 import * as styles from './DataGridToolbar.styles';
 
+/**
+ * Props accepted by {@link DataGridToolbar}.
+ *
+ * The component is intentionally pull-shaped: the parent (`<DataGrid>`)
+ * resolves column visibility / grouping config / menu open-state and
+ * passes only the values needed to paint the toolbar. This keeps the
+ * toolbar a leaf in the rendering tree and lets unit tests instantiate
+ * it without spinning up a full grid model.
+ *
+ * @typeParam TData - Row data shape, propagated from the parent grid.
+ */
 export interface DataGridToolbarProps<TData> {
   showColumnVisibilityMenu: boolean;
   showGroupControls: boolean;
@@ -17,6 +43,10 @@ export interface DataGridToolbarProps<TData> {
   onExpandAll: () => void;
 }
 
+/**
+ * Header-strip toolbar component — see {@link DataGridToolbarProps} for
+ * the field-by-field contract.
+ */
 export function DataGridToolbar<TData>(props: DataGridToolbarProps<TData>) {
   const {
     showColumnVisibilityMenu,

--- a/packages/react/src/use-keyboard.ts
+++ b/packages/react/src/use-keyboard.ts
@@ -788,6 +788,16 @@ function writeRangeToClipboard(
   clipboard?.writeText?.(tsv);
 }
 
+/**
+ * Normalises a `{ anchor, focus }` range pair into the contiguous
+ * row-id and field-id arrays the clipboard copy / cut paths iterate.
+ *
+ * The anchor / focus shape mirrors selection state: anchor is the
+ * cell where the user pressed mouse-down (or began a shift-select);
+ * focus is where the cursor currently is. The two may sit in any
+ * order, so this helper resolves the bounding-box min/max for both
+ * axes and slices the column / row lists accordingly.
+ */
 function resolveRangeIndices(
   range: { anchor: CellAddress; focus: CellAddress },
   columns: ColumnDef[],

--- a/scripts/causl-migration-baseline.json
+++ b/scripts/causl-migration-baseline.json
@@ -53,31 +53,31 @@
     {
       "ruleId": "S-07",
       "file": "react/src/DataGrid.tsx",
-      "line": 356,
+      "line": 383,
       "column": 9
     },
     {
       "ruleId": "S-07",
       "file": "react/src/DataGrid.tsx",
-      "line": 357,
+      "line": 384,
       "column": 9
     },
     {
       "ruleId": "S-07",
       "file": "react/src/DataGrid.tsx",
-      "line": 362,
+      "line": 389,
       "column": 9
     },
     {
       "ruleId": "S-01",
       "file": "react/src/DataGrid.tsx",
-      "line": 696,
+      "line": 723,
       "column": 7
     },
     {
       "ruleId": "S-07",
       "file": "react/src/DataGrid.tsx",
-      "line": 933,
+      "line": 960,
       "column": 9
     },
     {
@@ -341,31 +341,31 @@
     {
       "ruleId": "S-07",
       "file": "react/src/header/column-filter-menu/FilterConditionDialog.tsx",
-      "line": 279,
+      "line": 287,
       "column": 9
     },
     {
       "ruleId": "S-07",
       "file": "react/src/header/column-filter-menu/FilterConditionDialog.tsx",
-      "line": 280,
+      "line": 288,
       "column": 9
     },
     {
       "ruleId": "S-07",
       "file": "react/src/header/column-filter-menu/FilterConditionDialog.tsx",
-      "line": 281,
+      "line": 289,
       "column": 9
     },
     {
       "ruleId": "S-01",
       "file": "react/src/header/column-filter-menu/FilterConditionDialog.tsx",
-      "line": 307,
+      "line": 315,
       "column": 7
     },
     {
       "ruleId": "S-01",
       "file": "react/src/header/column-filter-menu/FilterConditionDialog.tsx",
-      "line": 314,
+      "line": 322,
       "column": 5
     },
     {
@@ -389,43 +389,43 @@
     {
       "ruleId": "S-06",
       "file": "react/src/state/use-grid-interaction.ts",
-      "line": 134,
+      "line": 176,
       "column": 11
     },
     {
       "ruleId": "S-06",
       "file": "react/src/state/use-grid-interaction.ts",
-      "line": 137,
+      "line": 179,
       "column": 39
     },
     {
       "ruleId": "S-06",
       "file": "react/src/state/use-grid-interaction.ts",
-      "line": 150,
+      "line": 192,
       "column": 43
     },
     {
       "ruleId": "S-06",
       "file": "react/src/state/use-grid-interaction.ts",
-      "line": 166,
+      "line": 208,
       "column": 11
     },
     {
       "ruleId": "S-06",
       "file": "react/src/state/use-grid-interaction.ts",
-      "line": 211,
+      "line": 253,
       "column": 40
     },
     {
       "ruleId": "S-06",
       "file": "react/src/state/use-grid-interaction.ts",
-      "line": 218,
+      "line": 260,
       "column": 11
     },
     {
       "ruleId": "S-06",
       "file": "react/src/state/use-grid-interaction.ts",
-      "line": 226,
+      "line": 268,
       "column": 11
     },
     {


### PR DESCRIPTION
## Summary

Brings the public-facing documentation and the in-source doc-string
coverage into sync with the current code. The codebase was already
heavily commented in most places — this sweep targets the remaining
gaps and refreshes anything that drifted from the latest features
(notably PR #135's `EditCause` API, the formula-bar / excel-mode /
validation-tooltip extensions, and the post-causl-migration test
counts).

## What changed

### READMEs

- **`README.md`** — refreshed test-suite counts (116 vitest files /
  2,071 tests, 43 Playwright specs), the storybook inventory
  (29 grid stories + 15 MUI primitive stories), the extension list
  (added formula-bar, excel-mode, validation-tooltip — previously
  missing), the e2e highlights (issue-133 race-fix, edit-commit-nav,
  spa-integration-byo-graph, causl-devtools-smoke), and the editing-
  feature description (mentions the new `beginEdit(cell, cause?)`
  signature).
- **`packages/react/src/__tests__/migration-contract/README.md`** —
  recharacterised as a forward-looking substrate-agnostic contract
  net (the Jotai → causl migration has landed). Dropped the dangling
  `PLAN_CAUSL_MIGRATION.md` reference; added a comparison table
  positioning these specs against unit and e2e coverage.
- **`tmp/README.md`** — already accurate; left as-is.

### Doc-string sweep (TSDoc)

Added or expanded TSDoc on every public surface that was still bare
and on the internal helpers that carry load-bearing rationale.

- `packages/core`: `types.ts`, `grid-model.ts`, `selection.ts`,
  `sorting.ts`.
- `packages/react`: `index.ts`, `body/DataGridBody.tsx`,
  `state/grid-interaction-state.ts`,
  `state/use-grid-interaction.ts`,
  `header/{DataGridColumnMenu, DataGridColumnGroupHeader,
  DataGridHeader::HeaderCell}.tsx`,
  `header/column-filter-menu/FilterConditionDialog.tsx`,
  `toolbar/DataGridToolbar.tsx`,
  `chrome/ChromeControlsCell.tsx`,
  `DataGrid.tsx`, `ValidationTooltip.tsx`, `use-keyboard.ts`.
- `packages/extensions`: `index.ts`.
- `packages/mui`: `index.ts`, `theme/index.ts`,
  `components/{EditableAutocomplete, EditableSelect,
  EditableTextField, DisplayTypography}.tsx`.

Every doc-string follows the codebase's existing voice: implies the
why / what / how through composition rather than spelling those words
out. No emojis added.

### Migration baseline refresh

The line-number-keyed baseline at
`scripts/causl-migration-baseline.json` was regenerated because the
new TSDoc shifted line positions in `DataGrid.tsx`,
`state/use-grid-interaction.ts`,
`state/grid-interaction-state.ts`, and
`header/column-filter-menu/FilterConditionDialog.tsx`. No new
violations; the entry count stays at 79.

## Test plan

- [x] `pnpm typecheck` — green (turned out the long-standing local
      typecheck failures were caused by stale
      `tsconfig.build.tsbuildinfo` files; a clean sweep restored a
      green local build).
- [x] `pnpm build` — green
- [x] `pnpm test` (vitest, 2,071 tests) — green
- [x] `pnpm lint` — 0 errors (24 pre-existing warnings unchanged)
- [x] `pnpm lint:migration` — 0 new findings; baseline refreshed
- [x] `pnpm exec playwright test` (full e2e via pre-push hook) —
      **178 passed**